### PR TITLE
Fix baremetal operator directory creation error

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -6,11 +6,15 @@ source utils/common.sh
 
 eval "$(go env)"
 
-BMOPATH="${GOPATH}/src/github.com/metal3-io/baremetal-operator"
+M3PATH="${GOPATH}/src/github.com/metal3-io"
+BMOPATH="${M3PATH}/baremetal-operator"
+
+if [ ! -d ${M3PATH} ] ; then
+    mkdir -p ${M3PATH}
+fi
 
 if [ ! -d ${BMOPATH} ] ; then
-    mkdir -p ${GOPATH}/src/github.com/metal3-io/
-    pushd ${BMOPATH}
+    pushd ${M3PATH}
     git clone https://github.com/metal3-io/baremetal-operator.git
     popd
 fi


### PR DESCRIPTION
At the time the script tries to change current directory to baremetal-operator, the repository is not cloned.