### PR TITLE
Doc creating config_${USER}.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Prerequisites:
 
 # Instructions
 
-tl;dr - Run `make`.
+tl;dr - Copy config_example.sh to config_${USER}.sh, then run `make`.
 
 The `Makefile` runs a series of scripts, described here:
 


### PR DESCRIPTION
config_${USER}.sh must exist. This patch updates the docs to include the
step to create it by copying from config_example.sh.