### PR TITLE
Fix running in nested virt & add required kustomise binary

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -56,6 +56,9 @@ popd
 # Needed to get a recent python-virtualbmc package
 sudo tripleo-repos current-tripleo
 
+# Disable rdo-qemu-ev repo as there are issues running in nested virt currently
+sudo yum-config-manager --disable rdo-qemu-ev
+
 # There are some packages which are newer in the tripleo repos
 sudo yum -y update
 

--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -107,3 +107,8 @@ if ! which kubectl 2>/dev/null ; then
     curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
         && chmod +x kubectl && sudo mv kubectl /usr/local/bin/.
 fi
+
+if ! which kustomize 2>/dev/null ; then
+    curl -Lo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 \
+          && chmod +x kustomize && sudo mv kustomize /usr/local/bin/.
+fi


### PR DESCRIPTION
This PR fixes running in nested virt envs, and adds the kustomise binary which is required to deploy the bmo.