### PR TITLE
Add kustomize to installation

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -104,3 +104,8 @@ if ! which kubectl 2>/dev/null ; then
     curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
         && chmod +x kubectl && sudo mv kubectl /usr/local/bin/.
 fi
+
+if ! which kustomize 2>/dev/null ; then
+    curl -Lo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 \
+          && chmod +x kustomize && sudo mv kustomize /usr/local/bin/.
+fi


### PR DESCRIPTION
This commit adds kustomize to the deployment script which is required
as of this commit:
 * https://github.com/metal3-io/metal3-dev-env/commit/ea8be6b0552cfb26761871c85bd8ef1c46998b6f

Signed-off-by: Pete Birley <pete@port.direct>