### PR TITLE
Adding an additional requirement for passing provisioning step

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -83,7 +83,8 @@ sudo yum -y install \
   qemu-kvm \
   virt-install \
   unzip \
-  yarn
+  yarn \
+  genisoimage
 
 # Install python packages not included as rpms
 sudo pip install \


### PR DESCRIPTION
Due to the missing of **genisoimage**, the provisioning procedure will reach an errors as shown in [1].
This PR aims to update the requirement packages to pass this bug.

[1] http://paste.openstack.org/raw/751328/

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>