### PR TITLE
vm-setup: remove additional DNS records

### DIFF
--- a/vm-setup/roles/common/tasks/main.yml
+++ b/vm-setup/roles/common/tasks/main.yml
@@ -64,13 +64,7 @@
               - 65535
             domain: "{{ cluster_domain }}"
             dns:
-              hosts:
-                - ip: "{{ baremetal_network_cidr | nthhost(5) }}"
-                  hostnames:
-                    - "api"
-                - ip: "{{ baremetal_network_cidr | nthhost(2) }}"
-                  hostnames:
-                    - "ns1"
+              hosts: "{{dns_extrahosts | default([])}}"
               forwarders:
                 - domain: "apps.{{ cluster_domain }}"
                   addr: "127.0.0.1"


### PR DESCRIPTION
These are needed in dev-scripts for OpenShift, but aren't needed
here so add an optional variable instead which we'll set only
when calling from openshift-metal3/dev-scripts