### PR TITLE
explicitly set extradisks to boolean for flavors

### DIFF
--- a/vm-setup/roles/common/defaults/main.yml
+++ b/vm-setup/roles/common/defaults/main.yml
@@ -20,13 +20,13 @@ flavors:
     memory: '{{master_memory|default(default_memory)}}'
     disk: '{{master_disk|default(default_disk)}}'
     vcpu: '{{master_vcpu|default(default_vcpu)}}'
-    extradisks: '{{extradisks}}'
+    extradisks: '{{extradisks|bool}}'
 
   worker:
     memory: '{{worker_memory|default(default_memory)}}'
     disk: '{{worker_disk|default(default_disk)}}'
     vcpu: '{{worker_vcpu|default(default_vcpu)}}'
-    extradisks: '{{extradisks}}'
+    extradisks: '{{extradisks|bool}}'
 
 # For dev-scripts usage this currently needs to be set to "openshift_"
 ironic_prefix: ""


### PR DESCRIPTION
It seems that when picking up the `extradisks` var for `flavors.master.extradisks` and `flavors.worker.extradisks` it is resulting in Ansible treating the `false` as a string instead of a boolean. This  results in the `when` check for the _Create additional blockdevice for objectstorage nodes_ in `vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml` passing when it should fail, causing the extradisks to be created and attached to the VMs when they shouldn't be.
