### PR TITLE
Fix provision_host.sh error

### DIFF
--- a/provision_host.sh
+++ b/provision_host.sh
@@ -17,7 +17,7 @@ if echo ${IMAGE_NAME} | grep -qi centos 2>/dev/null ; then
 else
     OS_TYPE=unknown
 fi
-user_data.sh ${BMHOST} ${OS_TYPE} | kubectl apply -n metal3 -f -
+./user_data.sh ${BMHOST} ${OS_TYPE} | kubectl apply -n metal3 -f -
 
 kubectl patch baremetalhost ${BMHOST} -n metal3 --type merge \
     -p '{"spec":{"image":{"url":"'${IMAGE_URL}'","checksum":"'${IMAGE_CHECKSUM}'"},"userData":{"name":"'${BMHOST}'-user-data","namespace":"metal3"}}}'


### PR DESCRIPTION
Fixes:

```
$ ./provision_host.sh worker-0
./provision_host.sh: line 20: user_data.sh: command not found
error: no objects passed to apply
baremetalhost.metal3.io/worker-0 patched
```