### PR TITLE
Use 'master' tag for ironic metal3 image

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -48,7 +48,7 @@ export NUM_WORKERS=${NUM_WORKERS:-"1"}
 export VM_EXTRADISKS=${VM_EXTRADISKS:-"false"}
 
 # Ironic vars
-export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic"}
+export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}
 export IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic-inspector"}
 export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
 


### PR DESCRIPTION
Podman is trying to pull image with tag `latest` but there is no this tag at this moment here: https://quay.io/repository/metal3-io/ironic?tag=latest&tab=tags

Only tags `master` and `no-cleaning`.

Use `master` tag explicitly to fix #14