### PR TITLE
Work around python*-zmq conflict

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -25,6 +25,9 @@ fi
 if ! grep -q zeromq /etc/yum.repos.d/epel.repo; then
   sudo sed -i '/enabled=1/a exclude=zeromq*' /etc/yum.repos.d/epel.repo
 fi
+if ! grep -q zmq /etc/yum.repos.d/epel.repo; then
+  sudo sed -i '/^exclude=zeromq/ s/$/,*zmq/' /etc/yum.repos.d/epel.repo
+fi
 
 # Install required packages
 # python-{requests,setuptools} required for tripleo-repos install


### PR DESCRIPTION
As reported in https://github.com/openshift-metal3/dev-scripts/issues/581

We should probably look at moving this repo setup into the vm-setup roles
but for now a quick-fix is to exclude the conflicting packages.