### PR TITLE
Add an option to use Docker instead of Podman

### DIFF
--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -2,6 +2,7 @@
 set -ex
 
 source lib/logging.sh
+source lib/common.sh
 
 sudo yum install -y libselinux-utils
 if selinuxenabled ; then
@@ -64,7 +65,6 @@ sudo yum -y install \
   libvirt-devel \
   libvirt-daemon-kvm \
   nodejs \
-  podman \
   python-ironicclient \
   python-ironic-inspector-client \
   python-lxml \
@@ -76,6 +76,19 @@ sudo yum -y install \
   virt-install \
   unzip \
   genisoimage
+
+if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
+  sudo yum -y install podman
+else
+  sudo yum install -y yum-utils \
+    device-mapper-persistent-data \
+    lvm2
+  sudo yum-config-manager \
+    --add-repo \
+    https://download.docker.com/linux/centos/docker-ce.repo
+  sudo yum install -y docker-ce docker-ce-cli containerd.io
+  sudo systemctl start docker
+fi
 
 # Install python packages not included as rpms
 sudo pip install \

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -6,13 +6,13 @@ source lib/common.sh
 
 # Kill and remove the running ironic containers
 for name in ironic ironic-inspector dnsmasq httpd mariadb; do
-    sudo podman ps | grep -w "$name$" && sudo podman kill $name
-    sudo podman ps --all | grep -w "$name$" && sudo podman rm $name -f
+    sudo ${CONTAINER_RUNTIME} ps | grep -w "$name$" && sudo ${CONTAINER_RUNTIME} kill $name
+    sudo ${CONTAINER_RUNTIME} ps --all | grep -w "$name$" && sudo ${CONTAINER_RUNTIME} rm $name -f
 done
 
 # Remove existing pod
-if  sudo podman pod exists ironic-pod ; then
-    sudo podman pod rm ironic-pod -f
+if  sudo ${CONTAINER_RUNTIME} pod exists ironic-pod ; then
+    sudo ${CONTAINER_RUNTIME} pod rm ironic-pod -f
 fi
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -11,8 +11,10 @@ for name in ironic ironic-inspector dnsmasq httpd mariadb; do
 done
 
 # Remove existing pod
-if  sudo ${CONTAINER_RUNTIME} pod exists ironic-pod ; then
-    sudo ${CONTAINER_RUNTIME} pod rm ironic-pod -f
+if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
+  if  sudo ${CONTAINER_RUNTIME} pod exists ironic-pod ; then
+      sudo ${CONTAINER_RUNTIME} pod rm ironic-pod -f
+  fi
 fi
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -32,6 +32,8 @@ MANAGE_INT_BRIDGE=${MANAGE_INT_BRIDGE:-y}
 INT_IF=${INT_IF:-}
 #Root disk to deploy coreOS - use /dev/sda on BM
 ROOT_DISK_NAME=${ROOT_DISK_NAME-"/dev/sda"}
+#Container runtime
+CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"podman"}
 
 export EXTERNAL_SUBNET="192.168.111.0/24"
 

--- a/ubuntu_install_requirements.sh
+++ b/ubuntu_install_requirements.sh
@@ -2,6 +2,7 @@
 set -ex
 
 source lib/logging.sh
+source lib/common.sh
 
 # sudo apt install -y libselinux-utils
 # if selinuxenabled ; then
@@ -41,6 +42,7 @@ sudo apt -y install \
   psmisc \
   python-pip \
   wget
+
 
 
 # Install pyenv
@@ -88,7 +90,6 @@ sudo apt -y install \
   jq \
   libguestfs-tools \
   nodejs \
-  podman \
   qemu-kvm \
   libvirt-bin libvirt-clients libvirt-dev \
   python-ironicclient \
@@ -98,6 +99,25 @@ sudo apt -y install \
   unzip \
   yarn \
   genisoimage
+
+
+if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
+  sudo apt -y install podman
+else
+  sudo apt -y install \
+    apt-transport-https \
+    ca-certificates \
+    gnupg-agent \
+    software-properties-common
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  sudo add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) \
+    stable"
+  sudo apt update
+  sudo apt install -y docker-ce docker-ce-cli containerd.io
+  sudo systemctl start docker
+fi
 
 # Install python packages not included as rpms
 sudo pip install \


### PR DESCRIPTION
Creates the environment variable CONTAINER_RUNTIME . The variable can be set to "docker" or "podman" depending on the runtime you want to use. It defaults to Podman. The requested runtime will be installed automatically. 