### PR TITLE
Move all download code into 01_install_requirement.sh

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -7,3 +7,55 @@ else
   # shellcheck disable=SC1091
   source centos_install_requirements.sh
 fi
+
+if ! which minikube 2>/dev/null ; then
+    curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+    chmod +x minikube
+    sudo mv minikube /usr/local/bin/.
+fi
+
+if ! which docker-machine-driver-kvm2 2>/dev/null ; then
+    curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2
+    chmod +x docker-machine-driver-kvm2
+    sudo mv docker-machine-driver-kvm2 /usr/local/bin/.
+fi
+
+if ! which kubectl 2>/dev/null ; then
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+    chmod +x kubectl
+    sudo mv kubectl /usr/local/bin/.
+fi
+
+if ! which kustomize 2>/dev/null ; then
+    curl -Lo kustomize $(curl --silent -L https://github.com/kubernetes-sigs/kustomize/releases/latest 2>&1 | awk -F'"' '/linux_amd64/ { print "https://github.com"$2; exit }')
+    chmod +x kustomize
+    sudo mv kustomize /usr/local/bin/.
+fi
+
+# Download Ironic binary and Ironic inspector image
+
+mkdir -p "$IRONIC_DATA_DIR/html/images"
+pushd "$IRONIC_DATA_DIR/html/images"
+if [ ! -f ironic-python-agent.initramfs ]; then
+    curl --insecure --compressed -L https://images.rdoproject.org/master/rdo_trunk/current-tripleo-rdo/ironic-python-agent.tar | tar -xf -
+fi
+
+for IMAGE_VAR in IRONIC_IMAGE IRONIC_INSPECTOR_IMAGE ; do
+    IMAGE=${!IMAGE_VAR}
+    sudo "${CONTAINER_RUNTIME}" pull "$IMAGE"
+done
+
+## Download centos 7 qcow2 image
+
+CENTOS_IMAGE=CentOS-7-x86_64-GenericCloud-1901.qcow2
+if [ ! -f ${CENTOS_IMAGE} ] ; then
+    curl --insecure --compressed -O -L http://cloud.centos.org/centos/7/images/${CENTOS_IMAGE}
+    md5sum ${CENTOS_IMAGE} | awk '{print $1}' > ${CENTOS_IMAGE}.md5sum
+fi
+popd
+
+ANSIBLE_FORCE_COLOR=true ansible-playbook \
+  -e "working_dir=$WORKING_DIR" \
+  -e "virthost=$HOSTNAME" \
+  -i vm-setup/inventory.ini \
+  -b -vvv vm-setup/install-package-playbook.yml

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -145,23 +145,6 @@ if [[ "$MANAGE_BR_BRIDGE" == "y" && $OS == "centos" ]] ; then
   fi
 fi
 
-mkdir -p "$IRONIC_DATA_DIR/html/images"
-pushd "$IRONIC_DATA_DIR/html/images"
-if [ ! -f ironic-python-agent.initramfs ]; then
-    curl --insecure --compressed -L https://images.rdoproject.org/master/rdo_trunk/current-tripleo-rdo/ironic-python-agent.tar | tar -xf -
-fi
-CENTOS_IMAGE=CentOS-7-x86_64-GenericCloud-1901.qcow2
-if [ ! -f ${CENTOS_IMAGE} ] ; then
-    curl --insecure --compressed -O -L http://cloud.centos.org/centos/7/images/${CENTOS_IMAGE}
-    md5sum ${CENTOS_IMAGE} | awk '{print $1}' > ${CENTOS_IMAGE}.md5sum
-fi
-popd
-
-for IMAGE_VAR in IRONIC_IMAGE IRONIC_INSPECTOR_IMAGE ; do
-    IMAGE=${!IMAGE_VAR}
-    sudo "${CONTAINER_RUNTIME}" pull "$IMAGE"
-done
-
 for name in ironic ironic-inspector dnsmasq httpd mariadb; do
     sudo "${CONTAINER_RUNTIME}" ps | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" kill $name
     sudo "${CONTAINER_RUNTIME}" ps --all | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" rm $name -f

--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -27,28 +27,18 @@ fi
 # Install required packages
 # python-{requests,setuptools} required for tripleo-repos install
 sudo yum -y install \
-  crudini \
-  curl \
-  dnsmasq \
-  figlet \
-  golang \
-  NetworkManager \
-  nmap \
-  patch \
-  psmisc \
   python-pip \
-  python-requests \
-  python-setuptools \
-  vim-enhanced \
+  redhat-lsb-core \
   wget
 
 # We're reusing some tripleo pieces for this setup so clone them here
-cd
+pushd $HOME
 if [ ! -d tripleo-repos ]; then
   git clone https://git.openstack.org/openstack/tripleo-repos
 fi
 pushd tripleo-repos
 sudo python setup.py install
+popd
 popd
 
 # Needed to get a recent python-virtualbmc package
@@ -57,27 +47,10 @@ sudo tripleo-repos current-tripleo
 # There are some packages which are newer in the tripleo repos
 sudo yum -y update
 
+
 # make sure additional requirments are installed
 sudo yum -y install \
   ansible \
-  bind-utils \
-  jq \
-  libguestfs-tools \
-  libvirt \
-  libvirt-devel \
-  libvirt-daemon-kvm \
-  nodejs \
-  python-ironicclient \
-  python-ironic-inspector-client \
-  python-lxml \
-  python-netaddr \
-  python-openstackclient \
-  python-virtualbmc \
-  qemu-kvm \
-  redhat-lsb-core \
-  virt-install \
-  unzip \
-  genisoimage
 
 if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
   sudo yum -y install podman
@@ -93,30 +66,3 @@ else
 fi
 
 # Install python packages not included as rpms
-sudo pip install \
-  lolcat \
-  yq
-
-if ! which minikube 2>/dev/null ; then
-    curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
-    chmod +x minikube
-    sudo mv minikube /usr/local/bin/.
-fi
-
-if ! which docker-machine-driver-kvm2 2>/dev/null ; then
-    curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2
-    chmod +x docker-machine-driver-kvm2
-    sudo mv docker-machine-driver-kvm2 /usr/local/bin/.
-fi
-
-if ! which kubectl 2>/dev/null ; then
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/"$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"/bin/linux/amd64/kubectl
-    chmod +x kubectl
-    sudo mv kubectl /usr/local/bin/.
-fi
-
-if ! which kustomize 2>/dev/null ; then
-    curl -Lo kustomize "$(curl --silent -L https://github.com/kubernetes-sigs/kustomize/releases/latest 2>&1 | awk -F'"' '/linux_amd64/ { print "https://github.com"$2; exit }')"
-    chmod +x kustomize
-    sudo mv kustomize /usr/local/bin/.
-fi

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -42,14 +42,16 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -i vm-setup/inventory.ini \
     -b -vvv vm-setup/teardown-playbook.yml
 
-sudo rm -rf /etc/NetworkManager/conf.d/dnsmasq.conf
 # There was a bug in this file, it may need to be recreated.
-if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
-    sudo ifdown provisioning || true
-    sudo rm -f /etc/sysconfig/network-scripts/ifcfg-provisioning || true
-fi
-# Leaving this around causes issues when the host is rebooted
-if [ "$MANAGE_BR_BRIDGE" == "y" ]; then
-    sudo ifdown baremetal || true
-    sudo rm -f /etc/sysconfig/network-scripts/ifcfg-baremetal || true
+if [[ $OS == "centos" ]]; then
+  sudo rm -rf /etc/NetworkManager/conf.d/dnsmasq.conf
+  if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
+      sudo ifdown provisioning || true
+      sudo rm -f /etc/sysconfig/network-scripts/ifcfg-provisioning || true
+  fi
+  # Leaving this around causes issues when the host is rebooted
+  if [ "$MANAGE_BR_BRIDGE" == "y" ]; then
+      sudo ifdown baremetal || true
+      sudo rm -f /etc/sysconfig/network-scripts/ifcfg-baremetal || true
+  fi
 fi

--- a/ubuntu_install_requirements.sh
+++ b/ubuntu_install_requirements.sh
@@ -15,37 +15,13 @@ source lib/common.sh
 # Update to latest packages first
 sudo apt -y update
 
-# Install EPEL required by some packages
-# if [ ! -f /etc/yum.repos.d/epel.repo ] ; then
-#     if grep -q "Red Hat Enterprise Linux" /etc/redhat-release ; then
-#         sudo yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/epel-release-7-11.noarch.rpm
-#     else
-#         sudo yum -y install epel-release --enablerepo=extras
-#     fi
-# fi
-
-# Work around a conflict with a newer zeromq from epel
-# if ! grep -q zeromq /etc/yum.repos.d/epel.repo; then
-#   sudo sed -i '/enabled=1/a exclude=zeromq*' /etc/yum.repos.d/epel.repo
-# fi
-
 # Install required packages
 
 sudo apt -y install \
-  crudini \
-  curl \
-  dnsmasq \
-  figlet \
-  golang \
+  python-pip \
   zlib1g-dev \
   libssl1.0-dev \
-  nmap \
-  patch \
-  psmisc \
-  python-pip \
   wget
-
-
 
 # Install pyenv
 
@@ -92,20 +68,6 @@ sudo apt -y update
 # make sure additional requirments are installed
 
 ##No bind-utils. It is for host, nslookop,..., no need in ubuntu
-sudo apt -y install \
-  jq \
-  libguestfs-tools \
-  nodejs \
-  qemu-kvm \
-  libvirt-bin libvirt-clients libvirt-dev \
-  python-ironicclient \
-  python-ironic-inspector-client \
-  golang-go \
-  python-lxml \
-  unzip \
-  yarn \
-  genisoimage
-
 
 if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
   sudo apt -y install podman
@@ -128,33 +90,3 @@ fi
 # Install python packages not included as rpms
 sudo pip install \
   ansible==2.8.2 \
-  lolcat \
-  yq \
-  virtualbmc \
-  python-ironicclient \
-  python-ironic-inspector-client \
-  lxml \
-  netaddr \
-  requests \
-  setuptools \
-  libvirt-python \
-
-if ! which minikube 2>/dev/null ; then
-    curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 \
-          && chmod +x minikube && sudo mv minikube /usr/local/bin/.
-fi
-
-if ! which docker-machine-driver-kvm2 >/dev/null ; then
-    curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2 \
-          && sudo install docker-machine-driver-kvm2 /usr/local/bin/
-fi
-
-if ! which kubectl 2>/dev/null ; then
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/"$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"/bin/linux/amd64/kubectl \
-        && chmod +x kubectl && sudo mv kubectl /usr/local/bin/.
-fi
-
-if ! which kustomize 2>/dev/null ; then
-    curl -Lo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 \
-          && chmod +x kustomize && sudo mv kustomize /usr/local/bin/.
-fi

--- a/vm-setup/install-package-playbook.yml
+++ b/vm-setup/install-package-playbook.yml
@@ -1,0 +1,12 @@
+---
+- name: Install packages needed for the Dev-env
+  hosts: virthost
+  connection: local
+  gather_facts: true
+  vars_files:
+    - vars/packages_installation.yml
+  tasks:
+    - import_role:
+        name: packages_installation
+  vars: 
+    packages: "{{ packages_installation }}"

--- a/vm-setup/roles/libvirt/defaults/main.yml
+++ b/vm-setup/roles/libvirt/defaults/main.yml
@@ -22,41 +22,6 @@ extradisks_list:
 # size of the disks to create when using extradisks
 extradisks_size: 8G
 
-# The packages required to set up our desired libvirt environment.
-# (Tested on Centos 7)
-libvirt_packages:
-  - qemu-kvm
-  - libvirt
-  - libvirt-python
-  - libguestfs-tools
-  - python-lxml
-  - polkit-pkla-compat
-  - python-netaddr
-  - python2-virtualbmc
-
-# We expect virtualbmc to already be installed on rhel8 as a pre-req to running this,
-# as there's no rhel package available yet.
-libvirt_packages_rhel8:
-  - qemu-kvm
-  - libvirt
-  - python3-libvirt
-  - libguestfs-tools
-  - python3-lxml
-  - polkit-pkla-compat
-  - python3-netaddr
-
-ubuntu_libvirt_packages:
-  - qemu-kvm
-  - libvirt-bin
-  - libvirt-clients
-  - libvirt-dev
-  - python-libvirt
-  - libguestfs-tools
-  - python-lxml
-  - gir1.2-polkit-1.0
-  - libpolkit-agent-1-0
-  - libpolkit-backend-1-0
-  - libpolkit-gobject-1-0
 
 
 # The name of the libvirt service.

--- a/vm-setup/roles/libvirt/tasks/install_setup_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/install_setup_tasks.yml
@@ -1,29 +1,3 @@
-# Install the packages required for our desired libvirt environment.
-# We store the list of packages in `libvirt_packages` so that in
-# theory we can support multiple distributions simply by passing in a
-# different list of packages.
-- name: Install packages for libvirt
-  package:
-    name: "{{ libvirt_packages }}"
-    state: present
-  become: true
-  when: ansible_os_family == "RedHat" and ansible_lsb.major_release|int == 7
-
-- name: Install packages for libvirt
-  package:
-    name: "{{ libvirt_packages_rhel8 }}"
-    state: present
-  become: true
-  when: ansible_os_family == "RedHat" and ansible_lsb.major_release|int == 8
-
-- name: Install packages for libvirt on Ubuntu
-  when: 
-    - ansible_facts['distribution'] == "Ubuntu"
-  package:
-    name: "{{ ubuntu_libvirt_packages }}"
-    state: present
-  become: true
-
 - name: Start libvirtd
   service:
     name: "{{ libvirtd_service }}"

--- a/vm-setup/roles/packages_installation/tasks/main.yml
+++ b/vm-setup/roles/packages_installation/tasks/main.yml
@@ -1,0 +1,36 @@
+- name: Install packages on Ubuntu
+  block:
+    - name: Install packages using standard package manager
+      package:
+        name: "{{ packages.ubuntu.packages +  packages.ubuntu.libvirt }}"
+        state: present
+      become: true
+    - name: Install packages using pip
+      pip:
+        name: "{{ packages.ubuntu.pip }}"
+        state: present
+      become: true
+  when: ansible_facts['distribution'] == "Ubuntu"
+
+
+- name: Install packages on CentOS
+  block:
+    - name: Install packages using standard package manager
+      block: 
+        - name: Install packages on rhel7
+          when: ansible_lsb.major_release|int == 7
+          package:
+             name: "{{ packages.centos.rhel7.packages }}"
+             state: present
+        - name: Install packages on rhel8
+          when: ansible_lsb.major_release|int == 8
+          package:
+             name: "{{ packages.centos.rhel8 }}"
+             state: present
+      become: true
+    - name: Install packages using pip
+      pip:
+        name: "{{ packages.centos.pip }}"
+        state: present
+      become: true
+  when: ansible_os_family == "RedHat"

--- a/vm-setup/roles/packages_installation/tasks/main.yml
+++ b/vm-setup/roles/packages_installation/tasks/main.yml
@@ -2,7 +2,7 @@
   block:
     - name: Install packages using standard package manager
       package:
-        name: "{{ packages.ubuntu.packages +  packages.ubuntu.libvirt }}"
+        name: "{{ packages.ubuntu.packages}}"
         state: present
       become: true
     - name: Install packages using pip
@@ -25,7 +25,7 @@
         - name: Install packages on rhel8
           when: ansible_lsb.major_release|int == 8
           package:
-             name: "{{ packages.centos.rhel8 }}"
+             name: "{{ packages.centos.rhel8.packages }}"
              state: present
       become: true
     - name: Install packages using pip

--- a/vm-setup/vars/packages_installation.yml
+++ b/vm-setup/vars/packages_installation.yml
@@ -1,0 +1,111 @@
+packages_installation:
+  ubuntu:
+    packages:
+     - crudini 
+     - curl 
+     - dnsmasq 
+     - figlet 
+     - golang 
+     - nmap 
+     - patch 
+     - psmisc 
+     - python-pip 
+     - wget
+     - libvirt-bin 
+     - libvirt-clients 
+     - libvirt-dev 
+     - jq 
+     - nodejs 
+     - golang-go 
+     - unzip 
+     - yarn 
+     - genisoimage 
+     - qemu-kvm
+     - libguestfs-tools
+     - gir1.2-polkit-1.0
+     - libpolkit-agent-1-0
+     - libpolkit-backend-1-0
+     - libpolkit-gobject-1-0
+    pip:
+     - ansible==2.8.2
+     - lolcat 
+     - yq 
+     - virtualbmc 
+     - python-ironicclient 
+     - python-ironic-inspector-client 
+     - lxml 
+     - netaddr 
+     - requests 
+     - setuptools 
+     - libvirt-python 
+  centos:
+    rhel7:
+        packages:
+         - crudini 
+         - curl 
+         - dnsmasq 
+         - figlet 
+         - golang 
+         - NetworkManager 
+         - nmap 
+         - patch 
+         - psmisc 
+         - python-pip 
+         - python-requests 
+         - python-setuptools 
+         - vim-enhanced 
+         - wget
+         - ansible 
+         - bind-utils 
+         - jq 
+         - libguestfs-tools 
+         - nodejs 
+         - python-ironicclient 
+         - python-ironic-inspector-client 
+         - python-openstackclient 
+         - redhat-lsb-core 
+         - unzip 
+         - genisoimage
+         - qemu-kvm
+         - libvirt
+         - libvirt-devel 
+         - libvirt-daemon-kvm 
+         - libvirt-python
+         - libguestfs-tools
+         - python-lxml
+         - polkit-pkla-compat
+         - python-netaddr
+         - python-virtualbmc
+         - virt-install 
+    rhel8:
+        package:
+         - curl 
+         - dnsmasq 
+         - golang 
+         - NetworkManager 
+         - nmap 
+         - patch 
+         - psmisc 
+         - vim-enhanced 
+         - wget
+         - ansible 
+         - bind-utils 
+         - jq 
+         - libguestfs-tools 
+         - nodejs 
+         - redhat-lsb-core 
+         - unzip 
+         - genisoimage
+         - qemu-kvm
+         - libvirt
+         - libvirt-devel 
+         - libvirt-daemon-kvm 
+         - python3-libvirt
+         - libguestfs-tools
+         - python3-lxml
+         - polkit-pkla-compat
+         - python3-netaddr
+         - virt-install 
+    pip:
+      - lolcat
+      - yq

--- a/vm-setup/vars/packages_installation.yml
+++ b/vm-setup/vars/packages_installation.yml
@@ -78,7 +78,7 @@ packages_installation:
          - python-virtualbmc
          - virt-install 
     rhel8:
-        package:
+        packages:
          - curl 
          - dnsmasq 
          - golang 


### PR DESCRIPTION
Hi, 
In this pull request, I move all download code to 01_installation_requirement.sh in order to make CI easier. We can use this script as a part of cloud-init , so we will have all needed binary after booting VM from a test image without running the whole dev-env. 

List commits made:
Move all download code into 01-install-requirement.sh

Add a OS checks in host_cleanup.sh 

Rebase onto upstream/metal3-dev-env and remove the all_os_install-requirements.sh