### PR TITLE
Parameterize the repos url and ref

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -10,22 +10,36 @@ M3PATH="${GOPATH}/src/github.com/metal3-io"
 BMOPATH="${M3PATH}/baremetal-operator"
 CAPBMPATH="${M3PATH}/cluster-api-provider-baremetal"
 
+BMOREPO="${BMOREPO:-https://github.com/metal3-io/baremetal-operator.git}"
+BMOBRANCH="${BMOBRANCH:-master}"
+CAPBMREPO="${CAPBMREPO:-https://github.com/metal3-io/cluster-api-provider-baremetal.git}"
+CAPBMBRANCH="${CAPBMBRANCH:-master}"
+FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-false}"
+
 function clone_repos() {
     mkdir -p ${M3PATH}
+    if [[ -d ${BMOPATH} && "${FORCE_REPO_UPDATE}"=="true" ]]; then
+      rm -rf ${BMOPATH}
+    fi
     if [ ! -d ${BMOPATH} ] ; then
         pushd ${M3PATH}
-        git clone https://github.com/metal3-io/baremetal-operator.git
+        git clone ${BMOREPO}
         popd
     fi
     pushd ${BMOPATH}
+    git checkout ${BMOBRANCH}
     git pull -r || true
     popd
+    if [[ -d ${CAPBMPATH} && "${FORCE_REPO_UPDATE}"=="true" ]]; then
+      rm -rf ${CAPBMPATH}
+    fi
     if [ ! -d ${CAPBMPATH} ] ; then
         pushd ${M3PATH}
-        git clone https://github.com/metal3-io/cluster-api-provider-baremetal.git
+        git clone ${CAPBMREPO}
         popd
     fi
     pushd ${CAPBMPATH}
+    git checkout ${CAPBMBRANCH}
     git pull -r || true
     popd
 }

--- a/config_example.sh
+++ b/config_example.sh
@@ -15,3 +15,34 @@
 # Default of ~/.ssh/id_rsa.pub is set in lib/common.sh
 #
 #export SSH_PUB_KEY=~/.ssh/id_rsa.pub
+
+#
+# Select the Container Runtime, can be "podman" or "docker"
+# Defaults to "podman"
+#
+#export CONTAINER_RUNTIME="podman"
+
+#
+# Set the Baremetal Operator repository to clone
+#
+#export BMOREPO="${BMOREPO:-https://github.com/metal3-io/baremetal-operator.git}"
+
+#
+# Set the Baremetal Operator branch to checkout
+#
+#export BMOBRANCH="${BMOBRANCH:-master}"
+
+#
+# Set the Cluster Api baremetal provider repository to clone
+#
+#export CAPBMREPO="${CAPBMREPO:-https://github.com/metal3-io/cluster-api-provider-baremetal.git}"
+
+#
+# Set the Cluster Api baremetal provider branch to checkout
+#
+#export CAPBMBRANCH="${CAPBMBRANCH:-master}"
+
+#
+# Force deletion of the BMO and CAPBM repositories before cloning them again
+#
+#export FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-false}"


### PR DESCRIPTION
When cloning the Baremetal-Operator and CAPI-provider-baremetal
repositories, parameterize the git URL and branch ref to allow
specifying fork repositories and branches for testing in CI. Add
a FORCE_REPO_UPDATE flag to delete the repositories to clean
previous states. Defaults to false.