### PR TITLE
Uefi

### DIFF
--- a/vm-setup/roles/libvirt/defaults/main.yml
+++ b/vm-setup/roles/libvirt/defaults/main.yml
@@ -14,6 +14,7 @@ libvirt_diskdev: sda
 libvirt_diskbus: scsi
 libvirt_arch: x86_64
 libvirt_cpu_mode: host-model
+libvirt_firmware: bios
 
 # how many disks should be created when using extradisks
 extradisks_list:

--- a/vm-setup/roles/libvirt/tasks/vm_teardown_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/vm_teardown_tasks.yml
@@ -38,7 +38,7 @@
 
         - name: Undefine vm vms
           command:
-            virsh undefine "{{ item.item.name }}"
+            virsh undefine --nvram "{{ item.item.name }}"
           when: item is success
           with_items: "{{ vm_check.results }}"
 

--- a/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
+++ b/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
@@ -6,7 +6,7 @@
   {{baremetal_vm_xml|default('')}}
 
   <os>
-    <type arch='{{ libvirt_arch }}'>hvm</type>
+    <type arch='{{ libvirt_arch }}' machine='q35'>hvm</type>
     <boot dev='network'/>
     <bootmenu enable='no'/>
   </os>

--- a/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
+++ b/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
@@ -7,6 +7,10 @@
 
   <os>
     <type arch='{{ libvirt_arch }}' machine='q35'>hvm</type>
+{% if libvirt_firmware  == 'uefi' %}
+     <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE.secboot.fd</loader>
+     <nvram>/var/lib/libvirt/qemu/nvram/{{ item.name }}.fd</nvram>
+{% endif %}
     <boot dev='network'/>
     <bootmenu enable='no'/>
   </os>


### PR DESCRIPTION
Should be merged with
https://github.com/openshift-metal3/dev-scripts/pull/784

    Add support for UEFI VMs

and

    Switch VM machine type to q35
    
    When needing UEFI boot in future this will be needed
    as i440fx isn't supported by the OVMF provided with
    RHEL/CentOS.
    
    From https://bugzilla.redhat.com/show_bug.cgi?id=1308678#c10
    "there will be no support for i440fx machine types"
