### PR TITLE
Cleanups and fixes for RHEL8

### DIFF
--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -17,8 +17,10 @@ sudo yum -y update
 
 # Install EPEL required by some packages
 if [ ! -f /etc/yum.repos.d/epel.repo ] ; then
-    if grep -q "Red Hat Enterprise Linux" /etc/redhat-release ; then
-        sudo yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/epel-release-7-11.noarch.rpm
+    if grep -q "Red Hat Enterprise Linux release 7" /etc/redhat-release ; then
+        sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    elif grep -q "Red Hat Enterprise Linux release 8" /etc/redhat-release ; then
+        sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
     else
         sudo yum -y install epel-release --enablerepo=extras
     fi

--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -15,12 +15,11 @@ fi
 # Update to latest packages first
 sudo yum -y update
 
-# Install EPEL required by some packages
+# Install additional repos as needed for each OS version
 if [ ! -f /etc/yum.repos.d/epel.repo ] ; then
     if grep -q "Red Hat Enterprise Linux release 7" /etc/redhat-release ; then
         sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     elif grep -q "Red Hat Enterprise Linux release 8" /etc/redhat-release ; then
-        sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
         sudo subscription-manager repos --enable=ansible-2-for-rhel-8-x86_64-rpms
         sudo alternatives --set python /usr/bin/python3
     else

--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -45,7 +45,10 @@ popd
 popd
 
 # Needed to get a recent python-virtualbmc package
-sudo tripleo-repos current-tripleo
+# Use the explicit path because on RHEL8 it gets installed
+# to /usr/local/bin which isn't in the path for the sudo'd shell
+TRIPLEO_REPOS=$(which tripleo-repos)
+sudo $TRIPLEO_REPOS current-tripleo
 
 # There are some packages which are newer in the tripleo repos
 sudo yum -y update

--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -21,7 +21,8 @@ if [ ! -f /etc/yum.repos.d/epel.repo ] ; then
         sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     elif grep -q "Red Hat Enterprise Linux release 8" /etc/redhat-release ; then
         sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-	sudo subscription-manager repos --enable=ansible-2-for-rhel-8-x86_64-rpms
+        sudo subscription-manager repos --enable=ansible-2-for-rhel-8-x86_64-rpms
+        sudo alternatives --set python /usr/bin/python3
     else
         sudo yum -y install epel-release --enablerepo=extras
     fi

--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -22,12 +22,14 @@ DISTRO="${ID}${VERSION_ID%.*}"
 if [ ! -f /etc/yum.repos.d/epel.repo ] ; then
     if [[ $DISTRO == "rhel7" ]]; then
         sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    elif [[ $DISTRO == "rhel8" ]]; then
-        sudo subscription-manager repos --enable=ansible-2-for-rhel-8-x86_64-rpms
-        sudo alternatives --set python /usr/bin/python3
-    else
+    elif [[ $DISTRO == "centos7" ]]; then
         sudo yum -y install epel-release dnf --enablerepo=extras
     fi
+fi
+
+if [[ $DISTRO == "rhel8" ]]; then
+    sudo subscription-manager repos --enable=ansible-2-for-rhel-8-x86_64-rpms
+    sudo alternatives --set python /usr/bin/python3
 fi
 
 # Install required packages

--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -21,6 +21,7 @@ if [ ! -f /etc/yum.repos.d/epel.repo ] ; then
         sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     elif grep -q "Red Hat Enterprise Linux release 8" /etc/redhat-release ; then
         sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+	sudo subscription-manager repos --enable=ansible-2-for-rhel-8-x86_64-rpms
     else
         sudo yum -y install epel-release --enablerepo=extras
     fi

--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -29,7 +29,7 @@ fi
 # Install required packages
 # python-{requests,setuptools} required for tripleo-repos install
 sudo yum -y install \
-  python-pip \
+  ansible \
   redhat-lsb-core \
   wget
 
@@ -50,10 +50,6 @@ sudo tripleo-repos current-tripleo
 sudo yum -y update
 
 
-# make sure additional requirments are installed
-sudo yum -y install \
-  ansible \
-
 if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
   sudo yum -y install podman
 else
@@ -66,5 +62,3 @@ else
   sudo yum install -y docker-ce docker-ce-cli containerd.io
   sudo systemctl start docker
 fi
-
-# Install python packages not included as rpms

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -85,8 +85,8 @@ fi
 
 # Check CentOS version
 os_version=$(awk -F= '/^VERSION_ID=/ { print $2 }' /etc/os-release | tr -d '"' | cut -f1 -d'.')
-if [[ ${os_version} -ne 7 ]] && [[ ${os_version} -ne 18 ]]; then
-  echo "Required CentOS 7 or RHEL 7 or Ubuntu 18.04"
+if [[ ${os_version} -ne 7 ]] && [[ ${os_version} -ne 8 ]] && [[ ${os_version} -ne 18 ]]; then
+  echo "Required CentOS 7 or RHEL 7/8 or Ubuntu 18.04"
   exit 1
 fi
 

--- a/vm-setup/install-package-playbook.yml
+++ b/vm-setup/install-package-playbook.yml
@@ -3,10 +3,6 @@
   hosts: virthost
   connection: local
   gather_facts: true
-  vars_files:
-    - vars/packages_installation.yml
   tasks:
     - import_role:
         name: packages_installation
-  vars: 
-    packages: "{{ packages_installation }}"

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -76,6 +76,7 @@ packages:
          - virt-install 
     rhel8:
         packages:
+         - crudini 
          - curl 
          - dnsmasq 
          - golang 

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -105,6 +105,7 @@ packages:
          - python3-lxml
          - polkit-pkla-compat
          - python3-netaddr
+         - python3-virtualbmc
          - virt-install 
     pip:
       - yq

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -94,6 +94,9 @@ packages:
          - jq 
          - libguestfs-tools 
          - nodejs 
+         - python3-ironicclient 
+         - python3-ironic-inspector-client 
+         - python3-openstackclient
          - redhat-lsb-core 
          - unzip 
          - genisoimage

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -83,6 +83,9 @@ packages:
          - nmap 
          - patch 
          - psmisc 
+         - python3-pip 
+         - python3-requests 
+         - python3-setuptools 
          - vim-enhanced 
          - wget
          - ansible 

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -107,5 +107,6 @@ packages:
          - python3-netaddr
          - python3-virtualbmc
          - virt-install 
+         - network-scripts
     pip:
       - yq

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -1,4 +1,4 @@
-packages_installation:
+packages:
   ubuntu:
     packages:
      - crudini 

--- a/vm-setup/vars/packages_installation.yml
+++ b/vm-setup/vars/packages_installation.yml
@@ -4,7 +4,6 @@ packages_installation:
      - crudini 
      - curl 
      - dnsmasq 
-     - figlet 
      - golang 
      - nmap 
      - patch 
@@ -28,7 +27,6 @@ packages_installation:
      - libpolkit-gobject-1-0
     pip:
      - ansible==2.8.2
-     - lolcat 
      - yq 
      - virtualbmc 
      - python-ironicclient 
@@ -44,7 +42,6 @@ packages_installation:
          - crudini 
          - curl 
          - dnsmasq 
-         - figlet 
          - golang 
          - NetworkManager 
          - nmap 
@@ -107,5 +104,4 @@ packages_installation:
          - python3-netaddr
          - virt-install 
     pip:
-      - lolcat
       - yq


### PR DESCRIPTION
This makes use of the recently added packages_installation role to install the needed packages on RHEL8, I also removed some unused packages for all platforms (lolcat/figlet) and moved the packages map definition to a more typical roles/default/main.yml location.

WIP as this has only been tested on RHEL8 so far, and not yet tested e2e with dev-scripts.