### PR TITLE
Ensure python3 is installed on RHEL8

### DIFF
--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -34,6 +34,7 @@ fi
 
 if [[ $DISTRO == "rhel8" ]]; then
     sudo subscription-manager repos --enable=ansible-2-for-rhel-8-x86_64-rpms
+    sudo yum -y install python3
     sudo alternatives --set python /usr/bin/python3
 fi
 


### PR DESCRIPTION
Turns out this is not available when you use a minimal install
so lets ensure it's installed before the call to alternatives,
which fails when /usr/bin/python3 does not exist.

Reported via https://github.com/openshift-metal3/dev-scripts/issues/811

Closes: openshift-metal3/dev-scripts/issues/811