### PR TITLE
Fix libvirt group issue for Minikube

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -29,12 +29,6 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -i vm-setup/inventory.ini \
     -b -vvv vm-setup/setup-playbook.yml
 
-# Allow local non-root-user access to libvirt
-# Restart libvirtd service to get the new group membership loaded
-if ! id "$USER" | grep -q libvirt; then
-  sudo usermod -a -G "libvirt" "$USER"
-  sudo systemctl restart libvirtd
-fi
 # Usually virt-manager/virt-install creates this: https://www.redhat.com/archives/libvir-list/2008-August/msg00179.html
 if ! virsh pool-uuid default > /dev/null 2>&1 ; then
     virsh pool-define /dev/stdin <<EOF


### PR DESCRIPTION
The move of Minikube broke the deployment since the user is not part of the libvirt group. This commit adds the user to libvirt group.

Note : We are adding the provisioning interface to Minikube before creating the provisioning network. Any attempt to start again Minikube before running the 02_xx script will fail.