### PR TITLE
Prevent missing group issue with Minikube in CI

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -74,7 +74,7 @@ function configure_minikube() {
 function init_minikube() {
     #If the vm exists, it has already been initialized
     if [[ "$(sudo virsh list --all)" != *"minikube"* ]]; then
-      minikube start
+      sudo su -l -c "minikube start" "$USER"
       # The interface doesn't appear in the minikube VM with --live,
       # so just attach it and make it reboot. As long as the
       # 02_configure_host.sh script does not run, the provisioning network does
@@ -82,7 +82,7 @@ function init_minikube() {
       sudo virsh attach-interface --domain minikube \
           --model virtio --source provisioning \
           --type network --config
-      minikube stop
+      sudo su -l -c "minikube stop" "$USER"
     fi
 }
 

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -30,8 +30,8 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -b -vvv vm-setup/setup-playbook.yml
 
 # Usually virt-manager/virt-install creates this: https://www.redhat.com/archives/libvir-list/2008-August/msg00179.html
-if ! virsh pool-uuid default > /dev/null 2>&1 ; then
-    virsh pool-define /dev/stdin <<EOF
+if ! sudo virsh pool-uuid default > /dev/null 2>&1 ; then
+    sudo virsh pool-define /dev/stdin <<EOF
 <pool type='dir'>
   <name>default</name>
   <target>
@@ -39,8 +39,8 @@ if ! virsh pool-uuid default > /dev/null 2>&1 ; then
   </target>
 </pool>
 EOF
-    virsh pool-start default
-    virsh pool-autostart default
+    sudo virsh pool-start default
+    sudo virsh pool-autostart default
 fi
 
 if [[ $OS == ubuntu ]]; then

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -114,7 +114,7 @@ function launch_cluster_api() {
 }
 
 clone_repos
-minikube start
+sudo su -l -c 'minikube start' "${USER}"
 launch_baremetal_operator
 apply_bm_hosts
 launch_cluster_api

--- a/04_verify.sh
+++ b/04_verify.sh
@@ -19,7 +19,7 @@ check_bm_hosts() {
     MAC="${5}"
     BM_HOSTS="$(kubectl --kubeconfig "${KUBECONFIG}" get baremetalhosts\
       -n metal3 -o json)"
-    BM_VMS="$(virsh list --all)"
+    BM_VMS="$(sudo virsh list --all)"
     BM_VMNAME="${NAME//-/_}"
     # Verify BM host exists
     RESULT_STR="${NAME} Baremetalhost exist"
@@ -64,7 +64,7 @@ check_bm_hosts() {
     process_status $?
 
     #Verify the VMs interfaces
-    BM_VM_IFACES="$(virsh domiflist "${BM_VMNAME}")"
+    BM_VM_IFACES="$(sudo virsh domiflist "${BM_VMNAME}")"
     for bridge in ${BRIDGES}; do
       RESULT_STR="${NAME} Baremetalhost VM interface ${bridge} exist"
       echo "$BM_VM_IFACES" | grep -w "${bridge}"  > /dev/null
@@ -200,7 +200,7 @@ process_status $?
 
 ## Fetch the VMs
 RESULT_STR="Fetch Baremetalhosts VMs"
-virsh list --all > /dev/null
+sudo virsh list --all > /dev/null
 process_status $?
 echo ""
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ verify:
 clean: delete_mgmt_cluster host_cleanup
 
 delete_mgmt_cluster:
-	minikube delete || true
+	sudo minikube delete || true
 
 host_cleanup:
 	./host_cleanup.sh


### PR DESCRIPTION
When starting minikube in the same script as we add the user to
libvirt group, it fails. This runs the Minikube commands in a
new login shell, and adds sudo for virsh where needed