### PR TITLE
Reinstate virtualbmc service teardown tasks

### DIFF
--- a/vm-setup/roles/virtbmc/tasks/teardown_tasks.yml
+++ b/vm-setup/roles/virtbmc/tasks/teardown_tasks.yml
@@ -2,6 +2,28 @@
 
 - name: Remove virtualbmc directories
   file:
-    path: "{{ working_dir }}/virtualbmc"
+    path: "{{ item }}"
     state: absent
+  with_items:
+    # From old systemd virtualbmc service
+    - "/etc/virtualbmc"
+    - "/var/log/virtualbmc"
+    - "/root/.vbmc/"
+    # Containerized version working dir
+    - "{{ working_dir }}/virtualbmc"
+  become: true
+
+- name: Stop/disable the Virtual BMCs (virtualbmc >= 1.4.0+) on CentOS
+  when:
+    - ansible_os_family == "RedHat"
+  service:
+    name: "virtualbmc"
+    state: "stopped" 
+    enabled: false
+  become: true
+
+- name: Stop/disable the Virtual BMCs (virtualbmc >= 1.4.0+) on Ubuntu
+  when:
+    - ansible_distribution == 'Ubuntu' 
+  shell: pkill vbmcd || true
   become: true


### PR DESCRIPTION
These were removed in #48 which is fine for a greenfield CI environment
but leads to unexpected behavior in developer test environments, since
the old systemd service is not stopped before starting the new containers.