### PR TITLE
source lib/common.sh in 01_prepare_host.sh

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-OS=$(awk -F= '/^ID=/ { print $2 }' /etc/os-release | tr -d '"')
+set -xe
+
+# shellcheck disable=SC1091
+source lib/logging.sh
+# shellcheck disable=SC1091
+source lib/common.sh
+
 if [[ $OS == ubuntu ]]; then
   # shellcheck disable=SC1091
   source ubuntu_install_requirements.sh
@@ -60,10 +66,10 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -i vm-setup/inventory.ini \
   -b -vvv vm-setup/install-package-playbook.yml
 
-pushd resources/vbmc
+pushd ${SCRIPTDIR}/resources/vbmc
 sudo "${CONTAINER_RUNTIME}" build -t "${VBMC_IMAGE}" .
 popd
-pushd resources/sushy-tools
+pushd ${SCRIPTDIR}/resources/sushy-tools
 sudo "${CONTAINER_RUNTIME}" build -t "${SUSHY_TOOLS_IMAGE}" .
 popd
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -2,17 +2,17 @@
 
 eval "$(go env)"
 
-SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 USER="$(whoami)"
 
 # Get variables from the config file
 if [ -z "${CONFIG:-}" ]; then
     # See if there's a config_$USER.sh in the SCRIPTDIR
-    if [ ! -f "${SCRIPTDIR}/../config_${USER}.sh" ]; then
-        cp "${SCRIPTDIR}/../config_example.sh" "${SCRIPTDIR}/../config_${USER}.sh"
+    if [ ! -f "${SCRIPTDIR}/config_${USER}.sh" ]; then
+        cp "${SCRIPTDIR}/config_example.sh" "${SCRIPTDIR}/config_${USER}.sh"
         echo "Automatically created config_${USER}.sh with default contents."
     fi
-    CONFIG="${SCRIPTDIR}/../config_${USER}.sh"
+    CONFIG="${SCRIPTDIR}/config_${USER}.sh"
 fi
 # shellcheck disable=SC1090
 source "$CONFIG"
@@ -81,7 +81,7 @@ if ! sudo -n uptime &> /dev/null ; then
 fi
 
 # Check OS
-OS=$(awk -F= '/^ID=/ { print $2 }' /etc/os-release | tr -d '"')
+export OS=$(awk -F= '/^ID=/ { print $2 }' /etc/os-release | tr -d '"')
 if [[ ! $OS =~ ^(centos|rhel|ubuntu)$ ]]; then
   echo "Unsupported OS"
   exit 1


### PR DESCRIPTION
Currently VBMC_IMAGE and SUSHY_TOOLS_IMAGE are undefined because
they're defined in lib/common.sh.

Also I noticed that the pushd uses a relative path which won't work
unless the calling shell is in the metal3-dev-env dir, and we're
not logging the output from this script.