### PR TITLE
Use vbmc and sushy-tools images from quay.io.

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -66,12 +66,8 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -i vm-setup/inventory.ini \
   -b -vvv vm-setup/install-package-playbook.yml
 
-pushd ${SCRIPTDIR}/resources/vbmc
-sudo "${CONTAINER_RUNTIME}" build -t "${VBMC_IMAGE}" .
-popd
-pushd ${SCRIPTDIR}/resources/sushy-tools
-sudo "${CONTAINER_RUNTIME}" build -t "${SUSHY_TOOLS_IMAGE}" .
-popd
+sudo "${CONTAINER_RUNTIME}" pull "${VBMC_IMAGE}"
+sudo "${CONTAINER_RUNTIME}" pull "${SUSHY_TOOLS_IMAGE}"
 
 # Allow local non-root-user access to libvirt
 # Restart libvirtd service to get the new group membership loaded

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -51,8 +51,8 @@ export NUM_WORKERS=${NUM_WORKERS:-"1"}
 export VM_EXTRADISKS=${VM_EXTRADISKS:-"false"}
 
 # VBMC and Redfish images
-export VBMC_IMAGE=${VBMC_IMAGE:-"vbmc"}
-export SUSHY_TOOLS_IMAGE=${SUSHY_TOOLS_IMAGE:-"sushy-tools"}
+export VBMC_IMAGE=${VBMC_IMAGE:-"quay.io/metal3-io/vbmc"}
+export SUSHY_TOOLS_IMAGE=${SUSHY_TOOLS_IMAGE:-"quay.io/metal3-io/sushy-tools"}
 
 # Ironic vars
 export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}


### PR DESCRIPTION
Instead of building these locally, pull pre-built images from quay.io.
These images are set to automatically rebuild any time metal3-dev-env
changes.