### PR TITLE
List command the script is blocking on.

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -156,7 +156,8 @@ iterate(){
   do
     if [[ "${RUNS}" == "0" ]]; then
       echo "   - Waiting for task completion (up to" \
-        "$((TEST_TIME_INTERVAL*TEST_MAX_TIME)) seconds)"
+        "$((TEST_TIME_INTERVAL*TEST_MAX_TIME)) seconds)" \
+        " - Command: '${COMMAND}'"
     fi
     RUNS="$((RUNS+1))"
     if [[ "${RUNS}" == "${TEST_MAX_TIME}" ]]; then


### PR DESCRIPTION
While running the verify or test script, the scripts will block with a
message like this:

  - Waiting for task completion (up to 1200 seconds)

This is while waiting for a long running task, like provisioning a
machine.  This trivial change outputs the command being run by the
function, to give a hint about what it's blocking on.

The command being run is usually another shell function with some
arguments, but so far it gives a pretty good hint about what's going
on.  For example:

  - Waiting for task completion (up to 1200 seconds)  - Command:
    'check_provisioning_status centos-0 master-0 provisioned'