### PR TITLE
Move ironic into cluster

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -115,6 +115,7 @@ function launch_cluster_api() {
 
 clone_repos
 sudo su -l -c 'minikube start' "${USER}"
+sudo su -l -c 'minikube ssh sudo ip addr add 172.22.0.2/24 dev eth2' "${USER}"
 launch_baremetal_operator
 apply_bm_hosts
 launch_cluster_api

--- a/04_verify.sh
+++ b/04_verify.sh
@@ -227,12 +227,7 @@ if [[ "${BMO_RUN_LOCAL}" == true ]] || [[ "${CAPBM_RUN_LOCAL}" == true ]]; then
   echo ""
 fi
 
-#Verify Ironic containers are running
-for name in ironic ironic-inspector dnsmasq httpd mariadb; do
-  iterate check_container "${name}"
-done
-echo ""
-
+iterate check_container httpd
 
 echo -e "\nNumber of failures : $FAILS"
 exit "${FAILS}"

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -7,7 +7,7 @@ source lib/logging.sh
 source lib/common.sh
 
 # Kill and remove the running ironic containers
-for name in ironic ironic-inspector dnsmasq httpd mariadb vbmc sushy-tools; do
+for name in ipa-downloader ironic ironic-inspector dnsmasq httpd mariadb vbmc sushy-tools; do
     sudo "${CONTAINER_RUNTIME}" ps | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" kill $name
     sudo "${CONTAINER_RUNTIME}" ps --all | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" rm $name -f
 done

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -36,6 +36,12 @@ ROOT_DISK_NAME=${ROOT_DISK_NAME-"/dev/sda"}
 #Container runtime
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"podman"}
 
+if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
+  export POD_NAME="--pod ironic-pod"
+else
+  export POD_NAME=""
+fi
+
 export EXTERNAL_SUBNET="192.168.111.0/24"
 
 export SSH_PUB_KEY=~/.ssh/id_rsa.pub
@@ -55,9 +61,13 @@ export VBMC_IMAGE=${VBMC_IMAGE:-"quay.io/metal3-io/vbmc"}
 export SUSHY_TOOLS_IMAGE=${SUSHY_TOOLS_IMAGE:-"quay.io/metal3-io/sushy-tools"}
 
 # Ironic vars
+export IPA_DOWNLOADER_IMAGE=${IPA_DOWNLOADER_IMAGE:-"quay.io/metal3-io/ironic-ipa-downloader:master"}
 export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}
-export IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic-inspector"}
 export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
+export IRONIC_IMAGE_DIR="$IRONIC_DATA_DIR/html/images"
+
+# Config for OpenStack CLI
+export OPENSTACK_CONFIG=$HOME/.config/openstack/clouds.yaml
 
 # Test and verification related variables
 SKIP_RETRIES="${SKIP_RETRIES:-false}"


### PR DESCRIPTION
This deploys the Ironic containers in the cluster itself, rather than
the provisioning host. The provisioning host still maintains an httpd
server for hosting a cache of the IPA images, as well as any additional
images the user wants to provision with (by default we populate it with
CentOS).

Goes with https://github.com/metal3-io/baremetal-operator/pull/309

fixes #41