### PR TITLE
Remove sudo from minikube delete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ verify:
 clean: delete_mgmt_cluster host_cleanup
 
 delete_mgmt_cluster:
-	sudo minikube delete || true
+	minikube delete || true
 
 host_cleanup:
 	./host_cleanup.sh


### PR DESCRIPTION
This fails for me, the minikube VM is not deleted but removing
the sudo removes it as expected.