### PR TITLE
Clean-up minikube VM correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ verify:
 clean: delete_mgmt_cluster host_cleanup
 
 delete_mgmt_cluster:
-	sudo minikube delete || true
+	sudo su -l -c "minikube delete" "$(USER)"
 
 host_cleanup:
 	./host_cleanup.sh


### PR DESCRIPTION
Currently the VM doesn't get cleaned up CentOS. This changes the
`minikube delete` like to be executed the same way as the rest of the
minikube commands.