### PR TITLE
Add script that runs shellcheck how it will run in CI.

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -14,25 +14,25 @@ else
   source centos_install_requirements.sh
 fi
 
-if ! which minikube 2>/dev/null ; then
+if ! command -v minikube 2>/dev/null ; then
     curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
     chmod +x minikube
     sudo mv minikube /usr/local/bin/.
 fi
 
-if ! which docker-machine-driver-kvm2 2>/dev/null ; then
+if ! command -v docker-machine-driver-kvm2 2>/dev/null ; then
     curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2
     chmod +x docker-machine-driver-kvm2
     sudo mv docker-machine-driver-kvm2 /usr/local/bin/.
 fi
 
-if ! which kubectl 2>/dev/null ; then
+if ! command -v kubectl 2>/dev/null ; then
     curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
     chmod +x kubectl
     sudo mv kubectl /usr/local/bin/.
 fi
 
-if ! which kustomize 2>/dev/null ; then
+if ! command -v kustomize 2>/dev/null ; then
     curl -Lo kustomize "$(curl --silent -L https://github.com/kubernetes-sigs/kustomize/releases/latest 2>&1 | awk -F'"' '/linux_amd64/ { print "https://github.com"$2; exit }')"
     chmod +x kustomize
     sudo mv kustomize /usr/local/bin/.

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,6 @@ test:
 	./05_test.sh
 
 lint:
-	shellcheck -s bash *.sh
+	./hack/shellcheck.sh
 
 .PHONY: all install_requirements configure_host launch_mgmt_cluster clean delete_mgmt_cluster host_cleanup verify test lint

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER=${IS_CONTAINER:-false}
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+  TOP_DIR="${1:-.}"
+  find "${TOP_DIR}" \
+    -type f -name '*.sh' -exec shellcheck -s bash {} \+
+else
+  podman run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/workdir:ro,z" \
+    --entrypoint sh \
+    --workdir /workdir \
+    registry.hub.docker.com/koalaman/shellcheck-alpine:stable \
+    /workdir/hack/shellcheck.sh "${@}"
+fi;

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -81,7 +81,8 @@ if ! sudo -n uptime &> /dev/null ; then
 fi
 
 # Check OS
-export OS=$(awk -F= '/^ID=/ { print $2 }' /etc/os-release | tr -d '"')
+OS=$(awk -F= '/^ID=/ { print $2 }' /etc/os-release | tr -d '"')
+export OS
 if [[ ! $OS =~ ^(centos|rhel|ubuntu)$ ]]; then
   echo "Unsupported OS"
   exit 1
@@ -95,14 +96,14 @@ if [[ ${os_version} -ne 7 ]] && [[ ${os_version} -ne 8 ]] && [[ ${os_version} -n
 fi
 
 # Check d_type support
-FSTYPE=$(df ${FILESYSTEM} --output=fstype | grep -v Type)
+FSTYPE=$(df "${FILESYSTEM}" --output=fstype | grep -v Type)
 
 case ${FSTYPE} in
   'ext4'|'btrfs')
   ;;
   'xfs')
     # shellcheck disable=SC2143
-    if [[ $(xfs_info ${FILESYSTEM} | grep -q "ftype=1") ]]; then
+    if [[ $(xfs_info "${FILESYSTEM}" | grep -q "ftype=1") ]]; then
       echo "Filesystem not supported"
       exit 1
     fi

--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -1,9 +1,9 @@
 # Log output automatically
-LOGDIR="$(dirname $0)/logs"
+LOGDIR="$(dirname "$0")/logs"
 if [ ! -d "$LOGDIR" ]; then
     mkdir -p "$LOGDIR"
 fi
-LOGFILE="$LOGDIR/$(basename $0 .sh)-$(date +%F-%H%M%S).log"
+LOGFILE="$LOGDIR/$(basename "$0" .sh)-$(date +%F-%H%M%S).log"
 echo "Logging to $LOGFILE"
 # Set fd 1 and 2 to write to the log file
 exec 1> >( tee "${LOGFILE}" ) 2>&1

--- a/vm-setup/roles/libvirt/files/get-domain-ip.sh
+++ b/vm-setup/roles/libvirt/files/get-domain-ip.sh
@@ -12,14 +12,14 @@ VMNAME=$1
 # `<mac address...` line.  Yes, we're parsing XML with awk.  It's probably
 # safe (because the XML is coming from libvirt, so we can be reasonably
 # confident that the formatting will remain the same).
-mac=$(virsh dumpxml $VMNAME | awk -F "'" '/mac address/ { print $2; exit }')
+mac=$(virsh dumpxml "$VMNAME" | awk -F "'" '/mac address/ { print $2; exit }')
 
 # Look up the MAC address in the ARP table.
-ip=$(ip neigh | grep $mac | awk '{print $1;}')
+ip=$(ip neigh | grep "$mac" | awk '{print $1;}')
 
 if [ -z "$ip" ]; then
     echo "vm ip is not available" >&2
     exit 1
 fi
 
-echo $ip
+echo "$ip"


### PR DESCRIPTION
Instead of running shellcheck directly, do it via a script that will
also be run by CI.  When not running in CI (from within a container),
it will run shellcheck from the same container image used in CI.
