### PR TITLE
Provide clouds.yaml for interacting with Ironic

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -155,20 +155,3 @@ sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name vbmc ${POD_NAM
 sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name sushy-tools ${POD_NAME} \
      -v "$WORKING_DIR/virtualbmc/sushy-tools":/root/sushy -v "/root/.ssh":/root/ssh \
      "${SUSHY_TOOLS_IMAGE}"
-
-# Create openstack clouds.yaml
-if [[ ! -f "$OPENSTACK_CONFIG" ]]
-then
-  mkdir -p "$HOME/.config/openstack"
-  echo "clouds:" > "$HOME/.config/openstack/clouds.yaml"
-fi
-
-if ! grep -qi metal3 "$OPENSTACK_CONFIG"
-then
-  cat <<EOF >>"$OPENSTACK_CONFIG"
-  metal3:
-    auth_type: none
-    baremetal_endpoint_override: http://172.22.0.2:6385
-    baremetal_introspection_endpoint_override: http://172.22.0.2:5050
-EOF
-fi

--- a/clouds.yaml
+++ b/clouds.yaml
@@ -1,0 +1,5 @@
+clouds:
+  metal3:
+    auth_type: none
+    baremetal_endpoint_override: http://172.22.0.2:6385
+    baremetal_introspection_endpoint_override: http://172.22.0.2:5050

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -66,9 +66,6 @@ export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}
 export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
 export IRONIC_IMAGE_DIR="$IRONIC_DATA_DIR/html/images"
 
-# Config for OpenStack CLI
-export OPENSTACK_CONFIG=$HOME/.config/openstack/clouds.yaml
-
 # Test and verification related variables
 SKIP_RETRIES="${SKIP_RETRIES:-false}"
 TEST_TIME_INTERVAL="${TEST_TIME_INTERVAL:-10}"


### PR DESCRIPTION
Instead of writing clouds.yaml to the user's home directory, make things work just like OpenShift's `clouds.yaml`, if you'd like to use it run the `openstack` CLI from within the repo directory.

This solves the problem of being able to use the `metal3` name for both repos, despite having different IP's, and also avoids the problem of `yq` wiping out any comments in a user's existing clouds.yaml in $HOME.