### PR TITLE
Fix iptables rules for PXE boot

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -108,12 +108,25 @@ else
   fi
 fi
 
-# Add firewall rules to ensure the IPA ramdisk can reach httpd, Ironic and the Inspector API on the host
-for port in 80 5050 6385 ; do
-    if ! sudo iptables -C INPUT -i provisioning -p tcp -m tcp --dport $port -j ACCEPT > /dev/null 2>&1; then
-        sudo iptables -I INPUT -i provisioning -p tcp -m tcp --dport $port -j ACCEPT
+# Add firewall rules to ensure the IPA ramdisk can reach httpd, Ironic and the
+# Inspector API on the cluster, and ironic can reach the agent (9999)
+for port in 6180 5050 6385 9999; do
+    if ! sudo iptables -C FORWARD -i provisioning -p tcp -m tcp --dport $port \
+      -j ACCEPT > /dev/null 2>&1; then
+        sudo iptables -I FORWARD -i provisioning -p tcp -m tcp --dport $port \
+          -j ACCEPT
+    fi
+    if ! sudo iptables -C FORWARD -i provisioning -p tcp -m tcp --sport $port \
+      -j ACCEPT > /dev/null 2>&1; then
+        sudo iptables -I FORWARD -i provisioning -p tcp -m tcp --sport $port \
+          -j ACCEPT
     fi
 done
+
+# Add firewall rules to ensure the IPA ramdisk can reach httpd on the host
+if ! sudo iptables -C INPUT -i provisioning -p tcp -m tcp --dport 80 -j ACCEPT > /dev/null 2>&1; then
+    sudo iptables -I INPUT -i provisioning -p tcp -m tcp --dport 80 -j ACCEPT
+fi
 
 # Allow ipmi to the virtual bmc processes that we just started
 if ! sudo iptables -C INPUT -i baremetal -p udp -m udp --dport 6230:6235 -j ACCEPT 2>/dev/null ; then
@@ -121,9 +134,9 @@ if ! sudo iptables -C INPUT -i baremetal -p udp -m udp --dport 6230:6235 -j ACCE
 fi
 
 #Allow access to dhcp and tftp server for pxeboot
-for port in 67 69 ; do
-    if ! sudo iptables -C INPUT -i provisioning -p udp --dport $port -j ACCEPT 2>/dev/null ; then
-        sudo iptables -I INPUT -i provisioning -p udp --dport $port -j ACCEPT
+for port in 67 68 69 ; do
+    if ! sudo iptables -C FORWARD -i provisioning -p udp --dport $port -j ACCEPT 2>/dev/null ; then
+        sudo iptables -I FORWARD -i provisioning -p udp --dport $port -j ACCEPT
     fi
 done
 


### PR DESCRIPTION
Ironic was moved in cluster, the DHCP traffic is not
anymore hitting the INPUT target on the host, but the FORWARD

Fixes #84 