### PR TITLE
Use ansible to setup firewalld or iptables rules as appropriate

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -108,6 +108,13 @@ if [[ ${os_version} -ne 7 ]] && [[ ${os_version} -ne 8 ]] && [[ ${os_version} -n
   exit 1
 fi
 
+# Use firewalld on CentOS/RHEL, iptables everywhere else
+export USE_FIREWALLD=False
+if [[ ($OS == "rhel" || $OS = "centos") && ${os_version} == 8 ]]
+then
+  export USE_FIREWALLD=True
+fi
+
 # Check d_type support
 FSTYPE=$(df "${FILESYSTEM}" --output=fstype | grep -v Type)
 

--- a/vm-setup/firewall.yml
+++ b/vm-setup/firewall.yml
@@ -1,0 +1,8 @@
+---
+- name: Setup dummy baremetal VMs
+  hosts: virthost
+  connection: local
+  gather_facts: true
+  tasks:
+    - import_role:
+        name: firewall

--- a/vm-setup/roles/firewall/defaults/main.yml
+++ b/vm-setup/roles/firewall/defaults/main.yml
@@ -1,0 +1,19 @@
+use_firewalld: true
+baremetal_interface: baremetal
+provisioning_interface: provisioning
+vbmc_port_range: "6230:6235"
+ironic_ports:
+  - "6180"
+  - "5050"
+  - "6385"
+  - "9999"
+provisioning_host_ports:
+  # Caching HTTP Server
+  - "80"
+  # Container image registry
+  - "5000"
+pxe_udp_ports:
+  - "5353"
+  - "67"
+  - "68"
+  - "69"

--- a/vm-setup/roles/firewall/tasks/firewalld.yaml
+++ b/vm-setup/roles/firewall/tasks/firewalld.yaml
@@ -1,0 +1,45 @@
+- firewalld:
+    zone: libvirt
+    interface: "{{ item }}"
+    permanent: yes
+    state: enabled
+  loop:
+    - "{{ provisioning_interface }}"
+    - "{{ baremetal_interface }}"
+
+- name: "firewalld: Provisioning host ports"
+  firewalld:
+    zone: libvirt
+    port: "{{ item }}/tcp"
+    permanent: yes
+    state: enabled
+  loop: "{{ provisioning_host_ports }}"
+
+- name: "firewalld: Ironic Ports"
+  firewalld:
+    zone: libvirt
+    port: "{{ item }}/tcp"
+    permanent: yes
+    state: enabled
+  loop: "{{ ironic_ports }}"
+
+- name: "firewalld: PXE Ports"
+  firewalld:
+    zone: libvirt
+    port: "{{ item }}/udp"
+    permanent: yes
+    state: enabled
+  loop: "{{ pxe_udp_ports }}"
+
+- name: "firewalld: VBMC Ports"
+  firewalld:
+    zone: libvirt
+    port: "{{ vbmc_port_range | regex_replace(':', '-') }}/udp"
+    permanent: yes
+    state: enabled
+
+- name: "firewalld: Firewalld service"
+  service:
+    name: firewalld
+    state: restarted
+    enabled: yes

--- a/vm-setup/roles/firewall/tasks/iptables.yaml
+++ b/vm-setup/roles/firewall/tasks/iptables.yaml
@@ -1,0 +1,45 @@
+- name: "iptables: Firewalld service stopped"
+  service:
+    name: firewalld
+    state: stopped
+    enabled: no
+  ignore_errors: True
+
+- name: "iptables: VBMC Ports"
+  iptables:
+    chain: INPUT
+    in_interface: "{{ baremetal_interface }}"
+    protocol: udp
+    match: udp
+    destination_port: "{{ vbmc_port_range }}"
+    jump: ACCEPT
+
+- name: "iptables: Ironic Ports"
+  iptables:
+    chain: FORWARD
+    in_interface: "{{ provisioning_interface }}"
+    protocol: tcp
+    match: tcp
+    destination_port: "{{ item }}"
+    jump: ACCEPT
+  loop: "{{ ironic_ports }}"
+
+- name: "iptables: Provisioning host ports"
+  iptables:
+    chain: INPUT
+    in_interface: "{{ provisioning_interface }}"
+    protocol: tcp
+    match: tcp
+    destination_port: "{{ item }}"
+    jump: ACCEPT
+  loop: "{{ provisioning_host_ports }}"
+
+- name: "iptables: PXE Ports"
+  iptables:
+    chain: FORWARD
+    in_interface: "{{ provisioning_interface }}"
+    protocol: udp
+    match: udp
+    destination_port: "{{ item }}"
+    jump: ACCEPT
+  loop: "{{ pxe_udp_ports }}"

--- a/vm-setup/roles/firewall/tasks/main.yml
+++ b/vm-setup/roles/firewall/tasks/main.yml
@@ -1,0 +1,10 @@
+- name: "firewalld"
+  include: firewalld.yaml
+  become: true
+  when: use_firewalld
+
+- name: "iptables"
+  include: iptables.yaml
+  become: true
+  when: not use_firewalld
+


### PR DESCRIPTION
I was running into an issue where firewalld was started and was
preempting the manual iptables configuration, with firewalld started I
wasn't able to reach the httpd server running on the provisioning host.
This ensures it's off and disabled.

We also weren't cleaning up the interfaces on RHEL, only CentOS.