### PR TITLE
refactor minikube initialization

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -88,31 +88,5 @@ function configure_minikube() {
     minikube config set vm-driver kvm2
 }
 
-function init_minikube() {
-    #If the vm exists, it has already been initialized
-    if [[ "$(sudo virsh list --all)" != *"minikube"* ]]; then
-      sudo su -l -c "minikube start" "$USER"
-      sudo su -l -c "minikube stop" "$USER"
-    fi
-
-    MINIKUBE_IFACES="$(sudo virsh domiflist minikube)"
-
-    # The interface doesn't appear in the minikube VM with --live,
-    # so just attach it before next boot. As long as the
-    # 02_configure_host.sh script does not run, the provisioning network does
-    # not exist. Attempting to start Minikube will fail until it is created.
-    if ! echo "$MINIKUBE_IFACES" | grep -w provisioning  > /dev/null ; then
-      sudo virsh attach-interface --domain minikube \
-          --model virtio --source provisioning \
-          --type network --config
-    fi
-
-    if ! echo "$MINIKUBE_IFACES" | grep -w baremetal  > /dev/null ; then
-      sudo virsh attach-interface --domain minikube \
-          --model virtio --source baremetal \
-          --type network --config
-    fi
-}
-
 configure_minikube
 init_minikube

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -35,9 +35,9 @@ BMOBRANCH="${BMOBRANCH:-master}"
 CAPBMREPO="${CAPBMREPO:-https://github.com/metal3-io/cluster-api-provider-baremetal.git}"
 CAPBMBRANCH="${CAPBMBRANCH:-master}"
 
-CAPIREPO="${CAPIREPO:-https://github.com/kubernetes-sigs/cluster-api.git}" 
+CAPIREPO="${CAPIREPO:-https://github.com/kubernetes-sigs/cluster-api.git}"
 CAPIBRANCH="${CAPIBRANCH:-master}"
-CABPKREPO="${CABPKREPO:-https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm.git}" 
+CABPKREPO="${CABPKREPO:-https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm.git}"
 CABPKBRANCH="${CABPKBRANCH:-master}"
 
 FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-false}"
@@ -171,6 +171,7 @@ function launch_cluster_api_bootstrap_provider_kubeadm() {
 }
 
 clone_repos
+init_minikube
 sudo su -l -c 'minikube start' "${USER}"
 sudo su -l -c 'minikube ssh sudo ip addr add 172.22.0.2/24 dev eth2' "${USER}"
 launch_baremetal_operator


### PR DESCRIPTION
in order to be able to call 03_launch_mgmt.sh script after make clean
and avoid failure on Minikube interfaces. (in case you do not run 01_prepare_host.sh after make clean to speed things up)