### PR TITLE
Add iptables rule to allow mdns for ironic on provisioning

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -111,15 +111,15 @@ fi
 # Add firewall rules to ensure the IPA ramdisk can reach httpd, Ironic and the
 # Inspector API on the cluster, and ironic can reach the agent (9999)
 for port in 6180 5050 6385 9999; do
-    if ! sudo iptables -C FORWARD -i provisioning -p tcp -m tcp --dport $port \
-      -j ACCEPT > /dev/null 2>&1; then
-        sudo iptables -I FORWARD -i provisioning -p tcp -m tcp --dport $port \
-          -j ACCEPT
+    if ! sudo iptables -C FORWARD -i provisioning -o provisioning -p tcp \
+      -m tcp --dport $port -j ACCEPT > /dev/null 2>&1; then
+        sudo iptables -I FORWARD -i provisioning -o provisioning -p tcp -m tcp \
+          --dport $port -j ACCEPT
     fi
-    if ! sudo iptables -C FORWARD -i provisioning -p tcp -m tcp --sport $port \
-      -j ACCEPT > /dev/null 2>&1; then
-        sudo iptables -I FORWARD -i provisioning -p tcp -m tcp --sport $port \
-          -j ACCEPT
+    if ! sudo iptables -C FORWARD -i provisioning -o provisioning -p tcp \
+      -m tcp --sport $port -j ACCEPT > /dev/null 2>&1; then
+        sudo iptables -I FORWARD -i provisioning -o provisioning -p tcp -m tcp \
+          --sport $port -j ACCEPT
     fi
 done
 
@@ -134,9 +134,11 @@ if ! sudo iptables -C INPUT -i baremetal -p udp -m udp --dport 6230:6235 -j ACCE
 fi
 
 #Allow access to dhcp and tftp server for pxeboot
-for port in 67 68 69 ; do
-    if ! sudo iptables -C FORWARD -i provisioning -p udp --dport $port -j ACCEPT 2>/dev/null ; then
-        sudo iptables -I FORWARD -i provisioning -p udp --dport $port -j ACCEPT
+for port in 67 68 69 5353; do
+    if ! sudo iptables -C FORWARD -i provisioning -o provisioning -p udp \
+      --dport $port -j ACCEPT 2>/dev/null ; then
+        sudo iptables -I FORWARD -i provisioning -o provisioning -p udp \
+          --dport $port -j ACCEPT
     fi
 done
 


### PR DESCRIPTION
Now using new version of ironic, IPA uses mdns to resolve the ironic endpoint. Adding port 5353 in iptables rules.

and small code refactoring for iptables commands. Also adding an out interface match on provisioning rules