### PR TITLE
Changes bmh naming

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -24,8 +24,7 @@ fi
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "working_dir=$WORKING_DIR" \
-    -e "num_masters=$NUM_MASTERS" \
-    -e "num_workers=$NUM_WORKERS" \
+    -e "num_nodes=$NUM_NODES" \
     -e "extradisks=$VM_EXTRADISKS" \
     -e "virthost=$HOSTNAME" \
     -e "platform=$NODES_PLATFORM" \

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -52,8 +52,7 @@ WORKING_DIR=${WORKING_DIR:-"/opt/metal3-dev-env"}
 NODES_FILE=${NODES_FILE:-"${WORKING_DIR}/ironic_nodes.json"}
 NODES_PLATFORM=${NODES_PLATFORM:-"libvirt"}
 
-export NUM_MASTERS=${NUM_MASTERS:-"1"}
-export NUM_WORKERS=${NUM_WORKERS:-"1"}
+export NUM_NODES=${NUM_NODES:-"2"}
 export VM_EXTRADISKS=${VM_EXTRADISKS:-"false"}
 
 # VBMC and Redfish images

--- a/vm-setup/roles/common/defaults/main.yml
+++ b/vm-setup/roles/common/defaults/main.yml
@@ -11,21 +11,14 @@ libvirt_nic_model: virtio
 default_disk: 50
 default_memory: 8192
 default_vcpu: 4
-num_masters: 1
-num_workers: 1
+num_nodes: 2
 extradisks: false
 virtualbmc_base_port: 6230
 flavors:
-  master:
-    memory: '{{master_memory|default(default_memory)}}'
-    disk: '{{master_disk|default(default_disk)}}'
-    vcpu: '{{master_vcpu|default(default_vcpu)}}'
-    extradisks: '{{extradisks|bool}}'
-
-  worker:
-    memory: '{{worker_memory|default(default_memory)}}'
-    disk: '{{worker_disk|default(default_disk)}}'
-    vcpu: '{{worker_vcpu|default(default_vcpu)}}'
+  node:
+    memory: '{{node_memory|default(default_memory)}}'
+    disk: '{{node_disk|default(default_disk)}}'
+    vcpu: '{{node_vcpu|default(default_vcpu)}}'
     extradisks: '{{extradisks|bool}}'
 
 # An optional prefix for node names

--- a/vm-setup/roles/common/tasks/main.yml
+++ b/vm-setup/roles/common/tasks/main.yml
@@ -6,21 +6,13 @@
 - name: Define vm_nodes if not already defined
   when: generate_vm_nodes
   block:
-    - name: Generate vm_nodes for "{{num_masters}}" masters
+    - name: Generate vm_nodes for "{{num_nodes}}" nodes
       set_fact:
         vm_nodes: "{{vm_nodes|default([]) + [
-                     {'name': ironic_prefix + 'master_%s'|format(item),
-                      'flavor': 'master',
+                     {'name': ironic_prefix + 'node_%s'|format(item),
+                      'flavor': 'node',
                       'virtualbmc_port': virtualbmc_base_port+item}]}}"
-      loop: "{{ range(0, num_masters|int)|list }}"
-    
-    - name: Generate vm_nodes for "{{num_workers}}" workers
-      set_fact:
-        vm_nodes: "{{vm_nodes|default([]) + [
-                     {'name': ironic_prefix + 'worker_%s'|format(item),
-                      'flavor': 'worker',
-                      'virtualbmc_port': virtualbmc_base_port+num_masters|int+item} ]}}"
-      loop: "{{ range(0, num_workers|int)|list }}"
+      loop: "{{ range(0, num_nodes|int)|list }}"
 
 # Describe our virtual networks.  These networks will be attached to
 # the vm nodes in the order in which they are defined with the following caveats:
@@ -30,19 +22,12 @@
 - name: Define networks when not already defined
   when: generate_networks
   block:
-    - name: Generate dhcp entries on baremetal network for "{{num_masters}}" masters
+    - name: Generate dhcp entries on baremetal network for "{{num_nodes}}" nodes
       set_fact:
         dhcp_hosts: "{{dhcp_hosts|default([]) + [
-                       {'name': 'master-%s'|format(item),
+                       {'name': 'node-%s'|format(item),
                         'ip': baremetal_network_cidr|nthhost(20+item)|string}]}}"
-      loop: "{{ range(0, num_masters|int)|list }}"
-    
-    - name: Generate dhcp entries on baremetal network for "{{num_workers}}" workers
-      set_fact:
-        dhcp_hosts: "{{dhcp_hosts|default([]) + [
-                       {'name': 'worker-%s'|format(item),
-                        'ip': baremetal_network_cidr|nthhost(20+num_masters|int+item)|string} ]}}"
-      loop: "{{ range(0, num_workers|int)|list }}"
+      loop: "{{ range(0, num_nodes|int)|list }}"
     
     - name: Set fact for networks
       set_fact:


### PR DESCRIPTION
This patch changes the naming of the baremetalhosts from master-0 and worker-0 to node-XX. Amount of nodes is parameterized. 