### PR TITLE
Fix Kustomize installation

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -33,7 +33,7 @@ if ! command -v kubectl 2>/dev/null ; then
 fi
 
 if ! command -v kustomize 2>/dev/null ; then
-    curl -Lo kustomize "$(curl --silent -L https://github.com/kubernetes-sigs/kustomize/releases/latest 2>&1 | awk -F'"' '/linux_amd64/ { print "https://github.com"$2; exit }')"
+    curl -Lo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F"${KUSTOMIZE_VERSION}"/kustomize_kustomize."${KUSTOMIZE_VERSION}"_linux_amd64
     chmod +x kustomize
     sudo mv kustomize /usr/local/bin/.
 fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -88,6 +88,9 @@ export IMAGE_CHECKSUM=http://172.22.0.1/images/${IMAGE_NAME}.md5sum
 #Path to CRs
 export V1ALPHA2_CR_PATH=../../crs/v1alpha2/
 
+#Kustomize version
+export KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-"v3.2.3"}
+
 # Test and verification related variables
 SKIP_RETRIES="${SKIP_RETRIES:-false}"
 TEST_TIME_INTERVAL="${TEST_TIME_INTERVAL:-10}"


### PR DESCRIPTION
The latest kustomize installation link doesn't seem to have a binary but an archive and this breaks the installation of kustomize in dev-env. Changing the download link to use Kustomize version 3.2.3 instead for a quick fix