### PR TITLE
Install golang using playbook

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -70,6 +70,9 @@ if [ ! -f "${IMAGE_NAME}" ] ; then
 fi
 popd
 
+# Install requirements
+ansible-galaxy install -r vm-setup/requirements.yml
+
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "working_dir=$WORKING_DIR" \
   -e "virthost=$HOSTNAME" \

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+[[ ":$PATH:" != *":/usr/local/go/bin:"* ]] && PATH="$PATH:/usr/local/go/bin"
+
 eval "$(go env)"
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"

--- a/vm-setup/install-package-playbook.yml
+++ b/vm-setup/install-package-playbook.yml
@@ -6,3 +6,7 @@
   tasks:
     - import_role:
         name: packages_installation
+    - import_role:
+        name: fubarhouse.golang
+      vars:
+        go_version: 1.12

--- a/vm-setup/requirements.yml
+++ b/vm-setup/requirements.yml
@@ -1,0 +1,2 @@
+- src: fubarhouse.golang
+  verison: 2.9.0

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -4,7 +4,6 @@ packages:
      - crudini 
      - curl 
      - dnsmasq 
-     - golang 
      - nmap 
      - patch 
      - psmisc 
@@ -14,7 +13,6 @@ packages:
      - libvirt-dev 
      - jq 
      - nodejs 
-     - golang-go 
      - unzip 
      - yarn 
      - genisoimage 
@@ -44,7 +42,6 @@ packages:
          - crudini 
          - curl 
          - dnsmasq 
-         - golang 
          - NetworkManager 
          - nmap 
          - patch 
@@ -81,7 +78,6 @@ packages:
          - crudini 
          - curl 
          - dnsmasq 
-         - golang 
          - NetworkManager 
          - nmap 
          - patch 


### PR DESCRIPTION
The versions of go available on CentOS and RHEL are limited to 1.11, but
many projects (e.g. openshift/installer) have moved to requiring a
minimum of 1.12.  This uses the ansible-role-golang from fubarhouse to
install golang, instead of relying on OS packages.