### PR TITLE
modify 05_test.sh to use primary interface for ssh

### DIFF
--- a/ip_range_check.py
+++ b/ip_range_check.py
@@ -1,0 +1,9 @@
+#!/usr/bin/python
+
+from ipaddress import IPv4Address
+import sys
+dhcp_range=unicode(sys.argv[2]).split(',')
+if IPv4Address(dhcp_range[0]) <= IPv4Address(unicode(sys.argv[1])) <= IPv4Address(dhcp_range[1]):
+  sys.exit(0)
+else:
+  sys.exit(1)

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -86,7 +86,7 @@ export CLUSTER_NAME=${CLUSTER_NAME:-"test1"}
 export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.16.0"}
 
 # Image url and checksum
-IMAGE_OS=${IMAGE_OS:-Cirros}
+IMAGE_OS=${IMAGE_OS:-Centos}
 if [[ "${IMAGE_OS}" == "Ubuntu" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-bionic-server-cloudimg-amd64.img}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://cloud-images.ubuntu.com/bionic/current}


### PR DESCRIPTION
This does not require networking setup on the vm. Fixes broken tests with cirros.
The default image is set back to centos as the userdata.sh generates user data for centos.