### PR TITLE
WIP: Size down the node vms

### DIFF
--- a/vm-setup/roles/common/defaults/main.yml
+++ b/vm-setup/roles/common/defaults/main.yml
@@ -9,8 +9,8 @@ libvirt_nic_model: virtio
 # These defaults are used if there are no flavor-specific
 # overrides configured.
 default_disk: 50
-default_memory: 8192
-default_vcpu: 4
+default_memory: 4096
+default_vcpu: 2
 num_masters: 1
 num_workers: 1
 extradisks: false


### PR DESCRIPTION
The second node cannot start deploying if the first node is
deployed with 8GB of ram