### PR TITLE
Install go 1.12.12 instead of 1.12.0

### DIFF
--- a/vm-setup/install-package-playbook.yml
+++ b/vm-setup/install-package-playbook.yml
@@ -9,4 +9,5 @@
     - import_role:
         name: fubarhouse.golang
       vars:
-        go_version: 1.12
+        go_version: 1.12.12
+        go_install_clean: true

--- a/vm-setup/requirements.yml
+++ b/vm-setup/requirements.yml
@@ -1,2 +1,2 @@
-- src: fubarhouse.golang
-  verison: 2.9.0
+- src: https://github.com/metal3-io/ansible-role-golang.git
+  verison: master


### PR DESCRIPTION
The playbook doesn't pick the latest 1.12, and there's some bug in 1.12
that's breaking terraform when building go installer from source.