### PR TITLE
Correctly use fork of fubarhouse.golang

### DIFF
--- a/vm-setup/requirements.yml
+++ b/vm-setup/requirements.yml
@@ -1,2 +1,3 @@
 - src: https://github.com/metal3-io/ansible-role-golang.git
   verison: master
+  name: fubarhouse.golang


### PR DESCRIPTION
I thought ansible would've been smart enough to know the name of the
fork's role but I guess not.  This explicitly overrides it so it
gets checked out in the right place. Otherwise you get an error like
this:

```
The error appears to be in
'/opt/dev-scripts/metal3-dev-env/vm-setup/install-package-playbook.yml':
line 10, column 15, but may
be elsewhere in the file depending on the exact syntax problem.
The offending line appears to be:
    - import_role:
            name: fubarhouse.golang
                          ^ here

```