### PR TITLE
Generate node data based on flavors map

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -20,8 +20,7 @@ fi
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "working_dir=$WORKING_DIR" \
-    -e "num_masters=$NUM_MASTERS" \
-    -e "num_workers=$NUM_WORKERS" \
+    -e "num_nodes=$NUM_NODES" \
     -e "extradisks=$VM_EXTRADISKS" \
     -e "virthost=$HOSTNAME" \
     -e "platform=$NODES_PLATFORM" \

--- a/05_test.sh
+++ b/05_test.sh
@@ -74,7 +74,7 @@ check_bmh_association(){
     jq -r '.metadata.annotations["metal3.io/BareMetalHost"]' | \
     tr '/' ' ' | awk '{print $2}')"
   RESULT_STR="${MACHINE_NAME} Baremetalhost associated"
-  is_in "${BMH_NAME}" "master-0 worker-0"
+  is_in "${BMH_NAME}" "node-0 node-1"
 
   # Fail fast if they are not associated as we cannot get the BMH name
   if [[ "${FAILS_CHECK}" != "${FAILS}" ]]; then

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -54,8 +54,7 @@ WORKING_DIR=${WORKING_DIR:-"/opt/metal3-dev-env"}
 NODES_FILE=${NODES_FILE:-"${WORKING_DIR}/ironic_nodes.json"}
 NODES_PLATFORM=${NODES_PLATFORM:-"libvirt"}
 
-export NUM_MASTERS=${NUM_MASTERS:-"1"}
-export NUM_WORKERS=${NUM_WORKERS:-"1"}
+export NUM_NODES=${NUM_NODES:-"2"}
 export VM_EXTRADISKS=${VM_EXTRADISKS:-"false"}
 
 # Docker registry for local images

--- a/vm-setup/roles/common/defaults/main.yml
+++ b/vm-setup/roles/common/defaults/main.yml
@@ -11,21 +11,14 @@ libvirt_nic_model: virtio
 default_disk: 50
 default_memory: 8192
 default_vcpu: 4
-num_masters: 1
-num_workers: 1
+num_nodes: 2
 extradisks: false
 virtualbmc_base_port: 6230
 flavors:
-  master:
-    memory: '{{master_memory|default(default_memory)}}'
-    disk: '{{master_disk|default(default_disk)}}'
-    vcpu: '{{master_vcpu|default(default_vcpu)}}'
-    extradisks: '{{extradisks|bool}}'
-
-  worker:
-    memory: '{{worker_memory|default(default_memory)}}'
-    disk: '{{worker_disk|default(default_disk)}}'
-    vcpu: '{{worker_vcpu|default(default_vcpu)}}'
+  node:
+    memory: '{{node_memory|default(default_memory)}}'
+    disk: '{{node_disk|default(default_disk)}}'
+    vcpu: '{{node_vcpu|default(default_vcpu)}}'
     extradisks: '{{extradisks|bool}}'
 
 # An optional prefix for node names

--- a/vm-setup/roles/common/tasks/main.yml
+++ b/vm-setup/roles/common/tasks/main.yml
@@ -5,14 +5,14 @@
 
 - name: Define vm_nodes if not already defined
   when: generate_vm_nodes
-  block:
-    - name: Generate vm_nodes for "{{num_nodes}}" nodes
-      set_fact:
-        vm_nodes: "{{vm_nodes|default([]) + [
-                     {'name': ironic_prefix + 'node_%s'|format(item),
-                      'flavor': 'node',
-                      'virtualbmc_port': virtualbmc_base_port+item}]}}"
-      loop: "{{ range(0, num_nodes|int)|list }}"
+  include_tasks: vm_nodes_tasks.yml
+  loop: "{{flavors|dict2items}}"
+  loop_control: 
+    loop_var: flavor
+
+- debug:
+    var: vm_nodes
+  when: generate_vm_nodes
 
 # Describe our virtual networks.  These networks will be attached to
 # the vm nodes in the order in which they are defined with the following caveats:
@@ -22,13 +22,6 @@
 - name: Define networks when not already defined
   when: generate_networks
   block:
-    - name: Generate dhcp entries on baremetal network for "{{num_nodes}}" nodes
-      set_fact:
-        dhcp_hosts: "{{dhcp_hosts|default([]) + [
-                       {'name': 'node-%s'|format(item),
-                        'ip': baremetal_network_cidr|nthhost(20+item)|string}]}}"
-      loop: "{{ range(0, num_nodes|int)|list }}"
-    
     - name: Set fact for networks
       set_fact:
         networks:
@@ -43,7 +36,6 @@
             dhcp_range:
               - "{{ baremetal_network_cidr|nthhost(20) }}"
               - "{{ baremetal_network_cidr|nthhost(60) }}"
-            dhcp_hosts: "{{dhcp_hosts}}"
             nat_port_range:
               - 1024
               - 65535

--- a/vm-setup/roles/common/tasks/main.yml
+++ b/vm-setup/roles/common/tasks/main.yml
@@ -6,21 +6,13 @@
 - name: Define vm_nodes if not already defined
   when: generate_vm_nodes
   block:
-    - name: Generate vm_nodes for "{{num_masters}}" masters
+    - name: Generate vm_nodes for "{{num_nodes}}" nodes
       set_fact:
         vm_nodes: "{{vm_nodes|default([]) + [
-                     {'name': ironic_prefix + 'master_%s'|format(item),
-                      'flavor': 'master',
+                     {'name': ironic_prefix + 'node_%s'|format(item),
+                      'flavor': 'node',
                       'virtualbmc_port': virtualbmc_base_port+item}]}}"
-      loop: "{{ range(0, num_masters|int)|list }}"
-    
-    - name: Generate vm_nodes for "{{num_workers}}" workers
-      set_fact:
-        vm_nodes: "{{vm_nodes|default([]) + [
-                     {'name': ironic_prefix + 'worker_%s'|format(item),
-                      'flavor': 'worker',
-                      'virtualbmc_port': virtualbmc_base_port+num_masters|int+item} ]}}"
-      loop: "{{ range(0, num_workers|int)|list }}"
+      loop: "{{ range(0, num_nodes|int)|list }}"
 
 # Describe our virtual networks.  These networks will be attached to
 # the vm nodes in the order in which they are defined with the following caveats:
@@ -30,19 +22,12 @@
 - name: Define networks when not already defined
   when: generate_networks
   block:
-    - name: Generate dhcp entries on baremetal network for "{{num_masters}}" masters
+    - name: Generate dhcp entries on baremetal network for "{{num_nodes}}" nodes
       set_fact:
         dhcp_hosts: "{{dhcp_hosts|default([]) + [
-                       {'name': 'master-%s'|format(item),
+                       {'name': 'node-%s'|format(item),
                         'ip': baremetal_network_cidr|nthhost(20+item)|string}]}}"
-      loop: "{{ range(0, num_masters|int)|list }}"
-    
-    - name: Generate dhcp entries on baremetal network for "{{num_workers}}" workers
-      set_fact:
-        dhcp_hosts: "{{dhcp_hosts|default([]) + [
-                       {'name': 'worker-%s'|format(item),
-                        'ip': baremetal_network_cidr|nthhost(20+num_masters|int+item)|string} ]}}"
-      loop: "{{ range(0, num_workers|int)|list }}"
+      loop: "{{ range(0, num_nodes|int)|list }}"
     
     - name: Set fact for networks
       set_fact:

--- a/vm-setup/roles/common/tasks/vm_nodes_tasks.yml
+++ b/vm-setup/roles/common/tasks/vm_nodes_tasks.yml
@@ -1,0 +1,14 @@
+---
+# We maintain a persistent index over the nested loop iterations
+# of the tasks via set_fact, ansible doesn't appear to provide
+# a facility like j2 namespaces to enable this.
+- set_fact:
+    vm_nodes_index: "{{vm_nodes_index|default(0)|int}}"
+- set_fact:
+    vm_nodes: "{{vm_nodes|default([]) + [
+                 {'name': ironic_prefix + '%s_%s'|format(flavor.key, item),
+                  'flavor': flavor.key,
+                  'virtualbmc_port': virtualbmc_base_port+vm_nodes_index|int+item} ]}}"
+  loop: "{{ range(0, lookup('vars', 'num_' + flavor.key + 's')|int)|list }}"
+- set_fact:
+    vm_nodes_index: "{{vm_nodes_index|int + lookup('vars', 'num_' + flavor.key + 's')|int }}"

--- a/vm-setup/roles/libvirt/tasks/network_setup_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/network_setup_tasks.yml
@@ -24,7 +24,6 @@
   register: node_mac_map
   when: vm_nodes
 
-
 # Create the global, root-managed libvirt networks to which we will
 # attach the undercoud and vm virtual machines.
 - name: Create libvirt networks

--- a/vm-setup/roles/libvirt/templates/network.xml.j2
+++ b/vm-setup/roles/libvirt/templates/network.xml.j2
@@ -1,8 +1,5 @@
 {% set nat_port_range = item.nat_port_range|default([1024, 65535]) %}
 {% set netmask = item.netmask|default('255.255.255.0') %}
-{% if item.dhcp_hosts is defined %}
-{% set dhcp_hosts_names = item.dhcp_hosts | map(attribute='name') | map('replace', '-', '_') | list %}
-{% endif %}
 <network>
   <name>{{ item.name }}</name>
   <bridge name='{{ item.bridge }}'/>
@@ -23,11 +20,15 @@
 {% if item.dhcp_range is defined %}
     <dhcp>
       <range start='{{ item.dhcp_range[0] }}' end='{{ item.dhcp_range[1] }}'/>
-  {% if item.dhcp_hosts is defined %}
-    {% for host in item.dhcp_hosts %}
-      <host mac='{{ node_mac_map.get(ironic_prefix + dhcp_hosts_names[loop.index0]).get(item.name) }}' name='{{ host.name }}' ip='{{ host.ip }}'/>
-    {% endfor %}
-  {% endif %}
+{% set ns = namespace(index=0) %}
+{% for flavor in flavors %}
+{% set numflavor = lookup('vars', 'num_' + flavor + 's')|default(0)|int %}
+{% for num in range(0, numflavor) %}
+{% set ironic_name = ironic_prefix + flavor + "_" + num|string %}
+      <host mac='{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{flavor}}-{{num}}' ip='{{item.dhcp_range[0]|ipmath(ns.index|int)}}'/>
+{% set ns.index = ns.index + 1 %}
+{% endfor %}
+{% endfor %}
     </dhcp>
 {% endif %}
   </ip>


### PR DESCRIPTION
Proposed follow-up to https://github.com/metal3-io/metal3-dev-env/pull/102

Instead of a hard-coded reference to the default flavor, we can iterate over the flavor and the number of nodes by looking at the dynamic variable num_nodes where "node" is the default flavor, but can also be any other name, or multiple flavors e.g master/worker where num_masters and num_workers can be used as before to control the host count for those flavors.

This means that e.g https://github.com/openshift-metal3/dev-scripts can continue to use master/worker flavors as before, by overriding the flavor vars like:

```
num_masters: 3
num_workers: 1
flavors:
  master:
    memory: 16384
    disk: 20
    vcpu: 4
    extradisks: false

  worker:
    memory: 8192
    disk: 20
    vcpu: 4
    extradisks: false
```

