### PR TITLE
Fix issue with labels in cloud-init

### DIFF
--- a/crs/v1alpha2/controlplane_centos.yaml
+++ b/crs/v1alpha2/controlplane_centos.yaml
@@ -35,7 +35,7 @@ spec:
     nodeRegistration:
       name: '{{ ds.meta_data.name }}'
       kubeletExtraArgs:
-        node-labels: 'metal3.io/uuid={{ ds.meta_data.uuid }},metal3.io/namespace={{ ds.meta_data.metal3-namespace }},metal3.io/name={{ ds.meta_data.metal3-name }}'
+        node-labels: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
   preKubeadmCommands:
     - ifup eth1
     - yum check-update

--- a/crs/v1alpha2/controlplane_ubuntu.yaml
+++ b/crs/v1alpha2/controlplane_ubuntu.yaml
@@ -35,7 +35,7 @@ spec:
     nodeRegistration:
       name: '{{ ds.meta_data.name }}'
       kubeletExtraArgs:
-        node-labels: 'metal3.io/uuid={{ ds.meta_data.uuid }},metal3.io/namespace={{ ds.meta_data.metal3-namespace }},metal3.io/name={{ ds.meta_data.metal3-name }}'
+        node-labels: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
   preKubeadmCommands:
     - ip link set dev enp2s0 up
     - dhclient enp2s0

--- a/crs/v1alpha2/workers_centos.yaml
+++ b/crs/v1alpha2/workers_centos.yaml
@@ -50,7 +50,7 @@ spec:
         nodeRegistration:
           name: '{{ ds.meta_data.name }}'
           kubeletExtraArgs:
-            node-labels: 'metal3.io/uuid={{ ds.meta_data.uuid }},metal3.io/namespace={{ ds.meta_data.metal3-namespace }},metal3.io/name={{ ds.meta_data.metal3-name }}'
+            node-labels: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
       preKubeadmCommands:
         - ifup eth1
         - yum check-update

--- a/crs/v1alpha2/workers_ubuntu.yaml
+++ b/crs/v1alpha2/workers_ubuntu.yaml
@@ -50,7 +50,7 @@ spec:
         nodeRegistration:
           name: '{{ ds.meta_data.name }}'
           kubeletExtraArgs:
-            node-labels: 'metal3.io/uuid={{ ds.meta_data.uuid }},metal3.io/namespace={{ ds.meta_data.metal3-namespace }},metal3.io/name={{ ds.meta_data.metal3-name }}'
+            node-labels: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
       preKubeadmCommands:
         - ip link set dev enp2s0 up
         - dhclient enp2s0


### PR DESCRIPTION
The current string breaks due to spaces being misinterpreted. This is a quick fix as the other labels are not in use.