### PR TITLE
Verify introspection by checking ready or available status

### DIFF
--- a/04_verify.sh
+++ b/04_verify.sh
@@ -73,8 +73,8 @@ check_bm_hosts() {
 
     #Verify the instrospection completed successfully
     RESULT_STR="${NAME} Baremetalhost introspecting completed"
-    equals "$(echo "${BM_HOST}" | jq -r '.status.provisioning.state')" \
-      "ready"
+    is_in "$(echo "${BM_HOST}" | jq -r '.status.provisioning.state')" \
+      "ready available"
 
     echo ""
 


### PR DESCRIPTION
Bare Metal Host 'Ready' provisioning status is changed to 'Available'

Required by https://github.com/metal3-io/baremetal-operator/pull/340