### PR TITLE
DNM test latest ironic image

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -54,6 +54,8 @@ podman)
   ;;
 esac
 
+echo "TEST DNM test with new https://quay.io/repository/metal3-io/ironic"
+
 # Pull images we'll need
 for IMAGE_VAR in IRONIC_IMAGE IPA_DOWNLOADER_IMAGE VBMC_IMAGE SUSHY_TOOLS_IMAGE DOCKER_REGISTRY_IMAGE; do
     IMAGE=${!IMAGE_VAR}


### PR DESCRIPTION
A new version was pushed to https://quay.io/repository/metal3-io/ironic
since ipv6 support was added in https://github.com/metal3-io/ironic-image/pull/107

This PR can be used to verify the integration tests are still working OK