### PR TITLE
Add Ansible role for v1alpha2 integration test.

### DIFF
--- a/04_verify.sh
+++ b/04_verify.sh
@@ -191,10 +191,6 @@ EXPTD_V1ALPHA2_RS="control-plane:cabpk-controller-manager \
   control-plane:capbm-controller-manager \
   control-plane:cluster-api-controller-manager \
   name:metal3-baremetal-operator"
-EXPTD_V1ALPHA2_PODS="control-plane:cabpk-controller-manager \
-  control-plane:capbm-controller-manager \
-  control-plane:cluster-api-controller-manager \
-  name:metal3-baremetal-operator"
 BRIDGES="provisioning baremetal"
 EXPTD_CONTAINERS="httpd-infra registry vbmc sushy-tools"
 
@@ -240,12 +236,11 @@ fi
 
 
 if [ "${CAPI_VERSION}" == "v1alpha2" ]; then
-  # Verify the v1alph2 Pods, Operators, Deployments, Replicasets
-  iterate check_k8s_pods "${EXPTD_V1ALPHA2_PODS}"
+  # Verify v1alpha2 Operators, Deployments, Replicasets
   iterate check_k8s_entity deployments "${EXPTD_V1ALPHA2_DEPLOYMENTS}"
   iterate check_k8s_rs "${EXPTD_V1ALPHA2_RS}"
 elif [ "${CAPI_VERSION}" == "v1alpha1" ]; then
-  # Verify the v1alph1 Operators, Statefulsets, Deployments, Replicasets
+  # Verify v1alpha1 Operators, Statefulsets, Deployments, Replicasets
   iterate check_k8s_entity statefulsets "${EXPTD_STATEFULSETS}"
   iterate check_k8s_entity deployments "${EXPTD_DEPLOYMENTS}"
   iterate check_k8s_rs "${EXPTD_RS}"
@@ -279,8 +274,13 @@ fi
 if [[ "${CAPBM_RUN_LOCAL}" == true ]]; then
   # shellcheck disable=SC2034
   RESULT_STR="CAPI operator locally running"
-  pgrep -f "go run ./cmd/manager/main.go" > /dev/null 2> /dev/null
-  process_status $?
+  if [ "${CAPI_VERSION}" == "v1alpha2" ]; then
+    pgrep -f "go run ./main.go" > /dev/null 2> /dev/null
+    process_status $?
+  elif [ "${CAPI_VERSION}" == "v1alpha1" ]; then
+    pgrep -f "go run ./cmd/manager/main.go" > /dev/null 2> /dev/null
+    process_status $?
+  fi
 fi
 if [[ "${BMO_RUN_LOCAL}" == true ]] || [[ "${CAPBM_RUN_LOCAL}" == true ]]; then
   echo ""

--- a/05_test_v1a2.sh
+++ b/05_test_v1a2.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -xe
+
+# shellcheck disable=SC1091
+source lib/logging.sh
+# shellcheck disable=SC1091
+source lib/common.sh
+
+# Disable SSH trong authentication
+export ANSIBLE_HOST_KEY_CHECKING=False
+
+ANSIBLE_FORCE_COLOR=true ansible-playbook \
+    -e "metal3_dir=$SCRIPTDIR" \
+    -e "IMAGE_OS=$IMAGE_OS" \
+    -e "DEFAULT_HOSTS_MEMORY=$DEFAULT_HOSTS_MEMORY" \
+    -e "CAPI_VERSION=$CAPI_VERSION" \
+    -i vm-setup/inventory.ini \
+    -b -vvv vm-setup/v1a2_integration_test.yml

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ host_cleanup:
 test:
 	./05_test.sh
 
+test_v1a2:
+	./05_test_v1a2.sh
+
 lint:
 	./hack/shellcheck.sh
 

--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -43,6 +43,7 @@ fi
 sudo yum -y install \
   ansible \
   redhat-lsb-core \
+  python3-pip \
   wget
 
 # Install tripleo-repos, used to get a recent version of python-virtualbmc

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -6,6 +6,7 @@ eval "$(go env)"
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 USER="$(whoami)"
+export USER=${USER}
 
 # Get variables from the config file
 if [ -z "${CONFIG:-}" ]; then
@@ -148,6 +149,8 @@ export IMAGE_CHECKSUM=http://$PROVISIONING_URL_HOST/images/${IMAGE_NAME}.md5sum
 #Path to CRs
 export V1ALPHA2_CR_PATH=${SCRIPTDIR}/crs/v1alpha2/
 
+# Target node username
+export NODE_USERNAME=${IMAGE_USERNAME}
 
 #Kustomize version
 export KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-"v3.2.3"}

--- a/ubuntu_install_requirements.sh
+++ b/ubuntu_install_requirements.sh
@@ -74,5 +74,7 @@ fi
 
 # Install python packages not included as rpms
 sudo pip3 install \
-  ansible==2.8.2 \
-  python-apt
+  ansible==2.9.1 \
+  python-apt \
+  openshift \
+  pyYAML

--- a/vm-setup/roles/common/tasks/main.yml
+++ b/vm-setup/roles/common/tasks/main.yml
@@ -7,7 +7,7 @@
   when: generate_vm_nodes
   include_tasks: vm_nodes_tasks.yml
   loop: "{{flavors|dict2items}}"
-  loop_control: 
+  loop_control:
     loop_var: flavor
 
 - debug:

--- a/vm-setup/roles/libvirt/tasks/network_setup_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/network_setup_tasks.yml
@@ -104,17 +104,17 @@
     dest: '/etc/qemu-kvm/bridge.conf' # Needs to be /etc/qemu/bridge.conf if supporting Fedora
     line: "allow {{ item.bridge }}"
   with_items: "{{ networks }}"
-  when: 
+  when:
     - ansible_os_family == "RedHat"
   become: true
 
 - name: Whitelist bridges for unprivileged access on Ubuntu or Fedora
   lineinfile:
-    dest: '/etc/qemu/bridge.conf' 
+    dest: '/etc/qemu/bridge.conf'
     line: "allow {{ item.bridge }}"
     create: yes
   with_items: "{{ networks }}"
-  when: 
+  when:
     - ansible_facts['distribution'] == "Ubuntu"
   become: true
 

--- a/vm-setup/roles/libvirt/templates/ironic_nodes.json.j2
+++ b/vm-setup/roles/libvirt/templates/ironic_nodes.json.j2
@@ -12,7 +12,7 @@
   {% for node in vm_nodes %}
     {
       "name": "{{ node.name|replace('_', '-') }}",
-      "driver": "{{ vm_driver }}", 
+      "driver": "{{ vm_driver }}",
       "resource_class": "baremetal",
       "driver_info": {
         "username": "admin",

--- a/vm-setup/roles/v1a2_integration_test/tasks/deprovision.yml
+++ b/vm-setup/roles/v1a2_integration_test/tasks/deprovision.yml
@@ -1,0 +1,74 @@
+---
+  - name: Deprovision cluster
+    k8s:
+      state: absent
+      src: "/tmp/cluster.yaml"
+      namespace: "{{ NAMESPACE }}"
+    register: deprovision_cluster
+
+  - name: Deprovisioning
+    block:
+      - name: Deprovision Ubuntu machines
+        k8s:
+          state: absent
+          src: "/tmp/{{ item }}_ubuntu.yaml"
+          namespace: "{{ NAMESPACE }}"
+        loop:
+           - controlplane
+           - workers
+        register: deprovision_ubuntu_machines
+
+      - name: Remove Ubuntu node crs
+        file:
+          path: "/tmp/{{ item }}.yaml"
+          state: absent
+        with_items:
+          - controlplane_ubuntu
+          - workers_ubuntu
+    when: IMAGE_OS == "Ubuntu"
+
+  - name: Deprovisioning
+    block:
+      - name: Deprovision CentOS machines
+        k8s:
+          state: absent
+          src: "/tmp/{{ item }}_centos.yaml"
+          namespace: "{{ NAMESPACE }}"
+        loop:
+           - controlplane
+           - workers
+        when: (IMAGE_OS == "Centos") or
+              (IMAGE_OS == "")
+        register: deprovision_centos_machines
+
+      - name: Remove CentOS node crs
+        file:
+          path: "/tmp/{{ item }}.yaml"
+          state: absent
+        with_items:
+          - controlplane_centos
+          - workers_centos
+    when: IMAGE_OS == "Centos"
+
+  - name: Remove cluster crs
+    file:
+      path: "/tmp/cluster.yaml"
+      state: absent
+
+  - name: Check if cluster deprovisioning started.
+    shell: "kubectl get cluster -n {{ NAMESPACE }} -o json | jq -r '.items[] | .status.phase'"
+    register: deprovision_cluster
+    retries: 2
+    delay: 20
+    until: (deprovision_cluster.stdout == "deleting") or
+           (deprovision_cluster.stdout == "")
+
+  - name: Wait until both bmh becomes ready again.
+    shell: |
+        kubectl get bmh -n {{ NAMESPACE }} -o json | jq -r '.items[] |
+        select (.status.provisioning.state == "ready") |
+        .metadata.name'
+    register: deprovisioned_nodes
+    retries: 150
+    delay: 3
+    until: deprovisioned_nodes.stdout_lines ==  ["node-0", "node-1"]

--- a/vm-setup/roles/v1a2_integration_test/tasks/main.yml
+++ b/vm-setup/roles/v1a2_integration_test/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: v1alpha2 deployment
+  include: "{{ item }}.yml"
+  with_items:
+    - provision
+    - verify
+    - deprovision

--- a/vm-setup/roles/v1a2_integration_test/tasks/provision.yml
+++ b/vm-setup/roles/v1a2_integration_test/tasks/provision.yml
@@ -1,0 +1,85 @@
+---
+# Populate crs with environment variables
+  - name: Template cluster.yaml
+    template:
+      src: "{{ CRS_PATH }}/cluster.yaml"
+      dest: "/tmp/cluster.yaml"
+
+  - name: Template Ubuntu machine crs
+    block:
+      - name: Template controlplane_ubuntu.yaml
+        template:
+          src: "{{ CRS_PATH }}/controlplane_ubuntu.yaml"
+          dest: "/tmp/controlplane_ubuntu.yaml"
+
+      - name: Template workers_ubuntu.yaml
+        template:
+          src: "{{ CRS_PATH }}/workers_ubuntu.yaml"
+          dest: "/tmp/workers_ubuntu.yaml"
+    when: IMAGE_OS == "Ubuntu"
+
+  - name: Template CentOS machine crs
+    block:
+      - name: Template controlplane_centos.yaml
+        template:
+          src: "{{ CRS_PATH }}/controlplane_centos.yaml"
+          dest: "/tmp/controlplane_centos.yaml"
+        vars:
+          IMAGE_NAME: '{{ IMAGE_NAME_CENTOS }}'
+          IMAGE_LOCATION: '{{ IMAGE_LOCATION_CENTOS }}'
+          IMAGE_USERNAME: '{{ IMAGE_USERNAME_CENTOS }}'
+
+      - name: Template workers_centos.yaml
+        template:
+          src: "{{ CRS_PATH }}/workers_centos.yaml"
+          dest: "/tmp/workers_centos.yaml"
+        vars:
+          IMAGE_NAME: '{{ IMAGE_NAME_CENTOS }}'
+          IMAGE_LOCATION: '{{ IMAGE_LOCATION_CENTOS }}'
+          IMAGE_USERNAME: '{{ IMAGE_USERNAME_CENTOS }}'
+    when: (IMAGE_OS == "Centos") or
+          (IMAGE_OS == "")
+
+  - name: Install openshift client
+    pip:
+      executable: "pip3"
+      name: openshift
+      state: present
+    become: true
+    become_user: root
+    when: ansible_facts['distribution'] == "CentOS"
+
+  - name: Switch Ansible's Python interpreter to Python 3
+    set_fact:
+      ansible_python_interpreter: /usr/bin/python3
+
+# Provision cluster & machines
+  - name: Provision cluster
+    k8s:
+      state: present
+      src: "/tmp/cluster.yaml"
+      namespace: "{{ NAMESPACE }}"
+    register: provision_cluster
+
+  - name: Create Ubuntu machines
+    k8s:
+      state: present
+      src: "/tmp/{{ item }}_ubuntu.yaml"
+      namespace: "{{ NAMESPACE }}"
+    loop:
+      - controlplane
+      - workers
+    register: ubuntu_machines
+    when: IMAGE_OS == "Ubuntu"
+
+  - name: Create CentOS machines
+    k8s:
+      state: present
+      src: "/tmp/{{ item }}_centos.yaml"
+      namespace: "{{ NAMESPACE }}"
+    loop:
+      - controlplane
+      - workers
+    register: centos_machines
+    when: (IMAGE_OS == "Centos") or
+          (IMAGE_OS == "")

--- a/vm-setup/roles/v1a2_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1a2_integration_test/tasks/verify.yml
@@ -1,0 +1,133 @@
+---
+  - name: Wait until cluster becomes provisioned.
+    shell: "kubectl get cluster -n metal3 -o json | jq -r '.items[] | .status.phase'"
+    register: provisioned_cluster
+    retries: 100
+    delay: 20
+    until: provisioned_cluster.stdout == "provisioned"
+
+  - name: Wait until both bmhs become provisioned.
+    shell: |
+        kubectl get bmh -n metal3 -o json | jq -r '.items[]
+        | select (.status.provisioning.state == "provisioned")
+        | .metadata.name'
+    register: provisioned_bmh
+    retries: 100
+    delay: 20
+    until: provisioned_bmh.stdout_lines ==  ["node-0", "node-1"]
+
+  - name: Get the IP of controlplane node
+    shell: |
+        kubectl get bmh -n "{{ NAMESPACE }}" -o json | jq -r '.items[]
+        | select (.spec.consumerRef.name == "{{ CLUSTER_NAME }}-controlplane-0")
+        | .status.hardware.nics[] | select (.name == "eth1") | .ip'
+    register: controlplane_ip
+
+  - name: Define variable for controlplane_node IP
+    set_fact:
+      bmh_ip: "{{ controlplane_ip.stdout }}"
+
+  - name: Define username variable for Ubuntu node
+    set_fact:
+      username: ubuntu
+    when: IMAGE_OS == "Ubuntu"
+
+  - name: Define username variable for target CentOS node
+    set_fact:
+      username: centos
+    when: (IMAGE_OS == "Centos") or
+          (IMAGE_OS == "")
+
+  - name: Verification test
+    delegate_to: "{{ bmh_ip }}"
+    vars:
+      ansible_user: "{{ username }}"
+      ansible_ssh_private_key_file: "{{ SSH_PRIVATE_KEY }}"
+      ansible_python_interpreter: /usr/bin/python3
+    become: yes
+    become_user: "{{ username }}"
+    block:
+      - name: Install python-pip3
+        package:
+          name: python3-pip
+          state: present
+          update_cache: yes
+        become: yes
+        become_user: root
+
+      - name: Install packages using pip3
+        pip:
+          executable: "pip3"
+          name: openshift
+          state: present
+        become: true
+        become_user: root
+
+      - name: Install jq
+        apt:
+          name: jq
+          state: present
+        become: yes
+        become_user: root
+        when:
+          ansible_distribution == "Ubuntu"
+
+      - name: Install jq
+        yum:
+          name: jq
+          state: present
+        become: yes
+        become_user: root
+        when:
+          ansible_distribution == "CentOS"
+
+      # Install Calico
+      - name: Download Calico manifest
+        get_url:
+          url: https://docs.projectcalico.org/v3.9/manifests/calico.yaml
+          dest: /tmp/
+          mode: '664'
+        register: calico_manifest
+
+      - name: Replace the POD_CIDR in calico config
+        replace:
+          path: /tmp/calico.yaml
+          regexp: "192.168.0.0/16"
+          replace: '{{ pod_cidr }}'
+        register: updated_manifest
+
+      - name: Apply Calico manifest
+        k8s:
+          state: present
+          src: "/tmp/calico.yaml"
+          namespace: "{{ NAMESPACE }}"
+        environment:
+          ansible_python_interpreter: /usr/bin/python3
+        register: install_cni
+
+      # Check for pods & nodes on the target cluster
+      - name: Check if pods in running state
+        shell: "kubectl get pods -A -o json | jq -r '.items[].status.phase' | grep -v Running"
+        environment:
+          KUBECONFIG: "{{ KUBECONFIG_PATH }}"
+        retries: 150
+        delay: 3
+        register: running_pods
+        failed_when: >
+          (running_pods.stderr != "") or
+          (running_pods.rc > 1) or
+          (running_pods.stdout != "")
+        until: running_pods.stdout == ""
+
+      - name: Check if nodes in ready state
+        shell: kubectl get nodes | grep -w Ready | wc -l
+        environment:
+          KUBECONFIG: "{{ KUBECONFIG_PATH }}"
+        retries: 150
+        delay: 3
+        register: ready_nodes
+        failed_when: >
+          (ready_nodes.stderr != "") or
+          (ready_nodes.rc != 0) or
+          (ready_nodes.stdout != "2")
+        until: ready_nodes.stdout == "2"

--- a/vm-setup/roles/v1a2_integration_test/templates/cluster.yaml
+++ b/vm-setup/roles/v1a2_integration_test/templates/cluster.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: cluster.x-k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  name: {{ CLUSTER_NAME }}
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: ["10.96.0.0/12"]
+    pods:
+      cidrBlocks: ["192.168.0.0/18"]
+    serviceDomain: "cluster.local"
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: BareMetalCluster
+    name: {{ CLUSTER_NAME }}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: BareMetalCluster
+metadata:
+  name: {{ CLUSTER_NAME }}
+spec:
+ apiEndpoint: http://192.168.111.249:6443
+ noCloudProvider: true

--- a/vm-setup/roles/v1a2_integration_test/templates/controlplane_centos.yaml
+++ b/vm-setup/roles/v1a2_integration_test/templates/controlplane_centos.yaml
@@ -1,0 +1,103 @@
+apiVersion: cluster.x-k8s.io/v1alpha2
+kind: Machine
+metadata:
+  name: {{ CLUSTER_NAME }}-controlplane-0
+  labels:
+    cluster.x-k8s.io/control-plane: "true"
+    cluster.x-k8s.io/cluster-name: "{{ CLUSTER_NAME }}"
+spec:
+  version: {{ KUBERNETES_VERSION }}
+  bootstrap:
+    configRef:
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      kind: KubeadmConfig
+      name: {{ CLUSTER_NAME }}-controlplane-0
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: BareMetalMachine
+    name: {{ CLUSTER_NAME }}-controlplane-0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: BareMetalMachine
+metadata:
+  name: {{ CLUSTER_NAME }}-controlplane-0
+spec:
+  image:
+    url: {{ IMAGE_URL }}
+    checksum: {{ IMAGE_CHECKSUM }}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: KubeadmConfig
+metadata:
+  name: {{ CLUSTER_NAME }}-controlplane-0
+spec:
+  initConfiguration:
+    nodeRegistration:
+      name: {{ " '{{ ds.meta_data.name }}' " }}
+      kubeletExtraArgs:
+        node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+  preKubeadmCommands:
+    - ifup eth1
+    - yum update -y
+    - yum install yum-utils -y
+    - yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    - setenforce 0
+    - sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
+    - >-
+      yum install gcc kernel-headers kernel-devel keepalived
+      device-mapper-persistent-data lvm2
+      docker-ce-18.09.9 docker-ce-cli-18.09.9 containerd.io
+      kubelet kubeadm kubectl --disableexcludes=kubernetes -y
+    - usermod -aG docker centos
+    - systemctl enable --now docker keepalived kubelet
+  postKubeadmCommands:
+    - mkdir -p /home/centos/.kube
+    - cp /etc/kubernetes/admin.conf /home/centos/.kube/config
+    - chown centos:centos /home/centos/.kube/config
+  files:
+    - path: /etc/keepalived/keepalived.conf
+      content: |
+        ! Configuration File for keepalived
+        global_defs {
+            notification_email {
+            sysadmin@example.com
+            support@example.com
+            }
+            notification_email_from lb@example.com
+            smtp_server localhost
+            smtp_connect_timeout 30
+        }
+        vrrp_instance VI_1 {
+            state MASTER
+            interface eth1
+            virtual_router_id 1
+            priority 101
+            advert_int 1
+            virtual_ipaddress {
+                192.168.111.249
+            }
+        }
+    - path: /etc/sysconfig/network-scripts/ifcfg-eth1
+      owner: root:root
+      permissions: '0644'
+      content: |
+        BOOTPROTO=dhcp
+        DEVICE=eth1
+        ONBOOT=yes
+        TYPE=Ethernet
+        USERCTL=no
+    - path: /etc/yum.repos.d/kubernetes.repo
+      owner: root:root
+      permissions: '0644'
+      content: |
+        [kubernetes]
+        name=Kubernetes
+        baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+        enabled=1
+        gpgcheck=1
+        repo_gpgcheck=0
+        gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+    - path: /home/centos/.ssh/authorized_keys
+      owner: centos:centos
+      permissions: '0600'
+      content: {{ SSH_PUB_KEY_CONTENT }}

--- a/vm-setup/roles/v1a2_integration_test/templates/controlplane_ubuntu.yaml
+++ b/vm-setup/roles/v1a2_integration_test/templates/controlplane_ubuntu.yaml
@@ -1,0 +1,97 @@
+apiVersion: cluster.x-k8s.io/v1alpha2
+kind: Machine
+metadata:
+  name: {{ CLUSTER_NAME }}-controlplane-0
+  labels:
+    cluster.x-k8s.io/control-plane: "true"
+    cluster.x-k8s.io/cluster-name: "{{ CLUSTER_NAME }}"
+spec:
+  version: {{ KUBERNETES_VERSION }}
+  bootstrap:
+    configRef:
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      kind: KubeadmConfig
+      name: {{ CLUSTER_NAME }}-controlplane-0
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: BareMetalMachine
+    name: {{ CLUSTER_NAME }}-controlplane-0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: BareMetalMachine
+metadata:
+  name: {{ CLUSTER_NAME }}-controlplane-0
+spec:
+  image:
+    url: {{ IMAGE_URL }}
+    checksum: {{ IMAGE_CHECKSUM }}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: KubeadmConfig
+metadata:
+  name: {{ CLUSTER_NAME }}-controlplane-0
+spec:
+  initConfiguration:
+    nodeRegistration:
+      name: {{ " '{{ ds.meta_data.name }}' " }}
+      kubeletExtraArgs:
+        node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+  preKubeadmCommands:
+    - ip link set dev enp2s0 up
+    - dhclient enp2s0
+    - mv /tmp/akeys /home/ubuntu/.ssh/authorized_keys
+    - chown ubuntu:ubuntu /home/ubuntu/.ssh/authorized_keys
+    - apt update -y
+    - >-
+      apt install net-tools gcc linux-headers-$(uname -r) keepalived
+      apt-transport-https ca-certificates curl gnupg-agent
+      software-properties-common -y
+    - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+    - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+    - echo 'deb https://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list
+    - apt update -y
+    - apt install docker-ce docker-ce-cli containerd.io kubelet kubeadm kubectl -y
+    - systemctl enable --now docker keepalived kubelet
+    - usermod -aG docker ubuntu
+  postKubeadmCommands:
+    - mkdir -p /home/ubuntu/.kube
+    - cp /etc/kubernetes/admin.conf /home/ubuntu/.kube/config
+    - chown ubuntu:ubuntu /home/ubuntu/.kube/config
+  files:
+      - path: /etc/keepalived/keepalived.conf
+        content: |
+          ! Configuration File for keepalived
+          global_defs {
+              notification_email {
+              sysadmin@example.com
+              support@example.com
+              }
+              notification_email_from lb@example.com
+              smtp_server localhost
+              smtp_connect_timeout 30
+          }
+          vrrp_instance VI_1 {
+              state MASTER
+              interface enp2s0
+              virtual_router_id 1
+              priority 101
+              advert_int 1
+              virtual_ipaddress {
+                  192.168.111.249
+              }
+          }
+      - path: /etc/network/interfaces
+        owner: root:root
+        permissions: '0644'
+        content: |
+          # interfaces(5) file used by ifup(8) and ifdown(8)
+          auto lo
+          iface lo inet loopback
+          ## To configure a dynamic IP address
+          auto enp2s0
+          iface enp2s0 inet dhcp
+      - path: /tmp/akeys
+        owner: root:root
+        permissions: '0644'
+        content: {{ SSH_PUB_KEY_CONTENT }}

--- a/vm-setup/roles/v1a2_integration_test/templates/workers_centos.yaml
+++ b/vm-setup/roles/v1a2_integration_test/templates/workers_centos.yaml
@@ -1,0 +1,90 @@
+apiVersion: cluster.x-k8s.io/v1alpha2
+kind: MachineDeployment
+metadata:
+  name: {{ CLUSTER_NAME }}-md-0
+  labels:
+    cluster.x-k8s.io/cluster-name: {{ CLUSTER_NAME }}
+    nodepool: nodepool-0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ CLUSTER_NAME }}
+      nodepool: nodepool-0
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: {{ CLUSTER_NAME }}
+        nodepool: nodepool-0
+    spec:
+      version: {{ KUBERNETES_VERSION }}
+      bootstrap:
+        configRef:
+          name: {{ CLUSTER_NAME }}-md-0
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: {{ CLUSTER_NAME }}-md-0
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+        kind: BareMetalMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: BareMetalMachineTemplate
+metadata:
+  name: {{ CLUSTER_NAME }}-md-0
+spec:
+  template:
+    spec:
+      image:
+        url: {{ IMAGE_URL }}
+        checksum: {{ IMAGE_CHECKSUM }}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: KubeadmConfigTemplate
+metadata:
+  name: {{ CLUSTER_NAME }}-md-0
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          name: {{ " '{{ ds.meta_data.name }}' " }}
+          kubeletExtraArgs:
+            node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+      preKubeadmCommands:
+        - ifup eth1
+        - yum update -y
+        - yum install yum-utils device-mapper-persistent-data lvm2 -y
+        - yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+        - setenforce 0
+        - sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
+        - >-
+          yum install docker-ce-18.09.9 docker-ce-cli-18.09.9 containerd.io
+          kubelet kubeadm kubectl --disableexcludes=kubernetes -y
+        - usermod -aG docker centos
+        - systemctl enable --now docker kubelet
+      files:
+        - path: /etc/sysconfig/network-scripts/ifcfg-eth1
+          owner: root:root
+          permissions: '0644'
+          content: |
+            BOOTPROTO=dhcp
+            DEVICE=eth1
+            ONBOOT=yes
+            TYPE=Ethernet
+            USERCTL=no
+        - path: /etc/yum.repos.d/kubernetes.repo
+          owner: root:root
+          permissions: '0644'
+          content: |
+            [kubernetes]
+            name=Kubernetes
+            baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+            enabled=1
+            gpgcheck=1
+            repo_gpgcheck=0
+            gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+        - path: /home/centos/.ssh/authorized_keys
+          owner: centos:centos
+          permissions: '0600'
+          content: {{ SSH_PUB_KEY_CONTENT }}

--- a/vm-setup/roles/v1a2_integration_test/templates/workers_ubuntu.yaml
+++ b/vm-setup/roles/v1a2_integration_test/templates/workers_ubuntu.yaml
@@ -1,0 +1,85 @@
+apiVersion: cluster.x-k8s.io/v1alpha2
+kind: MachineDeployment
+metadata:
+  name: {{ CLUSTER_NAME }}-md-0
+  labels:
+    cluster.x-k8s.io/cluster-name: {{ CLUSTER_NAME }}
+    nodepool: nodepool-0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ CLUSTER_NAME }}
+      nodepool: nodepool-0
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: {{ CLUSTER_NAME }}
+        nodepool: nodepool-0
+    spec:
+      version: {{ KUBERNETES_VERSION }}
+      bootstrap:
+        configRef:
+          name: {{ CLUSTER_NAME }}-md-0
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: {{ CLUSTER_NAME }}-md-0
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+        kind: BareMetalMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: BareMetalMachineTemplate
+metadata:
+  name: {{ CLUSTER_NAME }}-md-0
+spec:
+  template:
+    spec:
+      image:
+        url: {{ IMAGE_URL }}
+        checksum: {{ IMAGE_CHECKSUM }}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: KubeadmConfigTemplate
+metadata:
+  name: {{ CLUSTER_NAME }}-md-0
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          name: {{ " '{{ ds.meta_data.name }}' " }}
+          kubeletExtraArgs:
+            node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+      preKubeadmCommands:
+        - ip link set dev enp2s0 up
+        - dhclient enp2s0
+        - mv /tmp/akeys /home/ubuntu/.ssh/authorized_keys
+        - chown ubuntu:ubuntu /home/ubuntu/.ssh/authorized_keys
+        - apt update -y
+        - >-
+          apt install apt-transport-https ca-certificates
+          curl gnupg-agent software-properties-common -y
+        - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+        - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+        - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+        - echo 'deb https://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list
+        - apt update -y
+        - apt install docker-ce docker-ce-cli containerd.io kubelet kubeadm kubectl -y
+        - systemctl enable --now docker kubelet
+        - usermod -aG docker ubuntu
+      files:
+        - path: /etc/network/interfaces
+          owner: root:root
+          permissions: '0644'
+          content: |
+            # interfaces(5) file used by ifup(8) and ifdown(8)
+            auto lo
+            iface lo inet loopback
+            ## To configure a dynamic IP address
+            auto enp2s0
+            iface enp2s0 inet dhcp
+        - path: /tmp/akeys
+          owner: root:root
+          permissions: '0644'
+          content: {{ SSH_PUB_KEY_CONTENT }}

--- a/vm-setup/roles/v1a2_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1a2_integration_test/vars/main.yml
@@ -1,0 +1,32 @@
+---
+# Ansible playbook related variables
+API_VERSION: v1alpha2
+NAMESPACE: metal3
+HOME: "{{ lookup('env', 'HOME') }}"
+CRS_PATH: "{{ metal3_dir }}/vm-setup/roles/v1a2_integration_test/templates"
+KUBECONFIG_PATH: "/home/ubuntu/.kube/config"
+pod_cidr: 192.168.0.0/18
+
+SSH_PRIVATE_KEY: "{{ lookup('env', 'SSH_KEY') }}"
+SSH_PUB_KEY_CONTENT: "{{ lookup('file', '{{ HOME }}/.ssh/id_rsa.pub') }}"
+CLUSTER_NAME: "{{ lookup('env', 'CLUSTER_NAME') | default('test1', true) }}"
+KUBERNETES_VERSION: "{{ lookup('env', 'KUBERNETES_VERSION') | default('v1.17.0', true) }}"
+
+# Environment variables for deployment
+IMAGE_OS: "{{ lookup('env', 'IMAGE_OS') | default('Ubuntu', true)}}"
+CONTAINER_RUNTIME: "{{ lookup('env', 'CONTAINER_RUNTIME') | default('podman', true)}}"
+DEFAULT_HOSTS_MEMORY: "{{ lookup('env', 'DEFAULT_HOSTS_MEMORY') | default('4096', true)}}"
+CAPI_VERSION: "{{ lookup('env', 'CAPI_VERSION') | default('v1alpha2', true)}}"
+
+# Distibution specific environment variables
+IMAGE_NAME: 'bionic-server-cloudimg-amd64.img'
+IMAGE_LOCATION: 'https://cloud-images.ubuntu.com/bionic/current'
+IMAGE_USERNAME: 'ubuntu'
+IMAGE_URL: "http://172.22.0.1/images/{{ IMAGE_NAME }}"
+IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ IMAGE_NAME }}.md5sum"
+
+IMAGE_NAME_CENTOS: 'CentOS-7-x86_64-GenericCloud-1907.qcow2'
+IMAGE_LOCATION_CENTOS: 'http://cloud.centos.org/centos/7/images'
+IMAGE_USERNAME_CENTOS: 'centos'
+IMAGE_URL_CENTOS: "http://172.22.0.1/images/{{ IMAGE_NAME_CENTOS }}"
+IMAGE_CHECKSUM_CENTOS: "http://172.22.0.1/images/{{ IMAGE_NAME_CENTOS }}.md5sum"

--- a/vm-setup/v1a2_integration_test.yml
+++ b/vm-setup/v1a2_integration_test.yml
@@ -1,0 +1,10 @@
+---
+- name: v1alpha2 integration test
+  hosts: virthost
+  connection: local
+  gather_facts: true
+  become: yes
+  become_user: "{{ lookup('env', 'USER') }}"
+  tasks:
+    - import_role:
+        name: v1a2_integration_test


### PR DESCRIPTION
This PR adds an Ansible role for Metal3-dev-env v1alpha2 integration test which

- adds Ansible role for provisioning, deprovisioning and verification of machines & cluster
- changes Ansible version to 2.9.1
- installs OpenShift Python3 client to interact with Kubernetes 