### PR TITLE
Add missing ovs role

### DIFF
--- a/vm-setup/roles/libvirt/tasks/network_setup_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/network_setup_tasks.yml
@@ -5,7 +5,7 @@
   # Install OVS dependencies
   - name: Install OVS dependencies
     include_role:
-      name: 'parts/ovs'
+      name: 'ovs'
 
   # Create any OVS Bridges that have been defined
   - name: Create OVS Bridges

--- a/vm-setup/roles/ovs/defaults/main.yml
+++ b/vm-setup/roles/ovs/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# The package name for openvswitch
+ovs_package: openvswitch
+
+# The name of the openvswitch service.
+ovs_service: openvswitch
+

--- a/vm-setup/roles/ovs/tasks/main.yml
+++ b/vm-setup/roles/ovs/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Install Openvswitch package
+  package:
+    name: "{{ ovs_package }}"
+    state: present
+  become: true
+
+- name: Start Openvswitch
+  service:
+    name: "{{ ovs_service }}"
+    state: started
+    enabled: true
+  become: true
+


### PR DESCRIPTION
With the ability to pull the networks out into a separate config file,
comes the ability to specify an openvswitch network. A necessary role
was missing. This pulls in that missing role. It installs the necessary
ovs packages, and enables the service.