### PR TITLE
Add the ability to define a portgroup for a network

### DIFF
--- a/vm-setup/roles/libvirt/templates/network.xml.j2
+++ b/vm-setup/roles/libvirt/templates/network.xml.j2
@@ -57,4 +57,17 @@
   </dns>
 {% endif %}
 {% endif %}
+{% if item.portgroup is defined %}
+  {% for portgroup in item.portgroup %}
+  <portgroup name='{{ portgroup.name }}'>
+  {% if portgroup.vlan is defined %}
+    <vlan>
+    {% for vlan in portgroup.vlan %}
+      <tag id='{{ vlan.tag }}'/>
+    {% endfor %}
+    </vlan>
+  {% endif %}
+  </portgroup>
+  {% endfor %}
+{% endif %}
 </network>


### PR DESCRIPTION
With this one can define a portgroup:

networks:
  - name: metal3
    bridge: metal3
    forward_mode: bridge
    address: "{{ baremetal_network_cidr|nthhost(1) }}"
    netmask: "{{ baremetal_network_cidr|ipaddr('netmask') }}"
    virtualport_type: openvswitch
    portgroup:
      - name: provisioning
        default: yes
      - name: external
        vlan:
          - tag: 2
      - name: storage
        vlan:
          - tag: 3
      - name: trunk
        vlan:
          - tag: 2
          - tag: 3