### PR TITLE
Cast virtualbmc_base_port to int

### DIFF
--- a/vm-setup/roles/common/tasks/vm_nodes_tasks.yml
+++ b/vm-setup/roles/common/tasks/vm_nodes_tasks.yml
@@ -8,7 +8,7 @@
     vm_nodes: "{{vm_nodes|default([]) + [
                  {'name': ironic_prefix + '%s_%s'|format(flavor.key, item),
                   'flavor': flavor.key,
-                  'virtualbmc_port': virtualbmc_base_port+vm_nodes_index|int+item} ]}}"
+                  'virtualbmc_port': virtualbmc_base_port|int+vm_nodes_index|int+item} ]}}"
   loop: "{{ range(0, lookup('vars', 'num_' + flavor.key + 's')|int)|list }}"
 - set_fact:
     vm_nodes_index: "{{vm_nodes_index|int + lookup('vars', 'num_' + flavor.key + 's')|int }}"


### PR DESCRIPTION
When overriding this via the CLI to ansible-playbook there is a
type mismatch unless this is explicitly cast to an int.