### PR TITLE
Use v1alpha1 branch and master for v1alpha2

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -34,9 +34,9 @@ BMOBRANCH="${BMOBRANCH:-master}"
 CAPBMREPO="${CAPBMREPO:-https://github.com/metal3-io/cluster-api-provider-baremetal.git}"
 
 if [ "${V1ALPHA2_SWITCH}" == true ]; then
-  CAPBMBRANCH="${CAPBMBRANCH:-v1alpha2}"
-else
   CAPBMBRANCH="${CAPBMBRANCH:-master}"
+else
+  CAPBMBRANCH="${CAPBMBRANCH:-v1alpha1}"
 fi
 
 FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-false}"


### PR DESCRIPTION
the CAPBM master branch was swapped to v1alpha2, this enables compatibility with v1alpha1 and v1alpha2