### PR TITLE
WIP testing with CentOS8

### DIFF
--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -20,28 +20,26 @@ sudo yum -y update
 source /etc/os-release
 # VERSION_ID can be "7" or "8.x" so strip the minor version
 DISTRO="${ID}${VERSION_ID%.*}"
-if [ ! -f /etc/yum.repos.d/epel.repo ] ; then
-    if [[ $DISTRO == "rhel7" ]]; then
-        sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    elif [[ $DISTRO == "centos7" ]]; then
-        sudo yum -y install epel-release --enablerepo=extras
-    fi
-fi
 
 if [[ $DISTRO == "centos7" ]]; then
-    sudo yum -y install epel-release dnf --enablerepo=extras
-fi
-
-if [[ $DISTRO == "rhel8" ]]; then
-    sudo subscription-manager repos --enable=ansible-2-for-rhel-8-x86_64-rpms
-    sudo dnf -y install python3
-    sudo alternatives --set python /usr/bin/python3
-else
+  sudo yum -y install epel-release dnf --enablerepo=extras
   # Install tripleo-repos, used to get a more recent version of some packages on CentOS7
   sudo dnf -y --repofrompath="current-tripleo,https://trunk.rdoproject.org/${DISTRO}-master/current-tripleo" install "python*-tripleo-repos" --nogpgcheck
   sudo tripleo-repos current-tripleo
   # There are some packages which are newer in the tripleo repos
   sudo yum -y update
+fi
+
+if [[ $DISTRO == "rhel8" ]]; then
+  sudo subscription-manager repos --enable=ansible-2-for-rhel-8-x86_64-rpms
+elif [[ $DISTRO == "centos8" ]]; then
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+  sudo dnf -y install epel-release
+fi
+
+if [[ $DISTRO == "rhel8" ]] || [[ $DISTRO == "centos8" ]]; then
+  sudo dnf -y install python3
+  sudo alternatives --set python /usr/bin/python3
 fi
 
 # Install required packages

--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -34,24 +34,21 @@ fi
 
 if [[ $DISTRO == "rhel8" ]]; then
     sudo subscription-manager repos --enable=ansible-2-for-rhel-8-x86_64-rpms
-    sudo yum -y install python3
+    sudo dnf -y install python3
     sudo alternatives --set python /usr/bin/python3
+else
+  # Install tripleo-repos, used to get a more recent version of some packages on CentOS7
+  sudo dnf -y --repofrompath="current-tripleo,https://trunk.rdoproject.org/${DISTRO}-master/current-tripleo" install "python*-tripleo-repos" --nogpgcheck
+  sudo tripleo-repos current-tripleo
+  # There are some packages which are newer in the tripleo repos
+  sudo yum -y update
 fi
 
 # Install required packages
-# python-{requests,setuptools} required for tripleo-repos install
 sudo yum -y install \
   ansible \
   redhat-lsb-core \
   wget
-
-# Install tripleo-repos, used to get a recent version of python-virtualbmc
-sudo dnf -y --repofrompath="current-tripleo,https://trunk.rdoproject.org/${DISTRO}-master/current-tripleo" install "python*-tripleo-repos" --nogpgcheck
-sudo tripleo-repos current-tripleo
-
-# There are some packages which are newer in the tripleo repos
-sudo yum -y update
-
 
 if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
   sudo yum -y install podman

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -170,18 +170,18 @@ export OS
 OS_VERSION=$(awk -F= '/^VERSION_ID=/ { print $2 }' /etc/os-release | tr -d '"' | cut -f1 -d'.')
 export OS_VERSION
 if [[ $OS == centos ]]; then
-  if [[ ${OS_VERSION} -ne 7 ]]; then
-    echo "Required CentOS 7 or RHEL 8 or Ubuntu 18.04"
+  if [ ${OS_VERSION} -ne 7 ] && [ ${OS_VERSION} -ne 8 ]; then
+    echo "Required CentOS 7/8 or RHEL 8 or Ubuntu 18.04"
     exit 1
   fi
 elif [[ $OS == rhel ]]; then
   if [[ ${OS_VERSION} -ne 8 ]]; then
-    echo "Required CentOS 7 or RHEL 8 or Ubuntu 18.04"
+    echo "Required CentOS 7/8 or RHEL 8 or Ubuntu 18.04"
     exit 1
   fi
 elif [[ $OS == ubuntu ]]; then
   if [[ ${OS_VERSION} -ne 18 ]]; then
-    echo "Required CentOS 7 or RHEL 8 or Ubuntu 18.04"
+    echo "Required CentOS 7/8 or RHEL 8 or Ubuntu 18.04"
     exit 1
   fi
 else

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -37,81 +37,78 @@ packages:
      - setuptools 
      - libvirt-python
      - python-openstackclient
-  centos:
-    rhel7:
-        packages:
-         - crudini 
-         - curl 
-         - dnsmasq 
-         - NetworkManager 
-         - nmap
-         - OVMF
-         - patch 
-         - psmisc 
-         - python-pip 
-         - python-requests 
-         - python-setuptools 
-         - vim-enhanced 
-         - wget
-         - ansible 
-         - bind-utils 
-         - jq 
-         - libguestfs-tools 
-         - nodejs 
-         - python-ironicclient 
-         - python-ironic-inspector-client 
-         - python-openstackclient 
-         - redhat-lsb-core 
-         - unzip 
-         - genisoimage
-         - qemu-kvm
-         - libvirt
-         - libvirt-devel 
-         - libvirt-daemon-kvm 
-         - libvirt-python
-         - libguestfs-tools
-         - python-lxml
-         - polkit-pkla-compat
-         - python-netaddr
-         - python-virtualbmc
-         - virt-install 
-    rhel8:
-        packages:
-         - crudini 
-         - curl 
-         - dnsmasq
-         - edk2-ovmf
-         - NetworkManager 
-         - nmap 
-         - patch 
-         - psmisc 
-         - python3-pip 
-         - python3-requests 
-         - python3-setuptools 
-         - vim-enhanced 
-         - wget
-         - ansible 
-         - bind-utils 
-         - jq 
-         - libguestfs-tools 
-         - nodejs 
-         - python3-ironicclient 
-         - python3-ironic-inspector-client 
-         - python3-openstackclient
-         - redhat-lsb-core 
-         - unzip 
-         - genisoimage
-         - qemu-kvm
-         - libvirt
-         - libvirt-devel 
-         - libvirt-daemon-kvm 
-         - python3-libvirt
-         - libguestfs-tools
-         - python3-lxml
-         - polkit-pkla-compat
-         - python3-netaddr
-         - python3-virtualbmc
-         - virt-install 
-         - network-scripts
-    pip:
-      - yq
+  centos7:
+    packages:
+     - crudini 
+     - curl 
+     - dnsmasq 
+     - NetworkManager 
+     - nmap
+     - OVMF
+     - patch 
+     - psmisc 
+     - python-pip 
+     - python-requests 
+     - python-setuptools 
+     - vim-enhanced 
+     - wget
+     - ansible 
+     - bind-utils 
+     - jq 
+     - libguestfs-tools 
+     - nodejs 
+     - python-ironicclient 
+     - python-ironic-inspector-client 
+     - python-openstackclient 
+     - redhat-lsb-core 
+     - unzip 
+     - genisoimage
+     - qemu-kvm
+     - libvirt
+     - libvirt-devel 
+     - libvirt-daemon-kvm 
+     - libvirt-python
+     - libguestfs-tools
+     - python-lxml
+     - polkit-pkla-compat
+     - python-netaddr
+     - python-virtualbmc
+     - virt-install 
+  rhel8:
+    packages:
+     - curl 
+     - dnsmasq
+     - edk2-ovmf
+     - NetworkManager 
+     - nmap 
+     - patch 
+     - psmisc 
+     - python3-pip 
+     - python3-requests 
+     - python3-setuptools 
+     - vim-enhanced 
+     - wget
+     - ansible 
+     - bind-utils 
+     - jq 
+     - libguestfs-tools 
+     - nodejs 
+     - redhat-lsb-core 
+     - unzip 
+     - genisoimage
+     - qemu-kvm
+     - libvirt
+     - libvirt-devel 
+     - libvirt-daemon-kvm 
+     - python3-libvirt
+     - libguestfs-tools
+     - python3-lxml
+     - polkit-pkla-compat
+     - python3-netaddr
+     - virt-install 
+     - network-scripts
+    pip3:
+     - yq
+     - python-ironicclient
+     - python-ironic-inspector-client
+     - python-openstackclient

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -1,22 +1,22 @@
 packages:
   ubuntu:
     packages:
-     - crudini 
-     - curl 
-     - dnsmasq 
+     - crudini
+     - curl
+     - dnsmasq
      - nmap
      - ovmf
-     - patch 
-     - psmisc 
+     - patch
+     - psmisc
      - wget
-     - libvirt-bin 
-     - libvirt-clients 
-     - libvirt-dev 
-     - jq 
-     - nodejs 
-     - unzip 
-     - yarn 
-     - genisoimage 
+     - libvirt-bin
+     - libvirt-clients
+     - libvirt-dev
+     - jq
+     - nodejs
+     - unzip
+     - yarn
+     - genisoimage
      - qemu-kvm
      - libguestfs-tools
      - gir1.2-polkit-1.0
@@ -27,85 +27,124 @@ packages:
      - libvirt-python
      - lxml
     pip3:
-     - yq 
-     - virtualbmc 
-     - python-ironicclient 
-     - python-ironic-inspector-client 
-     - lxml 
-     - netaddr 
-     - requests 
-     - setuptools 
+     - yq
+     - virtualbmc
+     - python-ironicclient
+     - python-ironic-inspector-client
+     - lxml
+     - netaddr
+     - requests
+     - setuptools
      - libvirt-python
      - python-openstackclient
   centos7:
     packages:
-     - crudini 
-     - curl 
-     - dnsmasq 
-     - NetworkManager 
+     - crudini
+     - curl
+     - dnsmasq
+     - NetworkManager
      - nmap
      - OVMF
-     - patch 
-     - psmisc 
-     - python-pip 
-     - python-requests 
-     - python-setuptools 
-     - vim-enhanced 
+     - patch
+     - psmisc
+     - python-pip
+     - python-requests
+     - python-setuptools
+     - vim-enhanced
      - wget
-     - ansible 
-     - bind-utils 
-     - jq 
-     - libguestfs-tools 
-     - nodejs 
-     - python-ironicclient 
-     - python-ironic-inspector-client 
-     - python-openstackclient 
-     - redhat-lsb-core 
-     - unzip 
+     - ansible
+     - bind-utils
+     - jq
+     - libguestfs-tools
+     - nodejs
+     - python-ironicclient
+     - python-ironic-inspector-client
+     - python-openstackclient
+     - redhat-lsb-core
+     - unzip
      - genisoimage
      - qemu-kvm
      - libvirt
-     - libvirt-devel 
-     - libvirt-daemon-kvm 
+     - libvirt-devel
+     - libvirt-daemon-kvm
      - libvirt-python
      - libguestfs-tools
      - python-lxml
      - polkit-pkla-compat
      - python-netaddr
      - python-virtualbmc
-     - virt-install 
+     - virt-install
   rhel8:
     packages:
-     - curl 
+     - curl
      - dnsmasq
      - edk2-ovmf
-     - NetworkManager 
-     - nmap 
-     - patch 
-     - psmisc 
-     - python3-pip 
-     - python3-requests 
-     - python3-setuptools 
-     - vim-enhanced 
+     - NetworkManager
+     - nmap
+     - patch
+     - psmisc
+     - python3-pip
+     - python3-requests
+     - python3-setuptools
+     - vim-enhanced
      - wget
-     - ansible 
-     - bind-utils 
-     - jq 
-     - libguestfs-tools 
-     - nodejs 
-     - redhat-lsb-core 
-     - unzip 
+     - ansible
+     - bind-utils
+     - jq
+     - libguestfs-tools
+     - nodejs
+     - redhat-lsb-core
+     - unzip
      - genisoimage
      - qemu-kvm
      - libvirt
-     - libvirt-devel 
-     - libvirt-daemon-kvm 
+     - libvirt-devel
+     - libvirt-daemon-kvm
      - python3-libvirt
      - libguestfs-tools
      - python3-lxml
      - polkit-pkla-compat
      - python3-netaddr
-     - virt-install 
+     - virt-install
+     - network-scripts
+    pip3:
+     - yq
+     - python-ironicclient
+     - python-ironic-inspector-client
+     - python-openstackclient
+  centos8:
+    packages:
+     - crudini
+     - curl
+     - dnsmasq
+     - edk2-ovmf
+     - NetworkManager
+     - nmap
+     - patch
+     - psmisc
+     - python3-pip
+     - python3-requests
+     - python3-setuptools
+     - vim-enhanced
+     - wget
+     - ansible
+     - bind-utils
+     - jq
+     - libguestfs-tools
+     - nodejs
+     - redhat-lsb-core
+     - unzip
+     - genisoimage
+     - qemu-kvm
+     - libvirt
+     - libvirt-devel
+     - libvirt-daemon-kvm
+     - python3-libvirt
+     - libguestfs-tools
+     - python3-lxml
+     - polkit-pkla-compat
+     - python3-netaddr
+     - virt-install
      - network-scripts
     pip3:
      - yq

--- a/vm-setup/roles/packages_installation/tasks/main.yml
+++ b/vm-setup/roles/packages_installation/tasks/main.yml
@@ -19,24 +19,26 @@
   when: ansible_facts['distribution'] == "Ubuntu"
 
 
-- name: Install packages on CentOS
+- name: Install packages on CentOS 7
   block:
-    - name: Install packages using standard package manager
-      block: 
-        - name: Install packages on rhel7
-          when: ansible_lsb.major_release|int == 7
-          package:
-             name: "{{ packages.centos.rhel7.packages }}"
-             state: present
-        - name: Install packages on rhel8
-          when: ansible_lsb.major_release|int == 8
-          package:
-             name: "{{ packages.centos.rhel8.packages }}"
-             state: present
-      become: true
+    - package:
+         name: "{{ packages.centos7.packages }}"
+         state: present
     - name: Install packages using pip
       pip:
-        name: "{{ packages.centos.pip }}"
+        name: "{{ packages.centos7.pip }}"
         state: present
-      become: true
-  when: ansible_os_family == "RedHat"
+  become: true
+  when: ansible_os_family == "RedHat" and ansible_lsb.major_release|int == 7
+
+- name: Install packages on RHEL8
+  block:
+    - package:
+         name: "{{ packages.rhel8.packages }}"
+         state: present
+    - pip:
+        executable: "pip3"
+        name: "{{ packages.rhel8.pip3 }}"
+        state: present
+  become: true
+  when: ansible_os_family == "RedHat" and ansible_lsb.major_release|int == 8


### PR DESCRIPTION
This aims to remove the RDO repo dependency for both RHEL8 and CentOS8 - the packages we need from there have reduced since e.g vbmc is now containerized and the qemu-kvm changes needed are in the main el8 repos now.

The main TODO item is how we handle install of openstackclient but for now this is handled via pip, similar to what is already done on Ubuntu.

Marking this WIP as I've only tested on RHEL8 so far, @yrobla is planning to try with CentOS and provide feedback on any additional fixes needed.