### PR TITLE
Enable testing with an IPv6 EXTERNAL_SUBNET

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -46,6 +46,7 @@ else
   export POD_NAME=""
   export POD_NAME_INFRA=""
 fi
+
 export SSH_KEY=${SSH_KEY:-"${HOME}/.ssh/id_rsa"}
 export SSH_PUB_KEY=${SSH_PUB_KEY:-"${SSH_KEY}.pub"}
 # Generate user ssh key

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -56,4 +56,4 @@ network_address dhcp_range_end "$PROVISIONING_NETWORK" 100
 
 export CLUSTER_DHCP_RANGE=${CLUSTER_DHCP_RANGE:-"$dhcp_range_start,$dhcp_range_end"}
 
-export EXTERNAL_SUBNET="192.168.111.0/24"
+export EXTERNAL_SUBNET=${EXTERNAL_SUBNET:-"192.168.111.0/24"}

--- a/vm-setup/roles/common/defaults/main.yml
+++ b/vm-setup/roles/common/defaults/main.yml
@@ -50,6 +50,7 @@ networks:
     forward_mode: "{% if manage_baremetal == 'y' %}nat{% else %}bridge{% endif %}"
     address: "{{ baremetal_network_cidr|nthhost(1) }}"
     netmask: "{{ baremetal_network_cidr|ipaddr('netmask') }}"
+    prefix: "{{ baremetal_network_cidr|ipaddr('prefix') }}"
     dhcp_range:
       - "{{ baremetal_network_cidr|nthhost(20) }}"
       - "{{ baremetal_network_cidr|nthhost(60) }}"
@@ -61,4 +62,4 @@ networks:
       hosts: "{{dns_extrahosts | default([])}}"
       forwarders:
         - domain: "apps.{{ cluster_domain }}"
-          addr: "127.0.0.1"
+          addr: "{% if baremetal_network_cidr|ipv6 != False %}::1{% else %}127.0.0.1{% endif %}"

--- a/vm-setup/roles/libvirt/templates/network.xml.j2
+++ b/vm-setup/roles/libvirt/templates/network.xml.j2
@@ -1,7 +1,14 @@
 {% set nat_port_range = item.nat_port_range|default([1024, 65535]) %}
 {% set netmask = item.netmask|default("") %}
 {% set prefix = item.prefix|default("") %}
+{% if item.dns.options is defined %}
+<network xmlns:dnsmasq='http://libvirt.org/schemas/network/dnsmasq/1.0'>
+  <dnsmasq:options>
+    <dnsmasq:option value='{{ item.dns.options }}'/>
+  </dnsmasq:options>
+{% else %}
 <network>
+{% endif %}
   <name>{{ item.name }}</name>
   <bridge name='{{ item.bridge }}'/>
 {% if item.forward_mode is defined %}

--- a/vm-setup/roles/libvirt/templates/network.xml.j2
+++ b/vm-setup/roles/libvirt/templates/network.xml.j2
@@ -1,5 +1,6 @@
 {% set nat_port_range = item.nat_port_range|default([1024, 65535]) %}
-{% set netmask = item.netmask|default('255.255.255.0') %}
+{% set netmask = item.netmask|default("") %}
+{% set prefix = item.prefix|default("") %}
 <network>
   <name>{{ item.name }}</name>
   <bridge name='{{ item.bridge }}'/>
@@ -16,7 +17,11 @@
       <virtualport type='{{ item.virtualport_type }}'/>
 {% endif %}
 {% if item.address is defined  and item.forward_mode != 'bridge' %}
+{% if item.address|ipv6 != False %}
+  <ip family="ipv6" address='{{ item.address }}' prefix='{{ prefix }}'>
+{% else %}
   <ip address='{{ item.address }}' netmask='{{ netmask }}'>
+{% endif %}
 {% if item.dhcp_range is defined %}
     <dhcp>
       <range start='{{ item.dhcp_range[0] }}' end='{{ item.dhcp_range[1] }}'/>
@@ -25,7 +30,11 @@
 {% set numflavor = lookup('vars', 'num_' + flavor + 's')|default(0)|int %}
 {% for num in range(0, numflavor) %}
 {% set ironic_name = ironic_prefix + flavor + "_" + num|string %}
+{% if item.address|ipv6 != False %}
+      <host id='01:{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{flavor}}-{{num}}' ip='{{item.dhcp_range[0]|ipmath(ns.index|int)}}'/>
+{% else %}
       <host mac='{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{flavor}}-{{num}}' ip='{{item.dhcp_range[0]|ipmath(ns.index|int)}}'/>
+{% endif %}
 {% set ns.index = ns.index + 1 %}
 {% endfor %}
 {% endfor %}

--- a/vm-setup/roles/libvirt/templates/network.xml.j2
+++ b/vm-setup/roles/libvirt/templates/network.xml.j2
@@ -38,7 +38,7 @@
 {% for num in range(0, numflavor) %}
 {% set ironic_name = ironic_prefix + flavor + "_" + num|string %}
 {% if item.address|ipv6 != False %}
-      <host id='01:{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{flavor}}-{{num}}' ip='{{item.dhcp_range[0]|ipmath(ns.index|int)}}'/>
+      <host id='00:03:00:01:{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{flavor}}-{{num}}' ip='{{item.dhcp_range[0]|ipmath(ns.index|int)}}'/>
 {% else %}
       <host mac='{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{flavor}}-{{num}}' ip='{{item.dhcp_range[0]|ipmath(ns.index|int)}}'/>
 {% endif %}


### PR DESCRIPTION
This allows initial testing with an external/baremetal network
configured for ipv6