### PR TITLE
Fix Networking in Ubuntu ControlPlane CR

### DIFF
--- a/crs/v1alpha2/controlplane_ubuntu.yaml
+++ b/crs/v1alpha2/controlplane_ubuntu.yaml
@@ -81,16 +81,17 @@ spec:
                   192.168.111.249
               }
           }
-      - path: /etc/network/interfaces
+      - path : /etc/netplan/50-cloud-init.yaml
         owner: root:root
         permissions: '0644'
-        content: |
-          # interfaces(5) file used by ifup(8) and ifdown(8)
-          auto lo
-          iface lo inet loopback
-          ## To configure a dynamic IP address
-          auto enp2s0
-          iface enp2s0 inet dhcp
+        content: | 
+          network:
+              ethernets:
+                  enp1s0:
+                      dhcp4: true
+                  enp2s0:
+                      dhcp4: true
+              version: 2
       - path: /tmp/akeys
         owner: root:root
         permissions: '0644'

--- a/crs/v1alpha2/workers_ubuntu.yaml
+++ b/crs/v1alpha2/workers_ubuntu.yaml
@@ -69,16 +69,15 @@ spec:
         - systemctl enable --now docker kubelet
         - usermod -aG docker ubuntu
       files:
-        - path: /etc/network/interfaces
+        - path : /etc/netplan/50-cloud-init.yaml
           owner: root:root
           permissions: '0644'
-          content: |
-            # interfaces(5) file used by ifup(8) and ifdown(8)
-            auto lo
-            iface lo inet loopback
-            ## To configure a dynamic IP address
-            auto enp2s0
-            iface enp2s0 inet dhcp
+          content: | 
+            network:
+                ethernets:
+                    enp2s0:
+                        dhcp4: true
+                version: 2
         - path: /tmp/akeys
           owner: root:root
           permissions: '0644'


### PR DESCRIPTION
This PR fixes the networking interface issue in ubuntu controlplane and worker CR so that the networking survive while the node reboots. Previously, networking did not survive reboot