### PR TITLE
kill run-bmo-loop.sh script during host cleanup

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -24,6 +24,7 @@ fi
 
 # Kill the locally running operators
 if [ "${BMO_RUN_LOCAL}" = true ]; then
+  kill "$(pgrep "run-bmo-loop.sh")" 2> /dev/null || true
   kill "$(pgrep "operator-sdk")" 2> /dev/null || true
 fi
 if [ "${CAPBM_RUN_LOCAL}" = true ]; then


### PR DESCRIPTION
otherwise, operator-sdk will always be restarted

Signed-off-by: Leslie Qi Wang <leslie.qiwa@gmail.com>

Close https://github.com/metal3-io/metal3-dev-env/issues/164