### PR TITLE
Allow vrrp & icmp on provisioning network

### DIFF
--- a/vm-setup/roles/firewall/defaults/main.yml
+++ b/vm-setup/roles/firewall/defaults/main.yml
@@ -17,3 +17,6 @@ pxe_udp_ports:
   - "67"
   - "68"
   - "69"
+ironic_keepalived_proto:
+  - "112"
+  - "icmp"

--- a/vm-setup/roles/firewall/tasks/iptables.yaml
+++ b/vm-setup/roles/firewall/tasks/iptables.yaml
@@ -51,3 +51,11 @@
     destination_port: "{{ item }}"
     jump: ACCEPT
   loop: "{{ pxe_udp_ports }}"
+
+- name: "iptables: Ironic Endpoint Keepalived"
+  iptables:
+    chain: FORWARD
+    in_interface: "{{ provisioning_interface }}"
+    protocol: "{{ item }}"
+    jump: ACCEPT
+  loop: "{{ ironic_keepalived_proto }}"


### PR DESCRIPTION
Add firewall rules to allow icmp and vrrp packets on provisioning network. 

Co-authored-by: maelk <mael.kimmerlin@est.tech>, Xenwar <anwar.hassen@est.tech>