### PR TITLE
Source missing variables for provisioning

### DIFF
--- a/scripts/v1alpha2/create_controlplane.sh
+++ b/scripts/v1alpha2/create_controlplane.sh
@@ -5,4 +5,12 @@ METAL3_DIR="$(dirname "$(readlink -f "${0}")")/../.."
 # shellcheck disable=SC1090
 source "${METAL3_DIR}/lib/common.sh"
 
+# shellcheck disable=SC1091
+# shellcheck disable=SC1090
+source "${METAL3_DIR}/lib/images.sh"
+
+# shellcheck disable=SC1091
+# shellcheck disable=SC1090
+source "${METAL3_DIR}/lib/network.sh"
+
 make_v1alpha2_machine controlplane | kubectl apply -n metal3 -f -

--- a/scripts/v1alpha2/create_worker.sh
+++ b/scripts/v1alpha2/create_worker.sh
@@ -5,4 +5,12 @@ METAL3_DIR="$(dirname "$(readlink -f "${0}")")/../.."
 # shellcheck disable=SC1090
 source "${METAL3_DIR}/lib/common.sh"
 
+# shellcheck disable=SC1091
+# shellcheck disable=SC1090
+source "${METAL3_DIR}/lib/images.sh"
+
+# shellcheck disable=SC1091
+# shellcheck disable=SC1090
+source "${METAL3_DIR}/lib/network.sh"
+
 make_v1alpha2_machine workers | kubectl apply -n metal3 -f -

--- a/scripts/v1alpha2/delete_controlplane.sh
+++ b/scripts/v1alpha2/delete_controlplane.sh
@@ -5,4 +5,12 @@ METAL3_DIR="$(dirname "$(readlink -f "${0}")")/../.."
 # shellcheck disable=SC1090
 source "${METAL3_DIR}/lib/common.sh"
 
+# shellcheck disable=SC1091
+# shellcheck disable=SC1090
+source "${METAL3_DIR}/lib/images.sh"
+
+# shellcheck disable=SC1091
+# shellcheck disable=SC1090
+source "${METAL3_DIR}/lib/network.sh"
+
 make_v1alpha2_machine controlplane | kubectl delete -n metal3 -f -

--- a/scripts/v1alpha2/delete_worker.sh
+++ b/scripts/v1alpha2/delete_worker.sh
@@ -5,4 +5,12 @@ METAL3_DIR="$(dirname "$(readlink -f "${0}")")/../.."
 # shellcheck disable=SC1090
 source "${METAL3_DIR}/lib/common.sh"
 
+# shellcheck disable=SC1091
+# shellcheck disable=SC1090
+source "${METAL3_DIR}/lib/images.sh"
+
+# shellcheck disable=SC1091
+# shellcheck disable=SC1090
+source "${METAL3_DIR}/lib/network.sh"
+
 make_v1alpha2_machine workers | kubectl delete -n metal3 -f -


### PR DESCRIPTION
Provisioning of both controlplane&worker machines is failing because scripts are missing sourcing of variables from` /lib/images.sh `and `/lib/network.sh`.


```
The BareMetalMachine "test1-controlplane-0" is invalid: 
* spec.image.checksum: Invalid value: "null": spec.image.checksum in body must be of type string: "null"
* spec.image.url: Invalid value: "null": spec.image.url in body must be of type string: "null"

```

