### PR TITLE
Install 5.10.0 version of libvirt-python

### DIFF
--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -24,7 +24,7 @@ packages:
      - libpolkit-backend-1-0
      - libpolkit-gobject-1-0
     pip: # ansible uses these packages in python2 to run on the local machine
-     - libvirt-python
+     - libvirt-python==5.10.0
      - lxml
     pip3:
      - virtualbmc


### PR DESCRIPTION
Co-authored-by: kashifest kashif.khan@est.tech

Install 5.10.0 version of  libvirt-python which was used till now.
Metal3-dev-env fails with the latest version of libvirt-python. 

[CI report](https://jenkins.nordix.org/view/Airship/job/airship_metal3io_metal3_dev_env_v1a2_integration_test_ubuntu/51/console)