### PR TITLE
Default CAPI_VERSION set to v1alpha2

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -82,9 +82,9 @@
 
 # Select the Cluster API version
 # Accepted values : v1alpha1 v1alpha2
-# default: v1alpha1
+# default: v1alpha2
 #
-#export CAPI_VERSION=v1alpha1
+#export CAPI_VERSION=v1alpha2
 
 # Configure provisioning network for single-stack ipv6
 #PROVISIONING_IPV6=false

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -85,7 +85,7 @@ export BAREMETAL_OPERATOR_IMAGE=${BAREMETAL_OPERATOR_IMAGE:-"quay.io/metal3-io/b
 export OPENSTACK_CONFIG=$HOME/.config/openstack/clouds.yaml
 
 # CAPI version
-export CAPI_VERSION=${CAPI_VERSION:-"v1alpha1"}
+export CAPI_VERSION=${CAPI_VERSION:-"v1alpha2"}
 
 # CAPBM controller image
 if [ "${CAPI_VERSION}" == "v1alpha1" ]; then


### PR DESCRIPTION
Fix #200 

TBH, I'm not sure if you want to switch to v1alpha2 as the default API version, but just in case and in order to be 'compilant' with the documentation.