### PR TITLE
Fix when kubectl already installed and it is not latest

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -26,10 +26,15 @@ if ! command -v docker-machine-driver-kvm2 2>/dev/null ; then
     sudo mv docker-machine-driver-kvm2 /usr/local/bin/.
 fi
 
-if ! command -v kubectl 2>/dev/null ; then
-    curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+KUBECTL_LATEST=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+KUBECTL_LOCAL=$(kubectl version --client --short | cut -d ":" -f2 | sed 's/[[:space:]]//g' 2> /dev/null)
+KUBECTL_PATH=$(whereis -b kubectl | cut -d ":" -f2 | awk {'print $1'})
+
+if [ "$KUBECTL_LOCAL" != "$KUBECTL_LATEST" ]; then
+    curl -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_LATEST}/bin/linux/amd64/kubectl"
     chmod +x kubectl
-    sudo mv kubectl /usr/local/bin/.
+    KUBECTL_PATH="${KUBECTL_PATH:-/usr/local/bin/kubectl}"
+    sudo mv kubectl ${KUBECTL_PATH}
 fi
 
 if ! command -v kustomize 2>/dev/null ; then

--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -28,13 +28,13 @@ fi
 
 KUBECTL_LATEST=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 KUBECTL_LOCAL=$(kubectl version --client --short | cut -d ":" -f2 | sed 's/[[:space:]]//g' 2> /dev/null)
-KUBECTL_PATH=$(whereis -b kubectl | cut -d ":" -f2 | awk {'print $1'})
+KUBECTL_PATH=$(whereis -b kubectl | cut -d ":" -f2 | awk '{print $1}')
 
 if [ "$KUBECTL_LOCAL" != "$KUBECTL_LATEST" ]; then
     curl -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_LATEST}/bin/linux/amd64/kubectl"
     chmod +x kubectl
     KUBECTL_PATH="${KUBECTL_PATH:-/usr/local/bin/kubectl}"
-    sudo mv kubectl ${KUBECTL_PATH}
+    sudo mv kubectl "${KUBECTL_PATH}"
 fi
 
 if ! command -v kustomize 2>/dev/null ; then


### PR DESCRIPTION
Signed-off-by: Alberto Losada <alosadag@redhat.com>

This PR fixes issue #98 

I faced this issue when run the metal3-dev-env scripts in my CentOS 7 when kubernetes-client rpm package (v1.5.2) was already installed.

