### PR TITLE
Hack to fix oniguruma conflict on CentOS 7

### DIFF
--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -50,9 +50,12 @@ sudo yum -y install \
 sudo dnf -y --repofrompath="current-tripleo,https://trunk.rdoproject.org/${DISTRO}-master/current-tripleo" install "python*-tripleo-repos" --nogpgcheck
 sudo tripleo-repos current-tripleo
 
-# There are some packages which are newer in the tripleo repos
-sudo yum -y update
 
+# There are some packages which are newer in the tripleo repos
+# FIXME(stbenjam): On CentOS 7, the version of oniguruma conflicts with
+# the version shipped in the tripleo repos. This needs further
+# investigation.
+sudo yum -y update --exclude=oniguruma
 
 if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
   sudo yum -y install podman


### PR DESCRIPTION
If you have `jq` installed from epel prior to running metal3-dev-env,
`yum update`, there's a conflict when running `yum update` after
enabling the tripleo repos.

```
--> Finished Dependency Resolution
Error: Package: jq-1.6-1.el7.x86_64 (@epel)
           Requires: libonig.so.2()(64bit)
           Removing: oniguruma-5.9.5-3.el7.x86_64 (@epel)
               libonig.so.2()(64bit)
           Updated By: oniguruma-6.7.0-1.el7.x86_64 (delorean-master-testing)
              ~libonig.so.4()(64bit)
```

This introduces a hack to prevent it from being updated in `yum update`,
until this is fixed, we drop CentOS 7 support, or remove the need for
the tripleo repos at all.

