### PR TITLE
Adds calico as SDN to the new cluster

### DIFF
--- a/crs/v1alpha2/controlplane_centos.yaml
+++ b/crs/v1alpha2/controlplane_centos.yaml
@@ -54,6 +54,7 @@ spec:
     - mkdir -p /home/centos/.kube
     - cp /etc/kubernetes/admin.conf /home/centos/.kube/config
     - chown centos:centos /home/centos/.kube/config
+    - KUBECONFIG=/etc/kubernetes/admin.conf kubectl apply -f https://docs.projectcalico.org/v3.11/manifests/calico.yaml
   files:
     - path: /etc/keepalived/keepalived.conf
       content: |

--- a/crs/v1alpha2/controlplane_ubuntu.yaml
+++ b/crs/v1alpha2/controlplane_ubuntu.yaml
@@ -58,6 +58,7 @@ spec:
     - mkdir -p /home/ubuntu/.kube
     - cp /etc/kubernetes/admin.conf /home/ubuntu/.kube/config
     - chown ubuntu:ubuntu /home/ubuntu/.kube/config
+    - KUBECONFIG=/etc/kubernetes/admin.conf kubectl apply -f https://docs.projectcalico.org/v3.11/manifests/calico.yaml
   files:
       - path: /etc/keepalived/keepalived.conf
         content: |


### PR DESCRIPTION
The default kubeadmconfigs deploy everything but the SDN which means that the cluster is not fully functional and for a proper cluster you need to:

* ssh into the master host and add an SDN
or
* get the kubeconfig (by ssh'ing into the master host) to get the kubeconfig, then add an SDN

The calico SDN manifest (https://docs.projectcalico.org/v3.11/manifests/calico.yaml) almost fits the IPv4 range (`CALICO_IPV4POOL_CID=192.168.0.0/16`) but I believe this is ignored because it is created via the `--cluster-cidr` flag here https://github.com/metal3-io/metal3-dev-env/blob/master/crs/v1alpha2/cluster.yaml#L11

