### PR TITLE
Add missing ipcalc dependency to Ubuntu install

### DIFF
--- a/ubuntu_install_requirements.sh
+++ b/ubuntu_install_requirements.sh
@@ -24,6 +24,7 @@ sudo apt -y install \
   python-setuptools \
   zlib1g-dev \
   libssl1.0-dev \
+  ipcalc \
   wget
 
 # There are some packages which are newer in the tripleo repos


### PR DESCRIPTION
I ran into this while setting up in my Ubuntu 18.04 installation:

```
lib/network.sh: line 36: ipcalc: command not found
```

I haven't run into any related issues, but this PR should resolve any that might come up because of this.