### PR TITLE
Make code python 3 compatible

### DIFF
--- a/vm-setup/library/generate_macs.py
+++ b/vm-setup/library/generate_macs.py
@@ -55,7 +55,7 @@ def generate_baremetal_macs(nodes, networks):
                  random.randint(0x00, 0xff),
                  random.randint(0x00, 0xff),
                  random.randint(0x00, 0xff)]
-    base_mac = ':'.join(map(lambda x: "%02x" % x, base_nums))
+    base_mac = ':'.join(["%02x" % x for x in base_nums])
 
     start = random.randint(0x00, 0xff)
     if (start + (count * 2)) > 0xff:


### PR DESCRIPTION
Now python 2 is EOL, this patch set upgrades scripts to be python3
compatible.

Signed-off-by: Tin Lam <tin@irrational.io>