### PR TITLE
Specify cloning directory

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -54,7 +54,7 @@ function clone_repos() {
     fi
     if [ ! -d "${BMOPATH}" ] ; then
         pushd "${M3PATH}"
-        git clone "${BMOREPO}"
+        git clone "${BMOREPO}" "${BMOPATH}"
         popd
     fi
     pushd "${BMOPATH}"
@@ -66,7 +66,7 @@ function clone_repos() {
     fi
     if [ ! -d "${CAPBMPATH}" ] ; then
         pushd "${M3PATH}"
-        git clone "${CAPBMREPO}"
+        git clone "${CAPBMREPO}" "${CAPBMPATH}"
         popd
     fi
     pushd "${CAPBMPATH}"


### PR DESCRIPTION
Some forks of the repositories do not have the same name. The
deployment was failing in those cases as it assumes the path
for BMO and CAPBM