### PR TITLE
Make installing openstack/ironic clients optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ bmhosts_crs.yaml
 *.bk
 *.tmp
 clouds.yaml
+_clouds_yaml
 
 *.swp
 ipv6-*/

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -206,3 +206,9 @@ OPENSTACKCLIENT_PATH="${OPENSTACKCLIENT_PATH:-/usr/local/bin/openstack}"
 if ! command -v openstack | grep -v "${OPENSTACKCLIENT_PATH}"; then
   sudo ln -sf "${SCRIPTDIR}/openstackclient.sh" "${OPENSTACKCLIENT_PATH}"
 fi
+
+# Same for the vbmc CLI when not locally installed
+VBMC_PATH="${VBMC_PATH:-/usr/local/bin/vbmc}"
+if ! command -v vbmc | grep -v "${VBMC_PATH}"; then
+  sudo ln -sf "${SCRIPTDIR}/vbmc.sh" "${VBMC_PATH}"
+fi

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -198,3 +198,11 @@ sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name vbmc ${POD_NAM
 sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name sushy-tools ${POD_NAME_INFRA} \
      -v "$WORKING_DIR/virtualbmc/sushy-tools":/root/sushy -v "/root/.ssh":/root/ssh \
      "${SUSHY_TOOLS_IMAGE}"
+
+# Installing the openstack/ironic clients on the host is optional
+# if not installed, we copy a wrapper to OPENSTACKCLIENT_PATH which
+# runs the clients in a container (metal3-io/ironic-client)
+OPENSTACKCLIENT_PATH="${OPENSTACKCLIENT_PATH:-/usr/local/bin/openstack}"
+if ! command -v openstack | grep -v "${OPENSTACKCLIENT_PATH}"; then
+  sudo ln -sf "${SCRIPTDIR}/openstackclient.sh" "${OPENSTACKCLIENT_PATH}"
+fi

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -235,6 +235,9 @@ clone_repos
 #
 function create_clouds_yaml() {
   sed -e "s/__CLUSTER_URL_HOST__/$CLUSTER_URL_HOST/g" clouds.yaml.template > clouds.yaml
+  # To bind this into the ironic-client container we need a directory
+  mkdir -p "${SCRIPTDIR}"/_clouds_yaml
+  cp clouds.yaml "${SCRIPTDIR}"/_clouds_yaml/
 }
 
 create_clouds_yaml

--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -39,23 +39,25 @@ if [[ $DISTRO == "rhel8" ]]; then
 fi
 
 # Install required packages
-# python-{requests,setuptools} required for tripleo-repos install
 sudo yum -y install \
   ansible \
   redhat-lsb-core \
   python3-pip \
   wget
 
-# Install tripleo-repos, used to get a recent version of python-virtualbmc
-sudo dnf -y --repofrompath="current-tripleo,https://trunk.rdoproject.org/${DISTRO}-master/current-tripleo" install "python*-tripleo-repos" --nogpgcheck
-sudo tripleo-repos current-tripleo
+if [[ $DISTRO == "centos7" ]]; then
+  # Install tripleo-repos, used to get a recent version of python-jinja2
+  # which is required for some ansible templates
+  sudo dnf -y --repofrompath="current-tripleo,https://trunk.rdoproject.org/${DISTRO}-master/current-tripleo" install "python*-tripleo-repos" --nogpgcheck
+  sudo tripleo-repos current-tripleo
 
 
-# There are some packages which are newer in the tripleo repos
-# FIXME(stbenjam): On CentOS 7, the version of oniguruma conflicts with
-# the version shipped in the tripleo repos. This needs further
-# investigation.
-sudo yum -y update --exclude=oniguruma
+  # There are some packages which are newer in the tripleo repos
+  # FIXME(stbenjam): On CentOS 7, the version of oniguruma conflicts with
+  # the version shipped in the tripleo repos. This needs further
+  # investigation.
+  sudo yum -y update --exclude=oniguruma
+fi
 
 if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
   sudo yum -y install podman

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -74,6 +74,7 @@ export SUSHY_TOOLS_IMAGE=${SUSHY_TOOLS_IMAGE:-"quay.io/metal3-io/sushy-tools"}
 # Ironic vars
 export IPA_DOWNLOADER_IMAGE=${IPA_DOWNLOADER_IMAGE:-"quay.io/metal3-io/ironic-ipa-downloader"}
 export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic"}
+export IRONIC_CLIENT_IMAGE=${IRONIC_CLIENT_IMAGE:-"quay.io/metal3-io/ironic-client"}
 export IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic-inspector"}
 export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
 export IRONIC_IMAGE_DIR="$IRONIC_DATA_DIR/html/images"

--- a/openstackclient.sh
+++ b/openstackclient.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-source lib/common.sh
+DIR="$(dirname "$(readlink -f "$0")")"
+# shellcheck source=lib/common.sh
+source "${DIR}/lib/common.sh"
 
 sudo "${CONTAINER_RUNTIME}" run -ti --net=host \
   -v "${SCRIPTDIR}/_clouds_yaml/:/etc/openstack" \

--- a/openstackclient.sh
+++ b/openstackclient.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source lib/common.sh
+
+sudo "${CONTAINER_RUNTIME}" run -ti --net=host \
+  -v "${SCRIPTDIR}/_clouds_yaml/:/etc/openstack" \
+  -e OS_CLOUD=metal3 "${IRONIC_CLIENT_IMAGE}" "$@"

--- a/vbmc.sh
+++ b/vbmc.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source lib/common.sh
+
+sudo "${CONTAINER_RUNTIME}" exec -ti vbmc vbmc "$@"

--- a/vbmc.sh
+++ b/vbmc.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-source lib/common.sh
+DIR="$(dirname "$(readlink -f "$0")")"
+# shellcheck source=lib/common.sh
+source "${DIR}/lib/common.sh"
 
 sudo "${CONTAINER_RUNTIME}" exec -ti vbmc vbmc "$@"

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -13,7 +13,6 @@ packages:
      - libvirt-clients
      - libvirt-dev
      - jq
-     - nodejs
      - unzip
      - yarn
      - genisoimage
@@ -30,8 +29,6 @@ packages:
      - virtualbmc
      - lxml
      - netaddr
-     - requests
-     - setuptools
      - libvirt-python
   centos:
     rhel7:
@@ -44,16 +41,12 @@ packages:
          - OVMF
          - patch
          - psmisc
-         - python-pip
-         - python-requests
-         - python-setuptools
          - vim-enhanced
          - wget
          - ansible
          - bind-utils
          - jq
          - libguestfs-tools
-         - nodejs
          - redhat-lsb-core
          - unzip
          - genisoimage
@@ -66,11 +59,9 @@ packages:
          - python-lxml
          - polkit-pkla-compat
          - python-netaddr
-         - python-virtualbmc
          - virt-install
     rhel8:
         packages:
-         - crudini
          - curl
          - dnsmasq
          - edk2-ovmf
@@ -78,16 +69,12 @@ packages:
          - nmap
          - patch
          - psmisc
-         - python3-pip
-         - python3-requests
-         - python3-setuptools
          - vim-enhanced
          - wget
          - ansible
          - bind-utils
          - jq
          - libguestfs-tools
-         - nodejs
          - redhat-lsb-core
          - unzip
          - genisoimage
@@ -100,6 +87,5 @@ packages:
          - python3-lxml
          - polkit-pkla-compat
          - python3-netaddr
-         - python3-virtualbmc
          - virt-install
          - network-scripts

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -28,14 +28,11 @@ packages:
      - lxml
     pip3:
      - virtualbmc
-     - python-ironicclient
-     - python-ironic-inspector-client
      - lxml
      - netaddr
      - requests
      - setuptools
      - libvirt-python
-     - python-openstackclient
   centos:
     rhel7:
         packages:
@@ -57,9 +54,6 @@ packages:
          - jq
          - libguestfs-tools
          - nodejs
-         - python-ironicclient
-         - python-ironic-inspector-client
-         - python-openstackclient
          - redhat-lsb-core
          - unzip
          - genisoimage
@@ -94,9 +88,6 @@ packages:
          - jq
          - libguestfs-tools
          - nodejs
-         - python3-ironicclient
-         - python3-ironic-inspector-client
-         - python3-openstackclient
          - redhat-lsb-core
          - unzip
          - genisoimage

--- a/vm-setup/roles/virtbmc/tasks/teardown_tasks.yml
+++ b/vm-setup/roles/virtbmc/tasks/teardown_tasks.yml
@@ -13,15 +13,6 @@
     - "{{ working_dir }}/virtualbmc"
   become: true
 
-- name: Stop/disable the Virtual BMCs (virtualbmc >= 1.4.0+) on CentOS
-  when:
-    - ansible_os_family == "RedHat"
-  service:
-    name: "virtualbmc"
-    state: "stopped" 
-    enabled: false
-  become: true
-
 - name: Stop/disable the Virtual BMCs (virtualbmc >= 1.4.0+) on Ubuntu
   when:
     - ansible_distribution == 'Ubuntu' 


### PR DESCRIPTION
For RHEL/CentOS this has proven problematic because the RDO repos
aren't always available for a specific release (e.g RHEL7 and
recently CentOS 8 took a while to become available)

We could rely on pip for all platforms, but this can cause
dependency issues with packaged python packages, and typically
can't be used for debugging on a target cluster (whereas a
container image often can).

So this change provides a shell alias and a wrapper script to provide
a backwards compatible interface, but launch the new ironic-client
image instead - testing indicates this is slightly slower but it
should be sufficient for debug usage which is the primary purpose
of the clients in this context.