### PR TITLE
Clean RDO repos on RHEL/CentOS

### DIFF
--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -12,6 +12,10 @@ if selinuxenabled ; then
     sudo sed -i "s/=enforcing/=permissive/g" /etc/selinux/config
 fi
 
+# Remove any previous tripleo-repos to avoid version conflicts
+# (see FIXME re oniguruma below)
+sudo yum -y erase "python*-tripleo-repos"
+
 # Update to latest packages first
 sudo yum -y update
 


### PR DESCRIPTION
We need to clean these or we still hit the dependency issue
fixed for CI in https://github.com/metal3-io/metal3-dev-env/pull/203
when doing e.g `make clean all`

Also see similar fix in https://github.com/openshift-metal3/dev-scripts/pull/923/