### PR TITLE
Replace ipcalc with python script

### DIFF
--- a/lib/network.sh
+++ b/lib/network.sh
@@ -39,7 +39,7 @@ fi
 
 # shellcheck disable=SC2155
 export PROVISIONING_CIDR=$(python -c "import ipaddress; print(ipaddress.ip_network(u\"$PROVISIONING_NETWORK\").prefixlen)")
-export PROVISIONING_NETMASK=${PROVISIONING_NETMASK:-$(ipcalc --netmask "$PROVISIONING_NETWORK" | cut -d= -f2)}
+export PROVISIONING_NETMASK=${PROVISIONING_NETMASK:-$(python -c "import ipaddress; print(ipaddress.ip_network(u\"$PROVISIONING_NETWORK\").netmask)")}
 
 network_address PROVISIONING_IP "$PROVISIONING_NETWORK" 1
 network_address CLUSTER_PROVISIONING_IP "$PROVISIONING_NETWORK" 2

--- a/ubuntu_install_requirements.sh
+++ b/ubuntu_install_requirements.sh
@@ -22,7 +22,6 @@ sudo apt -y install \
   python3-setuptools \
   zlib1g-dev \
   libssl1.0-dev \
-  ipcalc \
   openssh-server \
   wget
 


### PR DESCRIPTION
Fixes: https://github.com/metal3-io/metal3-dev-env/issues/224

Output of `./01_prepare_host.sh`:
```
+++ python -c 'import ipaddress; print(ipaddress.ip_network(u"172.22.0.0/24").netmask)'                                                                                                                            
++ export PROVISIONING_NETMASK=255.255.255.0                                                                                                                                                                       
++ PROVISIONING_NETMASK=255.255.255.0 
```