### PR TITLE
Include tasks to download centos-updated.qcow2 & some Ansible vars modifications

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/provision.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/provision.yml
@@ -20,6 +20,26 @@
 
   - name: Template CentOS machine crs
     block:
+      - name: Verify specific centos image containing newer version of cloud-init is downloaded
+        get_url:
+          url: "{{ IMAGE_LOCATION_CENTOS }}"
+          dest: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME_CENTOS }}"
+          mode: 0664
+
+      - name: Calculate md5sum of the specific image
+        stat:
+         path: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME_CENTOS }}"
+         checksum_algorithm: md5
+        register: centos_md5
+
+      - name: Create the md5sum file
+        copy:
+          content: |
+            {{ centos_md5.stat.checksum }}
+
+          dest: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME_CENTOS }}.md5sum"
+          mode: 0664
+
       - name: Template controlplane_centos.yaml
         template:
           src: "{{ CRS_PATH }}/controlplane_centos.yaml"

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -24,8 +24,9 @@ IMAGE_USERNAME: 'ubuntu'
 IMAGE_URL: "http://172.22.0.1/images/{{ IMAGE_NAME }}"
 IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ IMAGE_NAME }}.md5sum"
 
-IMAGE_NAME_CENTOS: 'CentOS-7-x86_64-GenericCloud-1907.qcow2'
-IMAGE_LOCATION_CENTOS: 'http://cloud.centos.org/centos/7/images'
+IMAGE_NAME_CENTOS: "{{ lookup('env', 'IMAGE_NAME_CENTOS') | default('centos-updated.qcow2', true)}}"
+IMAGE_LOCATION_CENTOS: 'http://artifactory.nordix.org/artifactory/airship/images/centos.qcow2'
 IMAGE_USERNAME_CENTOS: 'centos'
 IMAGE_URL_CENTOS: "http://172.22.0.1/images/{{ IMAGE_NAME_CENTOS }}"
 IMAGE_CHECKSUM_CENTOS: "http://172.22.0.1/images/{{ IMAGE_NAME_CENTOS }}.md5sum"
+IRONIC_IMAGE_DIR: "{{ lookup('env', 'IRONIC_IMAGE_DIR') | default('/opt/metal3-dev-env/ironic/html/images')}}"


### PR DESCRIPTION
Signed-off-by: Alberto Losada <alosadag@redhat.com>

There are two main changes:

1. Ansible variable now includes a lookup for the IMAGE_NAME_CENTOS env var since an specific image with a proper cloud-init version needs to be used as OS for the provisioning process of the new cluster.

`IMAGE_NAME_CENTOS: "{{ lookup('env', 'IMAGE_NAME_CENTOS') | default('centos-updated.qcow2', true)}}"`

I think, the default image for CentOS should be the centos-updated, since it is the only that works when provisioning new clusters.

2. A few tasks have been added in order to verify that the centos-updated.qcow2 image and its md5 hash are available for the new bmh.