### PR TITLE
Add missing 'netplan apply' command in ubuntu CRs

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/templates/controlplane_ubuntu.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/controlplane_ubuntu.yaml
@@ -45,6 +45,7 @@ spec:
     - mv /tmp/akeys /home/ubuntu/.ssh/authorized_keys
     - chown ubuntu:ubuntu /home/ubuntu/.ssh/authorized_keys
     - apt update -y
+    - netplan apply
     - >-
       apt install net-tools gcc linux-headers-$(uname -r) bridge-utils
       apt-transport-https ca-certificates curl gnupg-agent

--- a/vm-setup/roles/v1aX_integration_test/templates/workers_ubuntu.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/workers_ubuntu.yaml
@@ -63,6 +63,7 @@ spec:
         - mv /tmp/akeys /home/ubuntu/.ssh/authorized_keys
         - chown ubuntu:ubuntu /home/ubuntu/.ssh/authorized_keys
         - apt update -y
+        - netplan apply
         - >-
           apt install apt-transport-https ca-certificates
           curl gnupg-agent software-properties-common -y


### PR DESCRIPTION
`netplan apply` command went missing accidentally while re-constructing CR templates. This PR adds the missing command. 