### PR TITLE
use NODES_FILE to manage where the nodes file is written

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -25,6 +25,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "default_memory=$DEFAULT_HOSTS_MEMORY" \
     -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
     -e "provisioning_url_host=$PROVISIONING_URL_HOST" \
+    -e "nodes_file=$NODES_FILE" \
     -i vm-setup/inventory.ini \
     -b -vvv vm-setup/setup-playbook.yml
 

--- a/vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml
@@ -136,4 +136,4 @@
 - name: Write ironic node json files
   template:
     src: ../templates/ironic_nodes.json.j2
-    dest: "{{ working_dir }}/ironic_nodes.json"
+    dest: "{{ nodes_file }}"


### PR DESCRIPTION
We define a NODES_FILE variable but the task used a hard-coded path for
the output file. Use the variable instead.