### PR TITLE
Do not install Docker on CentOS8

### DIFF
--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -59,20 +59,25 @@ fi
 if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
   sudo yum -y install podman
 else
-  sudo yum install -y yum-utils \
-    device-mapper-persistent-data \
-    lvm2
-  sudo yum-config-manager \
-    --add-repo \
-    https://download.docker.com/linux/centos/docker-ce.repo
-    cat <<EOF > daemon.json
+  if [[ $DISTRO == "centos7" ]]; then
+    sudo yum install -y yum-utils \
+      device-mapper-persistent-data \
+      lvm2
+    sudo yum-config-manager \
+      --add-repo \
+      https://download.docker.com/linux/centos/docker-ce.repo
+      cat <<EOF > daemon.json
 {
   "insecure-registries" : ["192.168.111.1:5000"]
 }
 EOF
-  sudo chown root:root daemon.json
-  sudo yum install -y docker-ce docker-ce-cli containerd.io
-  sudo mkdir -p /etc/docker
-  sudo mv daemon.json /etc/docker/daemon.json
-  sudo systemctl restart docker
+    sudo chown root:root daemon.json
+    sudo yum install -y docker-ce docker-ce-cli containerd.io
+    sudo mkdir -p /etc/docker
+    sudo mv daemon.json /etc/docker/daemon.json
+    sudo systemctl restart docker
+  else
+    echo "Only Podman is supported in CentOS/RHEL8"
+    exit 1
+  fi
 fi

--- a/ip_range_check.py
+++ b/ip_range_check.py
@@ -2,8 +2,9 @@
 
 from ipaddress import IPv4Address
 import sys
-dhcp_range=unicode(sys.argv[2]).split(',')
-if IPv4Address(dhcp_range[0]) <= IPv4Address(unicode(sys.argv[1])) <= IPv4Address(dhcp_range[1]):
+import six
+dhcp_range=six.text_type(sys.argv[2]).split(',')
+if IPv4Address(dhcp_range[0]) <= IPv4Address(six.text_type(sys.argv[1])) <= IPv4Address(dhcp_range[1]):
   sys.exit(0)
 else:
   sys.exit(1)

--- a/vm-setup/roles/firewall/tasks/firewalld.yaml
+++ b/vm-setup/roles/firewall/tasks/firewalld.yaml
@@ -9,6 +9,7 @@
     interface: "{{ item }}"
     permanent: yes
     state: enabled
+    immediate: yes
   loop:
     - "{{ provisioning_interface }}"
     - "{{ baremetal_interface }}"
@@ -19,6 +20,7 @@
     port: "{{ item }}/tcp"
     permanent: yes
     state: enabled
+    immediate: yes
   loop: "{{ provisioning_host_ports }}"
 
 - name: "firewalld: Ironic Ports"
@@ -27,6 +29,7 @@
     port: "{{ item }}/tcp"
     permanent: yes
     state: enabled
+    immediate: yes
   loop: "{{ ironic_ports }}"
 
 - name: "firewalld: PXE Ports"
@@ -35,6 +38,7 @@
     port: "{{ item }}/udp"
     permanent: yes
     state: enabled
+    immediate: yes
   loop: "{{ pxe_udp_ports }}"
 
 - name: "firewalld: VBMC Ports"
@@ -43,3 +47,4 @@
     port: "{{ vbmc_port_range | regex_replace(':', '-') }}/udp"
     permanent: yes
     state: enabled
+    immediate: yes

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -24,11 +24,13 @@ packages:
     pip: # ansible uses these packages in python2 to run on the local machine
      - libvirt-python==5.10.0
      - lxml
+     - six
     pip3:
      - virtualbmc
      - lxml
      - netaddr
      - libvirt-python
+     - six
   centos:
     rhel7:
         packages:
@@ -58,6 +60,7 @@ packages:
          - polkit-pkla-compat
          - python-netaddr
          - virt-install
+         - python-six
     rhel8:
         packages:
          - curl
@@ -87,3 +90,5 @@ packages:
          - python3-netaddr
          - virt-install
          - network-scripts
+         - firewalld
+         - python3-six

--- a/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
+++ b/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
@@ -75,7 +75,7 @@
       password = password
       domain_name = {{ item.name }}
       libvirt_uri = {{ vbmc_libvirt_uri }}
-      address = ::
+      address = {{ baremetal_network_cidr|nthhost(1) }}
       active = True
       port = {{ item.virtualbmc_port }}
   with_items: "{{ vm_nodes }}"


### PR DESCRIPTION
Currently docker installation fails in CentOS8 with 
```
Error: 
 Problem: package docker-ce-3:19.03.6-3.el7.x86_64 requires containerd.io >= 1.2.2-3, but none of the providers can be installed
  - cannot install the best candidate for the job
  - package containerd.io-1.2.10-3.2.el7.x86_64 is excluded
  - package containerd.io-1.2.2-3.3.el7.x86_64 is excluded
  - package containerd.io-1.2.2-3.el7.x86_64 is excluded
  - package containerd.io-1.2.4-3.1.el7.x86_64 is excluded
  - package containerd.io-1.2.5-3.1.el7.x86_64 is excluded
  - package containerd.io-1.2.6-3.3.el7.x86_64 is excluded
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
make: *** [Makefile:4: install_requirements] Error 1
```
Since Docker is not supported in CentOS8, this PR adds a failure message instead of installing Docker in CentOS8 only