### PR TITLE
Allow customization of hostnames for nodes

### DIFF
--- a/vm-setup/roles/libvirt/templates/network.xml.j2
+++ b/vm-setup/roles/libvirt/templates/network.xml.j2
@@ -37,10 +37,12 @@
 {% set numflavor = lookup('vars', 'num_' + flavor + 's')|default(0)|int %}
 {% for num in range(0, numflavor) %}
 {% set ironic_name = ironic_prefix + flavor + "_" + num|string %}
+{% set hostname_format = lookup('vars', flavor + '_hostname_format', default=flavor + '-%d') %}
+{% set hostname = hostname_format % num %}
 {% if item.address|ipv6 != False %}
-      <host id='00:03:00:01:{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{flavor}}-{{num}}' ip='{{item.dhcp_range[0]|ipmath(ns.index|int)}}'/>
+      <host id='00:03:00:01:{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}' ip='{{item.dhcp_range[0]|ipmath(ns.index|int)}}'/>
 {% else %}
-      <host mac='{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{flavor}}-{{num}}' ip='{{item.dhcp_range[0]|ipmath(ns.index|int)}}'/>
+      <host mac='{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}' ip='{{item.dhcp_range[0]|ipmath(ns.index|int)}}'/>
 {% endif %}
 {% set ns.index = ns.index + 1 %}
 {% endfor %}


### PR DESCRIPTION
The master-X hostname format came out of an OpenShift requirement
for etcd bootstrapping. We're making changes to eliminate that
requirement and it is desirable to be able to test those changes in
a virtual environment such as metal3-dev-env. This change allows
arbitrary formats for the hostnames of the defined flavors.

The way it works is that the user sets an Ansible variable named
{{flavor}}_hostname_format. This is a format string with exactly one
placeholder. The placeholder will be formatted with the number of
the node and that will become the node's hostname.

For example, if the master_hostname_format is set to "foo%sbar", the
resulting hostnames will be foo0bar, foo1bar, etc.