### PR TITLE
Add validation to ignore 404 when object is not found

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/deprovision_cluster.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/deprovision_cluster.yml
@@ -13,4 +13,5 @@
       state: absent
       src: "/tmp/cluster.yaml"
       namespace: "{{ NAMESPACE }}"
+    ignore_errors: yes
     register: deprovision_cluster

--- a/vm-setup/roles/v1aX_integration_test/tasks/deprovision_controlplane.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/deprovision_controlplane.yml
@@ -3,7 +3,7 @@
     set_fact:
       ansible_python_interpreter: /usr/bin/python3
 
-  - name: Provision Ubuntu based controlplane node
+  - name: Deprovision Ubuntu based controlplane node
     block:
       - name: Template controlplane_ubuntu.yaml
         template:
@@ -15,10 +15,11 @@
           state: absent
           src: "/tmp/controlplane_ubuntu.yaml"
           namespace: "{{ NAMESPACE }}"
+        ignore_errors: yes
         register: deprovision_ubuntu_master_node
     when: IMAGE_OS == "Ubuntu"
 
-  - name: Provision CentOS based controlplane node
+  - name: Deprovision CentOS based controlplane node
     block:
       - name: Template controlplane_centos.yaml
         template:
@@ -34,6 +35,7 @@
           state: absent
           src: "/tmp/controlplane_centos.yaml"
           namespace: "{{ NAMESPACE }}"
+        ignore_errors: yes
         register: deprovision_centos_master_node
     when: (IMAGE_OS == "Centos") or
           (IMAGE_OS == "")

--- a/vm-setup/roles/v1aX_integration_test/tasks/deprovision_worker.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/deprovision_worker.yml
@@ -3,7 +3,7 @@
     set_fact:
       ansible_python_interpreter: /usr/bin/python3
 
-  - name: Provision Ubuntu based worker node
+  - name: Deprovision Ubuntu based worker node
     block:
       - name: Template workers_ubuntu.yaml
         template:
@@ -15,10 +15,11 @@
           state: absent
           src: "/tmp/workers_ubuntu.yaml"
           namespace: "{{ NAMESPACE }}"
+        ignore_errors: yes
         register: deprovision_ubuntu_worker_node
     when: IMAGE_OS == "Ubuntu"
 
-  - name: Provision CentOS based worker node
+  - name: Deprovision CentOS based worker node
     block:
       - name: Template workers_centos.yaml
         template:
@@ -34,6 +35,7 @@
           state: absent
           src: "/tmp/workers_centos.yaml"
           namespace: "{{ NAMESPACE }}"
+        ignore_errors: yes
         register: deprovision_centos_worker_node
     when: (IMAGE_OS == "Centos") or
           (IMAGE_OS == "")


### PR DESCRIPTION
Sometimes integration CI fails while trying to deprovision controlplane machine after deprovisioning the worker machine. This patchset forces the deprovisioning task to ignore the failures so that CI doesn't fail in case `"404"` or  `"Not Found" `received.
```
fatal: [localhost]: FAILED! => {
    "changed": false,
    "error": 404,
    "invocation": {
        "module_args": {
            "api_key": null,
            "api_version": "v1",
            "append_hash": false,
            "apply": false,
            "ca_cert": null,
            "client_cert": null,
            "client_key": null,
            "context": null,
            "force": false,
            "host": null,
            "kind": null,
            "kubeconfig": null,
            "merge_type": null,
            "name": null,
            "namespace": "metal3",
            "password": null,
            "proxy": null,
            "resource_definition": null,
            "src": "/tmp/controlplane_ubuntu.yaml",
            "state": "absent",
            "username": null,
            "validate": null,
            "validate_certs": null,
            "wait": false,
            "wait_condition": null,
            "wait_sleep": 5,
            "wait_timeout": 120
        }
    },
    "msg": "Failed to delete object: b'{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"kubeadmconfigs.bootstrap.cluster.x-k8s.io \\\\\"test1-controlplane-0\\\\\" not found\",\"reason\":\"NotFound\",\"details\":{\"name\":\"test1-controlplane-0\",\"group\":\"bootstrap.cluster.x-k8s.io\",\"kind\":\"kubeadmconfigs\"},\"code\":404}\\n'",
    "reason": "Not Found",
    "status": 404
```