### PR TITLE
Wire in hostname configuration option

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -26,6 +26,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
     -e "provisioning_url_host=$PROVISIONING_URL_HOST" \
     -e "nodes_file=$NODES_FILE" \
+    -e "node_hostname_format=$NODE_HOSTNAME_FORMAT" \
     -i vm-setup/inventory.ini \
     -b -vvv vm-setup/setup-playbook.yml
 

--- a/config_example.sh
+++ b/config_example.sh
@@ -125,3 +125,8 @@
 
 # POD CIDR
 # export POD_CIDR=${POD_CIDR:-"192.168.0.0/18"
+
+# Node hostname format. This is a format string that must contain exactly one
+# %d format field that will be replaced with an integer representing the number
+# of the node.
+# export NODE_HOSTNAME_FORMAT="node-%d"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -38,6 +38,8 @@ INT_IF=${INT_IF:-}
 ROOT_DISK_NAME=${ROOT_DISK_NAME-"/dev/sda"}
 #Container runtime
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"podman"}
+# Hostname format
+NODE_HOSTNAME_FORMAT=${NODE_HOSTNAME_FORMAT:-"node-%d"}
 
 if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
   export POD_NAME="--pod ironic-pod"


### PR DESCRIPTION
A variable to allow configuring the hostnames of the Ironic nodes was added in #234. This wires it into the sample config file so it is easier to consume and document.