### PR TITLE
Remove python interpeter switching tasks in Ansible

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/deprovision_cluster.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/deprovision_cluster.yml
@@ -1,8 +1,4 @@
 ---
-  - name: Switch Ansible's Python interpreter to Python 3
-    set_fact:
-      ansible_python_interpreter: /usr/bin/python3
-
   - name: Template cluster.yaml
     template:
       src: "{{ CRS_PATH }}/cluster.yaml"

--- a/vm-setup/roles/v1aX_integration_test/tasks/deprovision_controlplane.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/deprovision_controlplane.yml
@@ -1,8 +1,4 @@
 ---
-  - name: Switch Ansible's Python interpreter to Python 3
-    set_fact:
-      ansible_python_interpreter: /usr/bin/python3
-
   - name: Deprovision Ubuntu based controlplane node
     block:
       - name: Template controlplane_ubuntu.yaml

--- a/vm-setup/roles/v1aX_integration_test/tasks/deprovision_worker.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/deprovision_worker.yml
@@ -1,8 +1,4 @@
 ---
-  - name: Switch Ansible's Python interpreter to Python 3
-    set_fact:
-      ansible_python_interpreter: /usr/bin/python3
-
   - name: Deprovision Ubuntu based worker node
     block:
       - name: Template workers_ubuntu.yaml

--- a/vm-setup/roles/v1aX_integration_test/tasks/provision_cluster.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/provision_cluster.yml
@@ -14,10 +14,6 @@
       src: "{{ CRS_PATH }}/cluster.yaml"
       dest: "/tmp/cluster.yaml"
 
-  - name: Switch Ansible's Python interpreter to Python 3
-    set_fact:
-      ansible_python_interpreter: /usr/bin/python3
-
   - name: Provision cluster
     k8s:
       state: present

--- a/vm-setup/roles/v1aX_integration_test/tasks/provision_controlplane.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/provision_controlplane.yml
@@ -1,9 +1,5 @@
 ---
 # Provision cluster & master node
-  - name: Switch Ansible's Python interpreter to Python 3
-    set_fact:
-      ansible_python_interpreter: /usr/bin/python3
-
   - name: Provision Ubuntu based controlplane node
     block:
       - name: Template controlplane_ubuntu.yaml

--- a/vm-setup/roles/v1aX_integration_test/tasks/provision_worker.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/provision_worker.yml
@@ -1,9 +1,5 @@
 ---
 # Provision worker node
-  - name: Switch Ansible's Python interpreter to Python 3
-    set_fact:
-      ansible_python_interpreter: /usr/bin/python3
-
   - name: Provision Ubuntu based worker node
     block:
       - name: Template workers_ubuntu.yaml

--- a/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
@@ -91,8 +91,6 @@
           state: present
           src: "/tmp/calico.yaml"
           namespace: "{{ NAMESPACE }}"
-        environment:
-          ansible_python_interpreter: /usr/bin/python3
         register: install_cni
 
       # Check for pods & nodes on the target cluster


### PR DESCRIPTION
Some of the playbooks have a task to explicitly configure a Python 3 interpreter. 
This was needed when Python 2 was in use in metal3-dev-env, which is not the case anymore after moving all the scripts to use Python 3.