### PR TITLE
Use RDO packages when installing virtualbmc

### DIFF
--- a/resources/vbmc/Dockerfile
+++ b/resources/vbmc/Dockerfile
@@ -1,7 +1,10 @@
-FROM registry.hub.docker.com/library/python:3.7
+FROM docker.io/centos:centos8
 
-RUN apt update && \
-    apt install -y libvirt-dev && \
-    pip3 install virtualbmc
+RUN dnf install -y python3 python3-requests && \
+    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current && \
+    dnf update -y && \
+    dnf install -y python3-virtualbmc && \
+    dnf clean all && \
+    rm -rf /var/cache/{yum,dnf}/*
 
-CMD /usr/local/bin/vbmcd --foreground
+CMD /usr/bin/vbmcd --foreground


### PR DESCRIPTION
Packages are safer since they pass CI testing, avoiding issues like
https://bugs.launchpad.net/pyghmi/+bug/1865987 that affects us now.
    
This change brings the virtualbmc image in sync with how ironic
images are built and also potentially reduces its size because
the development packages are no longer installed.
