### PR TITLE
Update dev-env with new CAPM3 repo

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -28,20 +28,23 @@ export GOPATH
 M3PATH="${GOPATH}/src/github.com/metal3-io"
 BMOPATH="${M3PATH}/baremetal-operator"
 RUN_LOCAL_IRONIC_SCRIPT="${BMOPATH}/tools/run_local_ironic.sh"
-CAPM3PATH="${M3PATH}/cluster-api-provider-baremetal"
-
-BMOREPO="${BMOREPO:-https://github.com/metal3-io/baremetal-operator.git}"
-BMOBRANCH="${BMOBRANCH:-master}"
-CAPM3REPO="${CAPM3REPO:-https://github.com/metal3-io/cluster-api-provider-baremetal.git}"
+CAPM3PATH="${M3PATH}/cluster-api-provider-metal3"
 
 if [ "${CAPI_VERSION}" == "v1alpha3" ]; then
   CAPM3BRANCH="${CAPM3BRANCH:-master}"
+  CAPM3REPO="${CAPM3REPO:-https://github.com/metal3-io/cluster-api-provider-metal3.git}"
 elif [ "${CAPI_VERSION}" == "v1alpha2" ]; then
+  CAPM3PATH="${M3PATH}/cluster-api-provider-baremetal"
   CAPM3BRANCH="${CAPM3BRANCH:-release-0.2}"
+  CAPM3REPO="${CAPM3REPO:-https://github.com/metal3-io/cluster-api-provider-baremetal.git}"
 elif [ "${CAPI_VERSION}" == "v1alpha1" ]; then
+  CAPM3PATH="${M3PATH}/cluster-api-provider-baremetal"
   CAPM3BRANCH="${CAPM3BRANCH:-v1alpha1}"
+  CAPM3REPO="${CAPM3REPO:-https://github.com/metal3-io/cluster-api-provider-baremetal.git}"
 fi
 
+BMOREPO="${BMOREPO:-https://github.com/metal3-io/baremetal-operator.git}"
+BMOBRANCH="${BMOBRANCH:-master}"
 FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-false}"
 
 BMO_RUN_LOCAL="${BMO_RUN_LOCAL:-false}"

--- a/config_example.sh
+++ b/config_example.sh
@@ -82,9 +82,9 @@
 
 # Select the Cluster API version
 # Accepted values : v1alpha1 v1alpha2 v1alpha3
-# default: v1alpha1
+# default: v1alpha3
 #
-#export CAPI_VERSION=v1alpha1
+#export CAPI_VERSION=v1alpha3
 
 # Configure provisioning network for single-stack ipv6
 #PROVISIONING_IPV6=false

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -86,7 +86,7 @@ export BAREMETAL_OPERATOR_IMAGE=${BAREMETAL_OPERATOR_IMAGE:-"quay.io/metal3-io/b
 export OPENSTACK_CONFIG=$HOME/.config/openstack/clouds.yaml
 
 # CAPI version
-export CAPI_VERSION=${CAPI_VERSION:-"v1alpha1"}
+export CAPI_VERSION=${CAPI_VERSION:-"v1alpha3"}
 
 # CAPM3 controller image
 if [ "${CAPI_VERSION}" == "v1alpha1" ]; then

--- a/vm-setup/roles/v1aX_integration_test/templates/cluster.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster.yaml
@@ -12,9 +12,11 @@ spec:
     serviceDomain: "cluster.local"
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
+{% if CAPI_VERSION == 'v1alpha2' %}
     kind: BareMetalCluster
+{% else %}
+    kind: Metal3Cluster
     name: {{ CLUSTER_NAME }}
-{% if CAPI_VERSION == 'v1alpha3' %}
   controlPlaneRef:
     kind: KubeadmControlPlane
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
@@ -22,7 +24,11 @@ spec:
 {% endif %}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
+{% if CAPI_VERSION == 'v1alpha2' %}
 kind: BareMetalCluster
+{% else %}
+kind: Metal3Cluster
+{% endif %}
 metadata:
   name: {{ CLUSTER_NAME }}
 spec:

--- a/vm-setup/roles/v1aX_integration_test/templates/controlplane_centos.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/controlplane_centos.yaml
@@ -7,7 +7,7 @@ spec:
   replicas: 1
   version: {{ KUBERNETES_VERSION }}
   infrastructureTemplate:
-    kind: BareMetalMachineTemplate
+    kind: Metal3MachineTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     name: {{ CLUSTER_NAME }}-controlplane
   kubeadmConfigSpec:
@@ -89,7 +89,7 @@ spec:
         content: {{ SSH_PUB_KEY_CONTENT }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: BareMetalMachineTemplate
+kind: Metal3MachineTemplate
 metadata:
   name: {{ CLUSTER_NAME }}-controlplane
 spec:
@@ -119,11 +119,19 @@ spec:
       name: {{ CLUSTER_NAME }}-controlplane-0
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
+{% if CAPI_VERSION == 'v1alpha2' %}
     kind: BareMetalMachine
+{% else %}
+    kind: Metal3Machine
+{% endif %}
     name: {{ CLUSTER_NAME }}-controlplane-0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
+{% if CAPI_VERSION == 'v1alpha2' %}
 kind: BareMetalMachine
+{% else %}
+kind: Metal3Machine
+{% endif %}
 metadata:
   name: {{ CLUSTER_NAME }}-controlplane-0
 spec:

--- a/vm-setup/roles/v1aX_integration_test/templates/controlplane_ubuntu.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/controlplane_ubuntu.yaml
@@ -7,7 +7,7 @@ spec:
   replicas: 1
   version: {{ KUBERNETES_VERSION }}
   infrastructureTemplate:
-    kind: BareMetalMachineTemplate
+    kind: Metal3MachineTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     name: {{ CLUSTER_NAME }}-controlplane
   kubeadmConfigSpec:
@@ -98,7 +98,7 @@ spec:
 
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: BareMetalMachineTemplate
+kind: Metal3MachineTemplate
 metadata:
   name: {{ CLUSTER_NAME }}-controlplane
 spec:
@@ -128,11 +128,19 @@ spec:
       name: {{ CLUSTER_NAME }}-controlplane-0
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
+{% if CAPI_VERSION == 'v1alpha2' %}
     kind: BareMetalMachine
+{% else %}
+    kind: Metal3Machine
+{% endif %}
     name: {{ CLUSTER_NAME }}-controlplane-0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
+{% if CAPI_VERSION == 'v1alpha2' %}
 kind: BareMetalMachine
+{% else %}
+kind: Metal3Machine
+{% endif %}
 metadata:
   name: {{ CLUSTER_NAME }}-controlplane-0
 spec:

--- a/vm-setup/roles/v1aX_integration_test/templates/workers_centos.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/workers_centos.yaml
@@ -32,10 +32,18 @@ spec:
       infrastructureRef:
         name: {{ CLUSTER_NAME }}-md-0
         apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
+{% if CAPI_VERSION == 'v1alpha2' %}
         kind: BareMetalMachineTemplate
+{% else %}
+        kind: Metal3MachineTemplate
+{% endif %}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
+{% if CAPI_VERSION == 'v1alpha2' %}
 kind: BareMetalMachineTemplate
+{% else %}
+kind: Metal3MachineTemplate
+{% endif %}
 metadata:
   name: {{ CLUSTER_NAME }}-md-0
 spec:

--- a/vm-setup/roles/v1aX_integration_test/templates/workers_ubuntu.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/workers_ubuntu.yaml
@@ -32,10 +32,18 @@ spec:
       infrastructureRef:
         name: {{ CLUSTER_NAME }}-md-0
         apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
+{% if CAPI_VERSION == 'v1alpha2' %}
         kind: BareMetalMachineTemplate
+{% else %}
+        kind: Metal3MachineTemplate
+{% endif %}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
+{% if CAPI_VERSION == 'v1alpha2' %}
 kind: BareMetalMachineTemplate
+{% else %}
+kind: Metal3MachineTemplate
+{% endif %}
 metadata:
   name: {{ CLUSTER_NAME }}-md-0
 spec:


### PR DESCRIPTION
A new repo https://github.com/metal3-io/cluster-api-provider-metal3 is created and this patch 
- updates variables to clone CAPM3 in case CAPI_VERSION=v1alpha3
- fixes [#200](https://github.com/metal3-io/metal3-dev-env/issues/200)
- updates kinds in CR templates