### PR TITLE
Add CAPM3 v1alpha4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Build Status
 [![CentOS V1alpha2 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a2_integration_test_centos/badge/icon?subject=CentOS%20E2E%20V1alpha2)](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a2_integration_test_centos)
 [![Ubuntu V1alpha3 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a3_integration_test_ubuntu/badge/icon?subject=Ubuntu%20E2E%20V1alpha3)](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a3_integration_test_ubuntu)
 [![CentOS V1alpha3 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a3_integration_test_centos/badge/icon?subject=CentOS%20E2E%20V1alpha3)](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a3_integration_test_centos)
+[![Ubuntu V1alpha4 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a4_integration_test_ubuntu/badge/icon?subject=Ubuntu%20E2E%20V1alpha4)](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a4_integration_test_ubuntu)
+[![CentOS V1alpha4 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a4_integration_test_centos/badge/icon?subject=CentOS%20E2E%20V1alpha4)](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a4_integration_test_centos)
 
 Instructions
 ------------

--- a/README_v1alphaX.md
+++ b/README_v1alphaX.md
@@ -1,6 +1,6 @@
-# v1alpha2 and v1alpha3 deployment
+# v1alpha2, v1alpha3 or v1alpha4 deployment
 
-Versions v1alpha2 and v1alpha3, later referred as **v1alphaX**.
+Versions v1alpha2, v1alpha3 or v1alpha4 are later referred as **v1alphaX**.
 
 The v1alphaX deployment can be done with Ubuntu 18.04 or Centos 7 target host
 images.
@@ -35,6 +35,12 @@ or
 
 ```sh
 export CAPI_VERSION=v1alpha3
+```
+
+or
+
+```sh
+export CAPI_VERSION=v1alpha4
 ```
 
 The following environment variables need to be set for **Centos**:

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -3,12 +3,13 @@
 set -eux
 
 IS_CONTAINER=${IS_CONTAINER:-false}
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
   TOP_DIR="${1:-.}"
   mdl --style all --warnings "${TOP_DIR}"
 else
-  podman run --rm \
+  "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -3,13 +3,14 @@
 set -eux
 
 IS_CONTAINER=${IS_CONTAINER:-false}
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
   TOP_DIR="${1:-.}"
   find "${TOP_DIR}" \
     -type f -name '*.sh' -exec shellcheck -s bash {} \+
 else
-  podman run --rm \
+  "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -87,12 +87,20 @@ export OPENSTACK_CONFIG=$HOME/.config/openstack/clouds.yaml
 
 # CAPI version
 export CAPI_VERSION=${CAPI_VERSION:-"v1alpha3"}
+CAPI_VERSION_LIST="v1alpha1 v1alpha2 v1alpha3 v1alpha4"
+echo "${CAPI_VERSION_LIST}" | grep -w "${CAPI_VERSION}"
+if $?; then
+  echo "Invalid CAPI version : ${CAPI_VERSION}. Not in : ${CAPI_VERSION_LIST}"
+  exit 1
+fi
 
 # CAPM3 controller image
 if [ "${CAPI_VERSION}" == "v1alpha1" ]; then
   export CAPM3_IMAGE=${CAPM3_IMAGE:-"quay.io/metal3-io/cluster-api-provider-baremetal:v1alpha1"}
 elif [ "${CAPI_VERSION}" == "v1alpha2" ]; then
   export CAPM3_IMAGE=${CAPM3_IMAGE:-"quay.io/metal3-io/cluster-api-provider-baremetal:release-0.2"}
+elif [ "${CAPI_VERSION}" == "v1alpha3" ]; then
+  export CAPM3_IMAGE=${CAPM3_IMAGE:-"quay.io/metal3-io/cluster-api-provider-metal3:release-0.3"}
 else
   export CAPM3_IMAGE=${CAPM3_IMAGE:-"quay.io/metal3-io/cluster-api-provider-metal3:master"}
 fi
@@ -104,16 +112,6 @@ export DEFAULT_HOSTS_MEMORY=${DEFAULT_HOSTS_MEMORY:-8192}
 export CLUSTER_NAME=${CLUSTER_NAME:-"test1"}
 export CLUSTER_APIENDPOINT_IP=${CLUSTER_APIENDPOINT_IP:-"192.168.111.249"}
 export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.17.0"}
-
-#Path to CRs
-export V1ALPHA2_CR_PATH=${SCRIPTDIR}/crs/v1alpha2/
-export V1ALPHA3_CR_PATH=${SCRIPTDIR}/crs/v1alpha3/
-
-if [ "${CAPI_VERSION}" == "v1alpha3" ]; then
-  export V1ALPHAX_CR_PATH=${V1ALPHA3_CR_PATH}
-else
-  export V1ALPHAX_CR_PATH=${V1ALPHA2_CR_PATH}
-fi
 
 #Kustomize version
 export KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-"v3.2.3"}

--- a/vm-setup/roles/v1aX_integration_test/templates/cluster.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster.yaml
@@ -1,5 +1,9 @@
 ---
+{% if CAPI_VERSION == 'v1alpha2' %}
 apiVersion: cluster.x-k8s.io/{{ CAPI_VERSION }}
+{% else %}
+apiVersion: cluster.x-k8s.io/v1alpha3
+{% endif %}
 kind: Cluster
 metadata:
   name: {{ CLUSTER_NAME }}
@@ -33,11 +37,11 @@ kind: Metal3Cluster
 metadata:
   name: {{ CLUSTER_NAME }}
 spec:
-{% if CAPI_VERSION == 'v1alpha3' %}
+{% if CAPI_VERSION == 'v1alpha2' %}
+  apiEndpoint: http://{{ CLUSTER_APIENDPOINT_HOST }}:6443
+{% else %}
   controlPlaneEndpoint:
     host: {{ CLUSTER_APIENDPOINT_HOST }}
     port: 6443
-{% else %}
-  apiEndpoint: http://{{ CLUSTER_APIENDPOINT_HOST }}:6443
 {% endif %}
   noCloudProvider: true

--- a/vm-setup/roles/v1aX_integration_test/templates/controlplane_centos.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/controlplane_centos.yaml
@@ -37,6 +37,11 @@ spec:
       name: {{ " '{{ ds.meta_data.name }}' " }}
       kubeletExtraArgs:
         node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+  joinConfiguration:
+    nodeRegistration:
+      name: {{ " '{{ ds.meta_data.name }}' " }}
+      kubeletExtraArgs:
+        node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
   preKubeadmCommands:
     - ifup eth1
     - yum update -y
@@ -116,7 +121,6 @@ spec:
     name: {{ CLUSTER_NAME }}-controlplane
   kubeadmConfigSpec:
     joinConfiguration:
-      controlPlane: {}
       nodeRegistration:
         name: {{ " '{{ ds.meta_data.name }}' " }}
         kubeletExtraArgs:
@@ -126,6 +130,9 @@ spec:
         name: {{ " '{{ ds.meta_data.name }}' " }}
         kubeletExtraArgs:
           node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
     preKubeadmCommands:
       - ifup eth1
       - yum update -y

--- a/vm-setup/roles/v1aX_integration_test/templates/controlplane_centos.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/controlplane_centos.yaml
@@ -1,6 +1,110 @@
-{% if CAPI_VERSION == 'v1alpha3' %}
+{% if CAPI_VERSION == 'v1alpha2' %}
+apiVersion: cluster.x-k8s.io/v1alpha2
+kind: Machine
+metadata:
+  name: {{ CLUSTER_NAME }}-controlplane-0
+  labels:
+    cluster.x-k8s.io/control-plane: "true"
+    cluster.x-k8s.io/cluster-name: "{{ CLUSTER_NAME }}"
+spec:
+  version: {{ KUBERNETES_VERSION }}
+  bootstrap:
+    configRef:
+      apiVersion: bootstrap.cluster.x-k8s.io/{{ CAPI_VERSION }}
+      kind: KubeadmConfig
+      name: {{ CLUSTER_NAME }}-controlplane-0
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
+    kind: BareMetalMachine
+    name: {{ CLUSTER_NAME }}-controlplane-0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: BareMetalMachine
+metadata:
+  name: {{ CLUSTER_NAME }}-controlplane-0
+spec:
+  image:
+    url: {{ IMAGE_URL }}
+    checksum: {{ IMAGE_CHECKSUM }}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: KubeadmConfig
+metadata:
+  name: {{ CLUSTER_NAME }}-controlplane-0
+spec:
+  initConfiguration:
+    nodeRegistration:
+      name: {{ " '{{ ds.meta_data.name }}' " }}
+      kubeletExtraArgs:
+        node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+  preKubeadmCommands:
+    - ifup eth1
+    - yum update -y
+    - yum install yum-utils -y
+    - yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    - setenforce 0
+    - sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
+    - >-
+      yum install gcc kernel-headers kernel-devel keepalived
+      device-mapper-persistent-data lvm2
+      docker-ce-18.09.9 docker-ce-cli-18.09.9 containerd.io
+      kubelet kubeadm kubectl --disableexcludes=kubernetes -y
+    - usermod -aG docker centos
+    - systemctl enable --now docker keepalived kubelet
+  postKubeadmCommands:
+    - mkdir -p /home/centos/.kube
+    - cp /etc/kubernetes/admin.conf /home/centos/.kube/config
+    - chown centos:centos /home/centos/.kube/config
+  files:
+    - path: /etc/keepalived/keepalived.conf
+      content: |
+        ! Configuration File for keepalived
+        global_defs {
+            notification_email {
+            sysadmin@example.com
+            support@example.com
+            }
+            notification_email_from lb@example.com
+            smtp_server localhost
+            smtp_connect_timeout 30
+        }
+        vrrp_instance VI_1 {
+            state MASTER
+            interface eth1
+            virtual_router_id 1
+            priority 101
+            advert_int 1
+            virtual_ipaddress {
+                {{ CLUSTER_APIENDPOINT_HOST }}
+            }
+        }
+    - path: /etc/sysconfig/network-scripts/ifcfg-eth1
+      owner: root:root
+      permissions: '0644'
+      content: |
+        BOOTPROTO=dhcp
+        DEVICE=eth1
+        ONBOOT=yes
+        TYPE=Ethernet
+        USERCTL=no
+    - path: /etc/yum.repos.d/kubernetes.repo
+      owner: root:root
+      permissions: '0644'
+      content: |
+        [kubernetes]
+        name=Kubernetes
+        baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+        enabled=1
+        gpgcheck=1
+        repo_gpgcheck=0
+        gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+    - path: /home/centos/.ssh/authorized_keys
+      owner: centos:centos
+      permissions: '0600'
+      content: {{ SSH_PUB_KEY_CONTENT }}
+{% else %}
 kind: KubeadmControlPlane
-apiVersion: controlplane.cluster.x-k8s.io/{{ CAPI_VERSION }}
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 metadata:
   name: {{ CLUSTER_NAME }}-controlplane
 spec:
@@ -8,7 +112,7 @@ spec:
   version: {{ KUBERNETES_VERSION }}
   infrastructureTemplate:
     kind: Metal3MachineTemplate
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
     name: {{ CLUSTER_NAME }}-controlplane
   kubeadmConfigSpec:
     joinConfiguration:
@@ -88,7 +192,7 @@ spec:
         permissions: '0600'
         content: {{ SSH_PUB_KEY_CONTENT }}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
 kind: Metal3MachineTemplate
 metadata:
   name: {{ CLUSTER_NAME }}-controlplane
@@ -98,120 +202,4 @@ spec:
       image:
         url: {{ IMAGE_URL }}
         checksum: {{ IMAGE_CHECKSUM }}
-{% endif %}
-{% if CAPI_VERSION == 'v1alpha2' %}
-apiVersion: cluster.x-k8s.io/{{ CAPI_VERSION }}
-kind: Machine
-metadata:
-  name: {{ CLUSTER_NAME }}-controlplane-0
-  labels:
-    cluster.x-k8s.io/control-plane: "true"
-    cluster.x-k8s.io/cluster-name: "{{ CLUSTER_NAME }}"
-spec:
-{% if CAPI_VERSION == 'v1alpha3' %}
-  clusterName: {{ CLUSTER_NAME }}
-{% endif %}
-  version: {{ KUBERNETES_VERSION }}
-  bootstrap:
-    configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/{{ CAPI_VERSION }}
-      kind: KubeadmConfig
-      name: {{ CLUSTER_NAME }}-controlplane-0
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
-{% if CAPI_VERSION == 'v1alpha2' %}
-    kind: BareMetalMachine
-{% else %}
-    kind: Metal3Machine
-{% endif %}
-    name: {{ CLUSTER_NAME }}-controlplane-0
----
-apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
-{% if CAPI_VERSION == 'v1alpha2' %}
-kind: BareMetalMachine
-{% else %}
-kind: Metal3Machine
-{% endif %}
-metadata:
-  name: {{ CLUSTER_NAME }}-controlplane-0
-spec:
-  image:
-    url: {{ IMAGE_URL }}
-    checksum: {{ IMAGE_CHECKSUM }}
----
-apiVersion: bootstrap.cluster.x-k8s.io/{{ CAPI_VERSION }}
-kind: KubeadmConfig
-metadata:
-  name: {{ CLUSTER_NAME }}-controlplane-0
-spec:
-  initConfiguration:
-    nodeRegistration:
-      name: {{ " '{{ ds.meta_data.name }}' " }}
-      kubeletExtraArgs:
-        node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
-  preKubeadmCommands:
-    - ifup eth1
-    - yum update -y
-    - yum install yum-utils -y
-    - yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-    - setenforce 0
-    - sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
-    - >-
-      yum install gcc kernel-headers kernel-devel keepalived
-      device-mapper-persistent-data lvm2
-      docker-ce-18.09.9 docker-ce-cli-18.09.9 containerd.io
-      kubelet kubeadm kubectl --disableexcludes=kubernetes -y
-    - usermod -aG docker centos
-    - systemctl enable --now docker keepalived kubelet
-  postKubeadmCommands:
-    - mkdir -p /home/centos/.kube
-    - cp /etc/kubernetes/admin.conf /home/centos/.kube/config
-    - chown centos:centos /home/centos/.kube/config
-  files:
-    - path: /etc/keepalived/keepalived.conf
-      content: |
-        ! Configuration File for keepalived
-        global_defs {
-            notification_email {
-            sysadmin@example.com
-            support@example.com
-            }
-            notification_email_from lb@example.com
-            smtp_server localhost
-            smtp_connect_timeout 30
-        }
-        vrrp_instance VI_1 {
-            state MASTER
-            interface eth1
-            virtual_router_id 1
-            priority 101
-            advert_int 1
-            virtual_ipaddress {
-                {{ CLUSTER_APIENDPOINT_HOST }}
-            }
-        }
-    - path: /etc/sysconfig/network-scripts/ifcfg-eth1
-      owner: root:root
-      permissions: '0644'
-      content: |
-        BOOTPROTO=dhcp
-        DEVICE=eth1
-        ONBOOT=yes
-        TYPE=Ethernet
-        USERCTL=no
-    - path: /etc/yum.repos.d/kubernetes.repo
-      owner: root:root
-      permissions: '0644'
-      content: |
-        [kubernetes]
-        name=Kubernetes
-        baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-        enabled=1
-        gpgcheck=1
-        repo_gpgcheck=0
-        gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-    - path: /home/centos/.ssh/authorized_keys
-      owner: centos:centos
-      permissions: '0600'
-      content: {{ SSH_PUB_KEY_CONTENT }}
 {% endif %}

--- a/vm-setup/roles/v1aX_integration_test/templates/controlplane_ubuntu.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/controlplane_ubuntu.yaml
@@ -1,6 +1,118 @@
-{% if CAPI_VERSION == 'v1alpha3' %}
+{% if CAPI_VERSION == 'v1alpha2' %}
+apiVersion: cluster.x-k8s.io/v1alpha2
+kind: Machine
+metadata:
+  name: {{ CLUSTER_NAME }}-controlplane-0
+  labels:
+    cluster.x-k8s.io/control-plane: "true"
+    cluster.x-k8s.io/cluster-name: "{{ CLUSTER_NAME }}"
+spec:
+  version: {{ KUBERNETES_VERSION }}
+  bootstrap:
+    configRef:
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      kind: KubeadmConfig
+      name: {{ CLUSTER_NAME }}-controlplane-0
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: BareMetalMachine
+    name: {{ CLUSTER_NAME }}-controlplane-0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: BareMetalMachine
+metadata:
+  name: {{ CLUSTER_NAME }}-controlplane-0
+spec:
+  image:
+    url: {{ IMAGE_URL }}
+    checksum: {{ IMAGE_CHECKSUM }}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: KubeadmConfig
+metadata:
+  name: {{ CLUSTER_NAME }}-controlplane-0
+spec:
+  initConfiguration:
+    nodeRegistration:
+      name: {{ " '{{ ds.meta_data.name }}' " }}
+      kubeletExtraArgs:
+        node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+  preKubeadmCommands:
+    - ip link set dev enp2s0 up
+    - dhclient enp2s0
+    - mv /tmp/akeys /home/ubuntu/.ssh/authorized_keys
+    - chown ubuntu:ubuntu /home/ubuntu/.ssh/authorized_keys
+    - apt update -y
+    - netplan apply
+    - >-
+      apt install net-tools gcc linux-headers-$(uname -r) bridge-utils
+      apt-transport-https ca-certificates curl gnupg-agent
+      software-properties-common -y
+    - apt install -y keepalived && systemctl stop keepalived
+    - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+    - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+    - echo 'deb https://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list
+    - apt update -y
+    - apt install docker-ce docker-ce-cli containerd.io kubelet kubeadm kubectl -y
+    - systemctl enable --now docker kubelet
+    - if (curl -sk --max-time 10 https://{{ CLUSTER_APIENDPOINT_HOST }}:6443/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
+    - usermod -aG docker ubuntu
+  postKubeadmCommands:
+    - mkdir -p /home/ubuntu/.kube
+    - cp /etc/kubernetes/admin.conf /home/ubuntu/.kube/config
+    - systemctl enable --now keepalived
+    - chown ubuntu:ubuntu /home/ubuntu/.kube/config
+  files:
+      - path: /etc/keepalived/keepalived.conf
+        content: |
+          ! Configuration File for keepalived
+          global_defs {
+              notification_email {
+              sysadmin@example.com
+              support@example.com
+              }
+              notification_email_from lb@example.com
+              smtp_server localhost
+              smtp_connect_timeout 30
+          }
+          vrrp_instance VI_2 {
+              state MASTER
+              interface enp2s0
+              virtual_router_id 2
+              priority 101
+              advert_int 1
+              virtual_ipaddress {
+                  {{ CLUSTER_APIENDPOINT_HOST }}
+              }
+          }
+      - path: /etc/netplan/50-cloud-init.yaml
+        owner: root:root
+        permissions: '0644'
+        content: |
+          network:
+              ethernets:
+                  enp2s0:
+                      dhcp4: true
+              version: 2
+      - path: /tmp/akeys
+        owner: root:root
+        permissions: '0644'
+        content: {{ SSH_PUB_KEY_CONTENT }}
+      - path : /etc/netplan/60-ironicendpoint.yaml
+        owner: root:root
+        permissions: '0644'
+        content: |
+          network:
+            version: 2
+            renderer: networkd
+            bridges:
+              ironicendpoint:
+                interfaces: [enp1s0]
+                dhcp4: yes
+{% else %}
 kind: KubeadmControlPlane
-apiVersion: controlplane.cluster.x-k8s.io/{{ CAPI_VERSION }}
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 metadata:
   name: {{ CLUSTER_NAME }}-controlplane
 spec:
@@ -8,7 +120,7 @@ spec:
   version: {{ KUBERNETES_VERSION }}
   infrastructureTemplate:
     kind: Metal3MachineTemplate
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
     name: {{ CLUSTER_NAME }}-controlplane
   kubeadmConfigSpec:
     joinConfiguration:
@@ -97,7 +209,7 @@ spec:
                   dhcp4: yes
 
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
 kind: Metal3MachineTemplate
 metadata:
   name: {{ CLUSTER_NAME }}-controlplane
@@ -107,128 +219,4 @@ spec:
       image:
         url: {{ IMAGE_URL }}
         checksum: {{ IMAGE_CHECKSUM }}
-{% endif %}
-{% if CAPI_VERSION == 'v1alpha2' %}
-apiVersion: cluster.x-k8s.io/{{ CAPI_VERSION }}
-kind: Machine
-metadata:
-  name: {{ CLUSTER_NAME }}-controlplane-0
-  labels:
-    cluster.x-k8s.io/control-plane: "true"
-    cluster.x-k8s.io/cluster-name: "{{ CLUSTER_NAME }}"
-spec:
-{% if CAPI_VERSION == 'v1alpha3' %}
-  clusterName: {{ CLUSTER_NAME }}
-{% endif %}
-  version: {{ KUBERNETES_VERSION }}
-  bootstrap:
-    configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/{{ CAPI_VERSION }}
-      kind: KubeadmConfig
-      name: {{ CLUSTER_NAME }}-controlplane-0
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
-{% if CAPI_VERSION == 'v1alpha2' %}
-    kind: BareMetalMachine
-{% else %}
-    kind: Metal3Machine
-{% endif %}
-    name: {{ CLUSTER_NAME }}-controlplane-0
----
-apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
-{% if CAPI_VERSION == 'v1alpha2' %}
-kind: BareMetalMachine
-{% else %}
-kind: Metal3Machine
-{% endif %}
-metadata:
-  name: {{ CLUSTER_NAME }}-controlplane-0
-spec:
-  image:
-    url: {{ IMAGE_URL }}
-    checksum: {{ IMAGE_CHECKSUM }}
----
-apiVersion: bootstrap.cluster.x-k8s.io/{{ CAPI_VERSION }}
-kind: KubeadmConfig
-metadata:
-  name: {{ CLUSTER_NAME }}-controlplane-0
-spec:
-  initConfiguration:
-    nodeRegistration:
-      name: {{ " '{{ ds.meta_data.name }}' " }}
-      kubeletExtraArgs:
-        node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
-  preKubeadmCommands:
-    - ip link set dev enp2s0 up
-    - dhclient enp2s0
-    - mv /tmp/akeys /home/ubuntu/.ssh/authorized_keys
-    - chown ubuntu:ubuntu /home/ubuntu/.ssh/authorized_keys
-    - apt update -y
-    - netplan apply
-    - >-
-      apt install net-tools gcc linux-headers-$(uname -r) bridge-utils
-      apt-transport-https ca-certificates curl gnupg-agent
-      software-properties-common -y
-    - apt install -y keepalived && systemctl stop keepalived
-    - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-    - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-    - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-    - echo 'deb https://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list
-    - apt update -y
-    - apt install docker-ce docker-ce-cli containerd.io kubelet kubeadm kubectl -y
-    - systemctl enable --now docker kubelet
-    - if (curl -sk --max-time 10 https://{{ CLUSTER_APIENDPOINT_HOST }}:6443/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
-    - usermod -aG docker ubuntu
-  postKubeadmCommands:
-    - mkdir -p /home/ubuntu/.kube
-    - cp /etc/kubernetes/admin.conf /home/ubuntu/.kube/config
-    - systemctl enable --now keepalived
-    - chown ubuntu:ubuntu /home/ubuntu/.kube/config
-  files:
-      - path: /etc/keepalived/keepalived.conf
-        content: |
-          ! Configuration File for keepalived
-          global_defs {
-              notification_email {
-              sysadmin@example.com
-              support@example.com
-              }
-              notification_email_from lb@example.com
-              smtp_server localhost
-              smtp_connect_timeout 30
-          }
-          vrrp_instance VI_2 {
-              state MASTER
-              interface enp2s0
-              virtual_router_id 2
-              priority 101
-              advert_int 1
-              virtual_ipaddress {
-                  {{ CLUSTER_APIENDPOINT_HOST }}
-              }
-          }
-      - path: /etc/netplan/50-cloud-init.yaml
-        owner: root:root
-        permissions: '0644'
-        content: |
-          network:
-              ethernets:
-                  enp2s0:
-                      dhcp4: true
-              version: 2
-      - path: /tmp/akeys
-        owner: root:root
-        permissions: '0644'
-        content: {{ SSH_PUB_KEY_CONTENT }}
-      - path : /etc/netplan/60-ironicendpoint.yaml
-        owner: root:root
-        permissions: '0644'
-        content: |
-          network:
-            version: 2
-            renderer: networkd
-            bridges:
-              ironicendpoint:
-                interfaces: [enp1s0]
-                dhcp4: yes
 {% endif %}

--- a/vm-setup/roles/v1aX_integration_test/templates/controlplane_ubuntu.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/controlplane_ubuntu.yaml
@@ -123,17 +123,19 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPI_VERSION }}
     name: {{ CLUSTER_NAME }}-controlplane
   kubeadmConfigSpec:
-    joinConfiguration:
-      controlPlane: {}
-      nodeRegistration:
-        name: {{ " '{{ ds.meta_data.name }}' " }}
-        kubeletExtraArgs:
-          node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
     initConfiguration:
       nodeRegistration:
         name: {{ " '{{ ds.meta_data.name }}' " }}
         kubeletExtraArgs:
           node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+    joinConfiguration:
+      nodeRegistration:
+        name: {{ " '{{ ds.meta_data.name }}' " }}
+        kubeletExtraArgs:
+          node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
     preKubeadmCommands:
       - ip link set dev enp2s0 up
       - dhclient enp2s0

--- a/vm-setup/roles/v1aX_integration_test/templates/workers_centos.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/workers_centos.yaml
@@ -1,4 +1,8 @@
+{% if CAPI_VERSION == 'v1alpha2' %}
 apiVersion: cluster.x-k8s.io/{{ CAPI_VERSION }}
+{% else %}
+apiVersion: cluster.x-k8s.io/v1alpha3
+{% endif %}
 kind: MachineDeployment
 metadata:
   name: {{ CLUSTER_NAME }}-md-0
@@ -6,7 +10,7 @@ metadata:
     cluster.x-k8s.io/cluster-name: {{ CLUSTER_NAME }}
     nodepool: nodepool-0
 spec:
-{% if CAPI_VERSION == 'v1alpha3' %}
+{% if CAPI_VERSION != 'v1alpha2' %}
   clusterName: {{ CLUSTER_NAME }}
 {% endif %}
   replicas: 1
@@ -20,7 +24,7 @@ spec:
         cluster.x-k8s.io/cluster-name: {{ CLUSTER_NAME }}
         nodepool: nodepool-0
     spec:
-{% if CAPI_VERSION == 'v1alpha3' %}
+{% if CAPI_VERSION != 'v1alpha2' %}
       clusterName: {{ CLUSTER_NAME }}
 {% endif %}
       version: {{ KUBERNETES_VERSION }}
@@ -53,7 +57,11 @@ spec:
         url: {{ IMAGE_URL }}
         checksum: {{ IMAGE_CHECKSUM }}
 ---
+{% if CAPI_VERSION == 'v1alpha2' %}
 apiVersion: bootstrap.cluster.x-k8s.io/{{ CAPI_VERSION }}
+{% else %}
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+{% endif %}
 kind: KubeadmConfigTemplate
 metadata:
   name: {{ CLUSTER_NAME }}-md-0

--- a/vm-setup/roles/v1aX_integration_test/templates/workers_ubuntu.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/workers_ubuntu.yaml
@@ -1,4 +1,8 @@
+{% if CAPI_VERSION == 'v1alpha2' %}
 apiVersion: cluster.x-k8s.io/{{ CAPI_VERSION }}
+{% else %}
+apiVersion: cluster.x-k8s.io/v1alpha3
+{% endif %}
 kind: MachineDeployment
 metadata:
   name: {{ CLUSTER_NAME }}-md-0
@@ -6,7 +10,7 @@ metadata:
     cluster.x-k8s.io/cluster-name: {{ CLUSTER_NAME }}
     nodepool: nodepool-0
 spec:
-{% if CAPI_VERSION == 'v1alpha3' %}
+{% if CAPI_VERSION != 'v1alpha2' %}
   clusterName: {{ CLUSTER_NAME }}
 {% endif %}
   replicas: 1
@@ -20,7 +24,7 @@ spec:
         cluster.x-k8s.io/cluster-name: {{ CLUSTER_NAME }}
         nodepool: nodepool-0
     spec:
-{% if CAPI_VERSION == 'v1alpha3' %}
+{% if CAPI_VERSION != 'v1alpha2' %}
       clusterName: {{ CLUSTER_NAME }}
 {% endif %}
       version: {{ KUBERNETES_VERSION }}
@@ -53,7 +57,11 @@ spec:
         url: {{ IMAGE_URL }}
         checksum: {{ IMAGE_CHECKSUM }}
 ---
+{% if CAPI_VERSION == 'v1alpha2' %}
 apiVersion: bootstrap.cluster.x-k8s.io/{{ CAPI_VERSION }}
+{% else %}
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+{% endif %}
 kind: KubeadmConfigTemplate
 metadata:
   name: {{ CLUSTER_NAME }}-md-0


### PR DESCRIPTION
This PR :
- adds CAPM3 v1alpha4 in the deployment and templates
- fixes shellcheck issues
- parameterize the container runtime for the test scripts
- this PR does not change the CAPI version