### PR TITLE
Update sushy container image

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -2,6 +2,6 @@ FROM registry.hub.docker.com/library/python:3.7
 
 RUN apt update && \
     apt install -y libvirt-dev && \
-    pip3 install sushy-tools==0.7.0 libvirt-python
+    pip3 install sushy-tools==0.8.0 libvirt-python
 
 CMD sushy-emulator -i 0.0.0.0 -p 8000 --config /root/sushy/conf.py


### PR DESCRIPTION
We need sushy-tools==0.8.0 which includes a fix for
the case expected when setting boot mode to UEFI.

We need this patch , https://review.opendev.org/#/c/688458/6/sushy_tools/emulator/resources/systems/libvirtdriver.py

