### PR TITLE
Add dns port to libvirt's firewall zone

### DIFF
--- a/vm-setup/roles/firewall/defaults/main.yml
+++ b/vm-setup/roles/firewall/defaults/main.yml
@@ -12,6 +12,8 @@ provisioning_host_ports:
   - "80"
   # Container image registry
   - "5000"
+  # DNS for registry naming resolution
+  - "53"
 pxe_udp_ports:
   # Multicast DNS
   - "5353"


### PR DESCRIPTION
In case of having to resolve external dns
entries through the installer host (like
resolving internal registry), the dns port
needs to be enabled.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>