### PR TITLE
Add ability to specity external SRV records

### DIFF
--- a/vm-setup/roles/common/defaults/main.yml
+++ b/vm-setup/roles/common/defaults/main.yml
@@ -63,3 +63,4 @@ networks:
       forwarders:
         - domain: "apps.{{ cluster_domain }}"
           addr: "{% if baremetal_network_cidr|ipv6 != False %}::1{% else %}127.0.0.1{% endif %}"
+      srvs: "{{dns_externalsrvs | default([])}}"


### PR DESCRIPTION
If multicast is not available, mDNS won't work. It is then necessary
to specify external SRV records for dnsmasq to use.