### PR TITLE
Use Kubeadm Kubelet extraArgs to set providerID in node templates

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/templates/cluster.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster.yaml
@@ -44,4 +44,4 @@ spec:
     host: {{ CLUSTER_APIENDPOINT_HOST }}
     port: 6443
 {% endif %}
-  noCloudProvider: true
+  noCloudProvider: false

--- a/vm-setup/roles/v1aX_integration_test/templates/controlplane_centos.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/controlplane_centos.yaml
@@ -37,11 +37,13 @@ spec:
       name: {{ " '{{ ds.meta_data.name }}' " }}
       kubeletExtraArgs:
         node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+        provider-id: 'metal3://{{ '{{ ds.meta_data.uuid }}' }}'
   joinConfiguration:
     nodeRegistration:
       name: {{ " '{{ ds.meta_data.name }}' " }}
       kubeletExtraArgs:
         node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+        provider-id: 'metal3://{{ '{{ ds.meta_data.uuid }}' }}'
   preKubeadmCommands:
     - ifup eth1
     - yum update -y
@@ -125,11 +127,13 @@ spec:
         name: {{ " '{{ ds.meta_data.name }}' " }}
         kubeletExtraArgs:
           node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+          provider-id: 'metal3://{{ '{{ ds.meta_data.uuid }}' }}'
     initConfiguration:
       nodeRegistration:
         name: {{ " '{{ ds.meta_data.name }}' " }}
         kubeletExtraArgs:
           node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+          provider-id: 'metal3://{{ '{{ ds.meta_data.uuid }}' }}'
     clusterConfiguration:
       apiServer:
         extraArgs:

--- a/vm-setup/roles/v1aX_integration_test/templates/controlplane_ubuntu.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/controlplane_ubuntu.yaml
@@ -37,6 +37,7 @@ spec:
       name: {{ " '{{ ds.meta_data.name }}' " }}
       kubeletExtraArgs:
         node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+        provider-id: 'metal3://{{ '{{ ds.meta_data.uuid }}' }}'
   preKubeadmCommands:
     - ip link set dev enp2s0 up
     - dhclient enp2s0
@@ -128,11 +129,13 @@ spec:
         name: {{ " '{{ ds.meta_data.name }}' " }}
         kubeletExtraArgs:
           node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+          provider-id: 'metal3://{{ '{{ ds.meta_data.uuid }}' }}'
     joinConfiguration:
       nodeRegistration:
         name: {{ " '{{ ds.meta_data.name }}' " }}
         kubeletExtraArgs:
           node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+          provider-id: 'metal3://{{ '{{ ds.meta_data.uuid }}' }}'
     clusterConfiguration:
       apiServer:
         extraArgs:

--- a/vm-setup/roles/v1aX_integration_test/templates/workers_centos.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/workers_centos.yaml
@@ -73,6 +73,7 @@ spec:
           name: {{ " '{{ ds.meta_data.name }}' " }}
           kubeletExtraArgs:
             node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+            provider-id: 'metal3://{{ '{{ ds.meta_data.uuid }}' }}'
       preKubeadmCommands:
         - ifup eth1
         - yum update -y

--- a/vm-setup/roles/v1aX_integration_test/templates/workers_ubuntu.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/workers_ubuntu.yaml
@@ -73,6 +73,7 @@ spec:
           name: {{ " '{{ ds.meta_data.name }}' " }}
           kubeletExtraArgs:
             node-labels: 'metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}'
+            provider-id: 'metal3://{{ '{{ ds.meta_data.uuid }}' }}'
       preKubeadmCommands:
         - ip link set dev enp2s0 up
         - dhclient enp2s0


### PR DESCRIPTION
This patch adds an extra arg to kubelet in the KubeadmConfigs to
set the providerID, instead of setting `noCloudProvider` to let
CAPM3 set it itself based on the label.