### PR TITLE
Make openstackclient.sh more flexible

### DIFF
--- a/openstackclient.sh
+++ b/openstackclient.sh
@@ -4,6 +4,12 @@ DIR="$(dirname "$(readlink -f "$0")")"
 # shellcheck source=lib/common.sh
 source "${DIR}/lib/common.sh"
 
+if [ -d "${PWD}/_clouds_yaml" ]; then
+  MOUNTDIR="${PWD}/_clouds_yaml"
+else
+  MOUNTDIR="${SCRIPTDIR}/_clouds_yaml"
+fi
+
 sudo "${CONTAINER_RUNTIME}" run -ti --net=host \
-  -v "${SCRIPTDIR}/_clouds_yaml/:/etc/openstack" \
-  -e OS_CLOUD=metal3 "${IRONIC_CLIENT_IMAGE}" "$@"
+  -v "${MOUNTDIR}:/etc/openstack" \
+  -e OS_CLOUD="${OS_CLOUD:-metal3}" "${IRONIC_CLIENT_IMAGE}" "$@"


### PR DESCRIPTION
Currently this is hard-coded so it always uses OS_CLOUD=metal3
and can only consume the _clouds_yaml from metal3-dev-env.

To enable compatibility with https://github.com/openshift-metal3/dev-scripts/
Check $PWD for an alternative _clouds_yaml, and allow for overriding
OS_CLOUD from the environment.

dev-scripts reuses some parts of metal3-dev-env for testing metal3
enabled openshift so this will make openstackclient.sh useful in
both repos.