### PR TITLE
Add support for repositories cloned beforehand

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -153,18 +153,21 @@ for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
       cd "${REPOPATH}" || exit
       [ "${BRANCH}" = "master" ] || git checkout "${BRANCH}"
     fi
+  # Assume it is a path
+  else
+    cd "${IMAGE}" || exit
+  fi
 
-    #shellcheck disable=SC2086
-    export $IMAGE_VAR="${IMAGE##*/}:latest"
-    #shellcheck disable=SC2086
-    export $IMAGE_VAR="192.168.111.1:5000/localimages/${!IMAGE_VAR}"
-    sudo "${CONTAINER_RUNTIME}" build -t "${!IMAGE_VAR}" . -f "${DOCKERFILE}"
-    cd - || exit
-    if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
-      sudo "${CONTAINER_RUNTIME}" push --tls-verify=false "${!IMAGE_VAR}" "${!IMAGE_VAR}"
-    else
-      sudo "${CONTAINER_RUNTIME}" push "${!IMAGE_VAR}"
-    fi
+  #shellcheck disable=SC2086
+  export $IMAGE_VAR="${IMAGE##*/}:latest"
+  #shellcheck disable=SC2086
+  export $IMAGE_VAR="192.168.111.1:5000/localimages/${!IMAGE_VAR}"
+  sudo "${CONTAINER_RUNTIME}" build -t "${!IMAGE_VAR}" . -f "${DOCKERFILE}"
+  cd - || exit
+  if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
+    sudo "${CONTAINER_RUNTIME}" push --tls-verify=false "${!IMAGE_VAR}" "${!IMAGE_VAR}"
+  else
+    sudo "${CONTAINER_RUNTIME}" push "${!IMAGE_VAR}"
   fi
 done
 

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -25,20 +25,20 @@ export GOPATH
 # BMO_RUN_LOCAL : run the baremetal operator locally (not in Kubernetes cluster)
 # CAPM3_RUN_LOCAL : run the CAPI operator locally
 
-M3PATH="${GOPATH}/src/github.com/metal3-io"
-BMOPATH="${M3PATH}/baremetal-operator"
+M3PATH="${M3PATH:-${GOPATH}/src/github.com/metal3-io}"
+BMOPATH="${BMOPATH:-${M3PATH}/baremetal-operator}"
 RUN_LOCAL_IRONIC_SCRIPT="${BMOPATH}/tools/run_local_ironic.sh"
-CAPM3PATH="${M3PATH}/cluster-api-provider-metal3"
+CAPM3PATH="${CAPM3PATH:-${M3PATH}/cluster-api-provider-metal3}"
 
 if [ "${CAPI_VERSION}" == "v1alpha3" ]; then
   CAPM3BRANCH="${CAPM3BRANCH:-release-0.3}"
   CAPM3REPO="${CAPM3REPO:-https://github.com/metal3-io/cluster-api-provider-metal3.git}"
 elif [ "${CAPI_VERSION}" == "v1alpha2" ]; then
-  CAPM3PATH="${M3PATH}/cluster-api-provider-baremetal"
+  CAPM3PATH="${CAPM3PATH:-${M3PATH}/cluster-api-provider-baremetal}"
   CAPM3BRANCH="${CAPM3BRANCH:-release-0.2}"
   CAPM3REPO="${CAPM3REPO:-https://github.com/metal3-io/cluster-api-provider-baremetal.git}"
 elif [ "${CAPI_VERSION}" == "v1alpha1" ]; then
-  CAPM3PATH="${M3PATH}/cluster-api-provider-baremetal"
+  CAPM3PATH="${CAPM3PATH:-${M3PATH}/cluster-api-provider-baremetal}"
   CAPM3BRANCH="${CAPM3BRANCH:-v1alpha1}"
   CAPM3REPO="${CAPM3REPO:-https://github.com/metal3-io/cluster-api-provider-baremetal.git}"
 else
@@ -92,7 +92,8 @@ function update_images(){
     fi
 
     OLD_IMAGE_VAR="${IMAGE_VAR%_LOCAL_IMAGE}_IMAGE"
-    OLD_IMAGE=${!OLD_IMAGE_VAR}
+    # Strip the tag for image replacement
+    OLD_IMAGE="${!OLD_IMAGE_VAR%:*}"
     #shellcheck disable=SC2086
     kustomize edit set image $OLD_IMAGE=$LOCAL_IMAGE
   done


### PR DESCRIPTION
This commit changes the way we handle the repositories:
- when building images, support paths, instead of URLs only
- when running kustomize, strip the tag of the old image to match
  more broadly
- When deploying BMO or CAPM3, accept paths to existing folders
  that are not in the go path.