### PR TITLE
Fix unset variable for image name

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -85,11 +85,9 @@ function clone_repos() {
 function update_images(){
   for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
     IMAGE=${!IMAGE_VAR}
-    if [[ "$IMAGE" =~ "://" ]] ; then
-     #shellcheck disable=SC2086
-     IMAGE_NAME="${IMAGE##*/}:latest"
-     LOCAL_IMAGE="192.168.111.1:5000/localimages/$IMAGE_NAME"
-    fi
+   #shellcheck disable=SC2086
+   IMAGE_NAME="${IMAGE##*/}:latest"
+   LOCAL_IMAGE="192.168.111.1:5000/localimages/$IMAGE_NAME"
 
     OLD_IMAGE_VAR="${IMAGE_VAR%_LOCAL_IMAGE}_IMAGE"
     # Strip the tag for image replacement


### PR DESCRIPTION
When testing a PR, the local image is built out of the repository that is already cloned locally, so the XXX_LOCAL_IMAGE is a path. In https://github.com/metal3-io/metal3-dev-env/commit/68b140c1d1b6e3899cc1fd48f1138b4a85dce258 a condition was forgotten. Currently PRs are not passing because the image name variable is not set.

/cc @fmuyassarov 
/cc @kashifest 