### PR TITLE
Remove duplicated Ansible tasks

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/download_image.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/download_image.yml
@@ -2,13 +2,13 @@
   - name: Get the facts about local CentOS image
     stat:
       path: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME_CENTOS }}"
-    register: image_path
+    register: image_path_centos
 
   - debug:
       msg: "Local image of CentOS is found"
     when:
       - IMAGE_OS == "Centos"
-      - image_path.stat.exists == True
+      - image_path_centos.stat.exists == True
 
   - name: Download CentOS image.
     block:
@@ -21,7 +21,7 @@
           dest: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME_CENTOS }}"
           mode: 0664
 
-      - name: Calculate md5sum of the specific image
+      - name: Calculate md5sum of the centos image
         stat:
          path: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME_CENTOS }}"
          checksum_algorithm: md5
@@ -35,5 +35,44 @@
           dest: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME_CENTOS }}.md5sum"
           mode: 0664
     when:
+      - image_path_centos.stat.exists == False
       - IMAGE_OS == "Centos"
-      - image_path.stat.exists == False
+
+  - name: Get the facts about local Ubuntu image
+    stat:
+      path: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME }}"
+    register: image_path_ubuntu
+
+  - debug:
+      msg: "Local image of CentOS is found"
+    when:
+      - IMAGE_OS == "Ubuntu"
+      - image_path_ubuntu.stat.exists == True
+
+  - name: Download Ubuntu image.
+    block:
+      - debug:
+          msg: "Local image of Ubuntu is not found, starting to download"
+
+      - name: Verify specific Ubuntu image containing newer version of cloud-init is downloaded
+        get_url:
+          url: "{{ IMAGE_LOCATION }}"
+          dest: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME }}"
+          mode: 0664
+
+      - name: Calculate md5sum of the Ubuntu image
+        stat:
+         path: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME }}"
+         checksum_algorithm: md5
+        register: ubuntu_md5
+
+      - name: Create the md5sum file
+        copy:
+          content: |
+            {{ ubuntu_md5.stat.checksum }}
+
+          dest: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME }}.md5sum"
+          mode: 0664
+    when:
+      - image_path_ubuntu.stat.exists == False
+      - IMAGE_OS == "Ubuntu"

--- a/vm-setup/roles/v1aX_integration_test/tasks/provision_controlplane.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/provision_controlplane.yml
@@ -17,26 +17,6 @@
 
   - name: Provision CentOS based controlplane node
     block:
-      - name: Verify specific centos image containing newer version of cloud-init is downloaded
-        get_url:
-          url: "{{ IMAGE_LOCATION_CENTOS }}"
-          dest: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME_CENTOS }}"
-          mode: 0664
-
-      - name: Calculate md5sum of the specific image
-        stat:
-         path: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME_CENTOS }}"
-         checksum_algorithm: md5
-        register: centos_md5
-
-      - name: Create the md5sum file
-        copy:
-          content: |
-            {{ centos_md5.stat.checksum }}
-
-          dest: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME_CENTOS }}.md5sum"
-          mode: 0664
-
       - name: Template controlplane_centos.yaml
         template:
           src: "{{ CRS_PATH }}/controlplane_centos.yaml"

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -17,6 +17,7 @@ IMAGE_OS: "{{ lookup('env', 'IMAGE_OS') | default('Ubuntu', true)}}"
 CONTAINER_RUNTIME: "{{ lookup('env', 'CONTAINER_RUNTIME') | default('podman', true)}}"
 DEFAULT_HOSTS_MEMORY: "{{ lookup('env', 'DEFAULT_HOSTS_MEMORY') | default('4096', true)}}"
 CAPI_VERSION: "{{ lookup('env', 'CAPI_VERSION') | default('v1alpha3', true)}}"
+IRONIC_IMAGE_DIR: "{{ lookup('env', 'IRONIC_IMAGE_DIR') | default('/opt/metal3-dev-env/ironic/html/images')}}"
 
 # Distibution specific environment variables
 IMAGE_NAME: 'bionic-server-cloudimg-amd64.img'
@@ -30,4 +31,3 @@ IMAGE_LOCATION_CENTOS: 'http://artifactory.nordix.org/artifactory/airship/images
 IMAGE_USERNAME_CENTOS: 'centos'
 IMAGE_URL_CENTOS: "http://172.22.0.1/images/{{ IMAGE_NAME_CENTOS }}"
 IMAGE_CHECKSUM_CENTOS: "http://172.22.0.1/images/{{ IMAGE_NAME_CENTOS }}.md5sum"
-IRONIC_IMAGE_DIR: "{{ lookup('env', 'IRONIC_IMAGE_DIR') | default('/opt/metal3-dev-env/ironic/html/images')}}"


### PR DESCRIPTION
Couple of the Ansible tasks are duplicated and were forgotten to be removed.
These particular tasks are now located in [download_image.yml](https://github.com/metal3-io/metal3-dev-env/blob/master/vm-setup/roles/v1aX_integration_test/tasks/download_image.yml)

This patchset:
1. removes duplicated tasks
2. adds tasks to download ubuntu image and creates its checksum on the fly 