### PR TITLE
Target cluster OS set to Centos8 instead of CentOS 7

### DIFF
--- a/lib/images.sh
+++ b/lib/images.sh
@@ -11,8 +11,8 @@ elif [[ "${IMAGE_OS}" == "FCOS" ]]; then
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20191014.0/x86_64/}
   export IMAGE_USERNAME=${IMAGE_USERNAME:-core}
 elif [[ "${IMAGE_OS}" == "Centos" ]]; then
-  export IMAGE_NAME=${IMAGE_NAME:-CentOS-7-x86_64-GenericCloud-1907.qcow2}
-  export IMAGE_LOCATION=${IMAGE_LOCATION:-http://cloud.centos.org/centos/7/images}
+  export IMAGE_NAME=${IMAGE_NAME:-CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64.qcow2}
+  export IMAGE_LOCATION=${IMAGE_LOCATION:-https://cloud.centos.org/centos/8/x86_64/images/}
   export IMAGE_USERNAME=${IMAGE_USERNAME:-centos}
 else
   export IMAGE_NAME=${IMAGE_NAME:-cirros-0.4.0-x86_64-disk.img}

--- a/vm-setup/roles/v1aX_integration_test/tasks/provision_cluster.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/provision_cluster.yml
@@ -1,12 +1,21 @@
 ---
-  - name: Install openshift client
+  - name: Install openshift client in CentOS 8 using pip3
     pip:
       executable: "pip3"
       name: openshift
       state: present
     become: true
     become_user: root
-    when: ansible_facts['distribution'] == "CentOS"
+    when: ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == '8'
+
+  - name: Install openshift client in CentOS 7 using pip
+    pip:
+      executable: "pip"
+      name: openshift
+      state: present
+    become: true
+    become_user: root
+    when: ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == '7'
 
 # Populate cr with environment variables
   - name: Template cluster.yaml

--- a/vm-setup/roles/v1aX_integration_test/templates/controlplane_centos.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/controlplane_centos.yaml
@@ -51,10 +51,10 @@ spec:
     - yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
     - setenforce 0
     - sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
+    - yum install docker-ce docker-ce-cli --disableexcludes=kubernetes --nobest -y
     - >-
       yum install gcc kernel-headers kernel-devel keepalived
       device-mapper-persistent-data lvm2
-      docker-ce-18.09.9 docker-ce-cli-18.09.9 containerd.io
       kubelet kubeadm kubectl --disableexcludes=kubernetes -y
     - usermod -aG docker centos
     - systemctl enable --now docker keepalived kubelet
@@ -105,8 +105,8 @@ spec:
         gpgcheck=1
         repo_gpgcheck=0
         gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-    - path: /home/centos/.ssh/authorized_keys
-      owner: centos:centos
+    - path: /tmp/akeys
+      owner: root:root
       permissions: '0600'
       content: {{ SSH_PUB_KEY_CONTENT }}
 {% else %}
@@ -139,15 +139,17 @@ spec:
         extraArgs:
     preKubeadmCommands:
       - ifup eth1
+      - mv /tmp/akeys /home/centos/.ssh/authorized_keys
+      - chown centos:centos /home/centos/.ssh/authorized_keys
       - yum update -y
       - yum install yum-utils -y
       - yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
       - setenforce 0
       - sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
+      - yum install docker-ce docker-ce-cli --disableexcludes=kubernetes --nobest -y
       - >-
         yum install gcc kernel-headers kernel-devel keepalived
         device-mapper-persistent-data lvm2
-        docker-ce-18.09.9 docker-ce-cli-18.09.9 containerd.io
         kubelet kubeadm kubectl --disableexcludes=kubernetes -y
       - usermod -aG docker centos
       - systemctl enable --now docker keepalived kubelet
@@ -198,8 +200,8 @@ spec:
           gpgcheck=1
           repo_gpgcheck=0
           gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-      - path: /home/centos/.ssh/authorized_keys
-        owner: centos:centos
+      - path: /tmp/akeys
+        owner: root:root
         permissions: '0600'
         content: {{ SSH_PUB_KEY_CONTENT }}
 ---

--- a/vm-setup/roles/v1aX_integration_test/templates/workers_centos.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/workers_centos.yaml
@@ -76,14 +76,15 @@ spec:
             provider-id: 'metal3://{{ '{{ ds.meta_data.uuid }}' }}'
       preKubeadmCommands:
         - ifup eth1
+        - mv /tmp/akeys /home/centos/.ssh/authorized_keys
+        - chown centos:centos /home/centos/.ssh/authorized_keys
         - yum update -y
         - yum install yum-utils device-mapper-persistent-data lvm2 -y
         - yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
         - setenforce 0
         - sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
-        - >-
-          yum install docker-ce-18.09.9 docker-ce-cli-18.09.9 containerd.io
-          kubelet kubeadm kubectl --disableexcludes=kubernetes -y
+        - yum install docker-ce docker-ce-cli --disableexcludes=kubernetes --nobest -y
+        - yum install kubelet kubeadm kubectl --disableexcludes=kubernetes -y
         - usermod -aG docker centos
         - systemctl enable --now docker kubelet
       files:
@@ -107,7 +108,7 @@ spec:
             gpgcheck=1
             repo_gpgcheck=0
             gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-        - path: /home/centos/.ssh/authorized_keys
-          owner: centos:centos
+        - path: /tmp/akeys
+          owner: root:root
           permissions: '0600'
           content: {{ SSH_PUB_KEY_CONTENT }}

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -12,8 +12,8 @@ POD_CIDR: "{{ lookup('env', 'POD_CIDR') }}"
 SSH_PRIVATE_KEY: "{{ lookup('env', 'SSH_KEY') }}"
 SSH_PUB_KEY_CONTENT: "{{ lookup('file', '{{ HOME }}/.ssh/id_rsa.pub') }}"
 
-# Environment variables for deployment
-IMAGE_OS: "{{ lookup('env', 'IMAGE_OS') | default('Ubuntu', true)}}"
+# Environment variables for deployment. IMAGE_OS can be Centos or Ubuntu, change accordingly to your needs.
+IMAGE_OS: "{{ lookup('env', 'IMAGE_OS') | default('Centos', true)}}"
 CONTAINER_RUNTIME: "{{ lookup('env', 'CONTAINER_RUNTIME') | default('podman', true)}}"
 DEFAULT_HOSTS_MEMORY: "{{ lookup('env', 'DEFAULT_HOSTS_MEMORY') | default('4096', true)}}"
 CAPI_VERSION: "{{ lookup('env', 'CAPI_VERSION') | default('v1alpha3', true)}}"
@@ -26,8 +26,8 @@ IMAGE_USERNAME: 'ubuntu'
 IMAGE_URL: "http://172.22.0.1/images/{{ IMAGE_NAME }}"
 IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ IMAGE_NAME }}.md5sum"
 
-IMAGE_NAME_CENTOS: "{{ lookup('env', 'IMAGE_NAME_CENTOS') | default('centos-updated.qcow2', true)}}"
-IMAGE_LOCATION_CENTOS: 'http://artifactory.nordix.org/artifactory/airship/images/centos.qcow2'
+IMAGE_NAME_CENTOS: "{{ lookup('env', 'IMAGE_NAME_CENTOS') | default('CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64.qcow2', true)}}"
+IMAGE_LOCATION_CENTOS: 'https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64.qcow2'
 IMAGE_USERNAME_CENTOS: 'centos'
 IMAGE_URL_CENTOS: "http://172.22.0.1/images/{{ IMAGE_NAME_CENTOS }}"
 IMAGE_CHECKSUM_CENTOS: "http://172.22.0.1/images/{{ IMAGE_NAME_CENTOS }}.md5sum"


### PR DESCRIPTION
This PR focuses on set CentOS 8 as the default option when selecting Centos as base image for the target cluster. It replaces CentOS 7 as the default CentOS version.

- Linked to issue #263 

Notes:
==========

- Changes in the lib/images.sh to set CentOS 8 as the default
- Changes in the templates for worker and control-plane since CentOS 8 does not run latest docker. Basically, included --nobest option which installs Docker 18.9.1 (docker-ce-18.09.1-3.el7.x86_64). Additionally configure to work with the official cloud image instead of the modified centos-update.qcow2.
- The default OS_IMAGE is changed to Centos instead of Ubuntu. Since the default image that is downloaded with make scripts is CentOS - now, version 8 qcow2 image. It does not make sense to download Centos cloud image with make scripts and then download the Ubuntu image using the Ansible playbook. The ironic folder ends up with two images. 

I set the default to Centos in the Ansible vars yaml file since Centos image is downloaded during metal3-dev-env configuration time. However, it can be changed to set Ubuntu the default, basically changing in both sides (images.sh and Ansible provision playbook).
- Added an extra task during cluster provisioning in case CentOS 7 is the OS for the server where the metal3-dev-env is set up. It should be pointed in the documentation that CentOS 8 is the suggested one along with Ubuntu 18.04.

Extra details:
===============

- I have been able to deploy the metal3-dev-env on a physical server running CentOS 8 and CentOS 7 both provisioning the target control-plane and workers with the cloud CentOS 8 image. 

```sh
[centos@node-2 ~]$ kubectl  get nodes -o wide
NAME     STATUS   ROLES    AGE   VERSION   INTERNAL-IP      EXTERNAL-IP   OS-IMAGE                KERNEL-VERSION                CONTAINER-RUNTIME
node-1   Ready    <none>   10h   v1.17.4   192.168.111.21   <none>        CentOS Linux 8 (Core)   4.18.0-147.3.1.el8_1.x86_64   docker://18.9.1
node-2   Ready    master   15h   v1.17.4   192.168.111.22   <none>        CentOS Linux 8 (Core)   4.18.0-147.3.1.el8_1.x86_64   docker://18.9.1
node-3   Ready    <none>   10h   v1.17.4   192.168.111.23   <none>        CentOS Linux 8 (Core)   4.18.0-147.3.1.el8_1.x86_64   docker://18.9.1
node-4   Ready    <none>   10h   v1.17.4   192.168.111.24   <none>        CentOS Linux 8 (Core)   4.18.0-147.3.1.el8_1.x86_64   docker://18.9.1
```

I think it's time to set the default CentOS version to major release 8 in both the target cluster and the metal3-dev-env host that runs libvirtd. Try-it document must be updated accordingly once the PR is merged.

In the near future, centos-update.qcow2 can be decomissioned since now downloads the public cloud image from Centos download page.