### PR TITLE
Ensure python-pip package exists when libvirtd server is running CentOS 7

### DIFF
--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -43,6 +43,8 @@ sudo yum -y install \
   wget
 
 if [[ $DISTRO == "centos7" ]]; then
+  # Install pip since it is used by the k8s Ansible module
+  sudo dnf -y install python-pip
   # Install tripleo-repos, used to get a recent version of python-jinja2
   # which is required for some ansible templates
   sudo dnf -y --repofrompath="current-tripleo,https://trunk.rdoproject.org/${DISTRO}-master/current-tripleo" install "python*-tripleo-repos" --nogpgcheck


### PR DESCRIPTION
This PR installs python-pip when installing metal3-dev-env in CentOS 7.

This is related to merged PR #264 . Solves the problem if pip is not installed,
. In my case it is installed during provisioning time. However, this is not a packages that comes by default in CentOS 7. We must be sure the package is installed so that the openshift-client can be installed during cluster provisioning. See https://github.com/metal3-io/metal3-dev-env/blob/bd605e8d3cbb3015ea38adc8c5fbc62cd8c6450c/vm-setup/roles/v1aX_integration_test/tasks/provision_cluster.yml#L11
