### PR TITLE
Use dnf instead of yum

### DIFF
--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -6,7 +6,7 @@ source lib/logging.sh
 # shellcheck disable=SC1091
 source lib/common.sh
 
-sudo yum install -y libselinux-utils
+sudo dnf install -y libselinux-utils
 if selinuxenabled ; then
     sudo setenforce permissive
     sudo sed -i "s/=enforcing/=permissive/g" /etc/selinux/config
@@ -14,10 +14,10 @@ fi
 
 # Remove any previous tripleo-repos to avoid version conflicts
 # (see FIXME re oniguruma below)
-sudo yum -y erase "python*-tripleo-repos"
+sudo dnf -y remove "python*-tripleo-repos"
 
 # Update to latest packages first
-sudo yum -y update
+sudo dnf -y upgrade
 
 # Install additional repos as needed for each OS version
 # shellcheck disable=SC1091
@@ -25,18 +25,18 @@ source /etc/os-release
 # VERSION_ID can be "7" or "8.x" so strip the minor version
 DISTRO="${ID}${VERSION_ID%.*}"
 if [[ $DISTRO =~ "centos" ]]; then
-    sudo yum -y install epel-release dnf --enablerepo=extras
+    sudo dnf -y install epel-release dnf --enablerepo=extras
 elif [[ $DISTRO == "rhel8" ]]; then
     sudo subscription-manager repos --enable=ansible-2-for-rhel-8-x86_64-rpms
 fi
 
 if [[ $DISTRO == "rhel8" || $DISTRO == "centos8" ]]; then
-    sudo yum -y install python3
+    sudo dnf -y install python3
     sudo alternatives --set python /usr/bin/python3
 fi
 
 # Install required packages
-sudo yum -y install \
+sudo dnf -y install \
   ansible \
   redhat-lsb-core \
   python3-pip \
@@ -53,17 +53,17 @@ if [[ $DISTRO == "centos7" ]]; then
   # FIXME(stbenjam): On CentOS 7, the version of oniguruma conflicts with
   # the version shipped in the tripleo repos. This needs further
   # investigation.
-  sudo yum -y update --exclude=oniguruma
+  sudo dnf -y upgrade --exclude=oniguruma
 fi
 
 if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
-  sudo yum -y install podman
+  sudo dnf -y install podman
 else
   if [[ $DISTRO == "centos7" ]]; then
-    sudo yum install -y yum-utils \
+    sudo dnf install -y dnf-utils \
       device-mapper-persistent-data \
       lvm2
-    sudo yum-config-manager \
+    sudo dnf config-manager \
       --add-repo \
       https://download.docker.com/linux/centos/docker-ce.repo
       cat <<EOF > daemon.json
@@ -72,7 +72,7 @@ else
 }
 EOF
     sudo chown root:root daemon.json
-    sudo yum install -y docker-ce docker-ce-cli containerd.io
+    sudo dnf install -y docker-ce docker-ce-cli containerd.io
     sudo mkdir -p /etc/docker
     sudo mv daemon.json /etc/docker/daemon.json
     sudo systemctl restart docker


### PR DESCRIPTION
The dnf command replaces yum and it's available for both centos 7
and 8, let's use it instead of the obsolete, bugged and slow yum.