### PR TITLE
Remove nodes_file on tear down

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -42,6 +42,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "extradisks=$VM_EXTRADISKS" \
     -e "virthost=$HOSTNAME" \
     -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
+    -e "nodes_file=$NODES_FILE" \
     -i vm-setup/inventory.ini \
     -b -vvv vm-setup/teardown-playbook.yml
 

--- a/vm-setup/roles/libvirt/tasks/main.yml
+++ b/vm-setup/roles/libvirt/tasks/main.yml
@@ -10,4 +10,5 @@
   block:
     - include_tasks: network_teardown_tasks.yml
     - include_tasks: vm_teardown_tasks.yml
+      when: vm_platform == "libvirt"
   when: libvirt_action == "teardown"

--- a/vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml
@@ -137,3 +137,4 @@
   template:
     src: ../templates/ironic_nodes.json.j2
     dest: "{{ nodes_file }}"
+    force: no

--- a/vm-setup/roles/libvirt/tasks/vm_teardown_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/vm_teardown_tasks.yml
@@ -92,3 +92,8 @@
         path: "/run/user/{{ pool_uid.stdout }}/libvirt/storage/run/{{ libvirt_volume_pool }}.xml"
         state: absent
       when: pool_check is success
+
+    - name: Remove ironic_nodes.json
+      file:
+        path: "{{ nodes_file }}"
+        state: absent


### PR DESCRIPTION
And only create a new one if it doesn't exist. This to ensure
we don't create a new one without also defining new VM's.

Also only run teardown if vm_platform == "libvirt" to avoid
removing a user defined nodes_file.