### PR TITLE
Add optional dual-stack baremetal network support

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -270,6 +270,10 @@ if "${EPHEMERAL_CLUSTER}" == "kind"; then
 else
   init_minikube
   sudo su -l -c 'minikube start' "${USER}"
+  if [[ -n "${MINIKUBE_BMNET_V6_IP}" ]]; then
+	  sudo su -l -c "minikube ssh -- sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0" "${USER}"
+	  sudo su -l -c "minikube ssh -- sudo ip addr add $MINIKUBE_BMNET_V6_IP/64 dev eth3" "${USER}"
+  fi
   if [[ "${PROVISIONING_IPV6}" == "true" ]]; then
     sudo su -l -c 'minikube ssh "sudo ip -6 addr add '"$CLUSTER_PROVISIONING_IP/$PROVISIONING_CIDR"' dev eth2"' "${USER}"
   else

--- a/config_example.sh
+++ b/config_example.sh
@@ -1,12 +1,28 @@
 #!/bin/bash
 
 #
+# Choose whether the "baremetal" libvirt network will use IPv4, IPv6, or IPv4+IPv6.
+# This network is the primary network interface for the virtual bare metal hosts.
+#
+# Note that this only sets up the underlying network, and fully provisioning IPv6
+# kubernetes clusters is not yet automated.  If IPv6 is enabled, DHCPv6 will
+# be available to the virtual bare metal hosts.
+#
+# v4   -- IPv4 (default)
+# v6   -- IPv6
+# v4v6 -- dual-stack IPv4+IPv6
+#
+#export IP_STACK=v6
+
+#
 # This is the subnet used on the "baremetal" libvirt network, created as the
-# primary network interface for the virtual bare metalhosts.
+# primary network interface for the virtual bare metal hosts.
 #
-# Default of 192.168.111.0/24 set in lib/common.sh
+# V4 default of 192.168.111.0/24 set in lib/network.sh
+# V6 default of fd55::/64 is set in lib/network.sh
 #
-#export EXTERNAL_SUBNET="192.168.111.0/24"
+#export EXTERNAL_SUBNET_V4="192.168.111.0/24"
+#export EXTERNAL_SUBNET_V6="fd55::/64"
 
 #
 # This SSH key will be automatically injected into the provisioned host

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -68,6 +68,13 @@ network_address dhcp_range_end "$PROVISIONING_NETWORK" 100
 
 export CLUSTER_DHCP_RANGE=${CLUSTER_DHCP_RANGE:-"$dhcp_range_start,$dhcp_range_end"}
 
+EXTERNAL_SUBNET=${EXTERNAL_SUBNET:-""}
+if [[ -n "${EXTERNAL_SUBNET}" ]]; then
+    echo "EXTERNAL_SUBNET has been removed in favor of EXTERNAL_SUBNET_V4 and EXTERNAL_NETWORK_V6."
+    echo "Please update your configuration to drop the use of EXTERNAL_SUBNET."
+    exit 1
+fi
+
 export IP_STACK=${IP_STACK:-"v4"}
 if [[ "${IP_STACK}" == "v4" ]]; then
     export EXTERNAL_SUBNET_V4=${EXTERNAL_SUBNET_V4:-"192.168.111.0/24"}

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 #
 # Get the nth address from an IPv4 or IPv6 Network
 #
@@ -69,6 +68,19 @@ network_address dhcp_range_end "$PROVISIONING_NETWORK" 100
 
 export CLUSTER_DHCP_RANGE=${CLUSTER_DHCP_RANGE:-"$dhcp_range_start,$dhcp_range_end"}
 
-export EXTERNAL_SUBNET=${EXTERNAL_SUBNET:-"192.168.111.0/24"}
+export IP_STACK=${IP_STACK:-"v4"}
+if [[ "${IP_STACK}" == "v4" ]]; then
+    export EXTERNAL_SUBNET_V4=${EXTERNAL_SUBNET_V4:-"192.168.111.0/24"}
+    export EXTERNAL_SUBNET_V6=""
+elif [[ "${IP_STACK}" == "v6" ]]; then
+    export EXTERNAL_SUBNET_V4=""
+    export EXTERNAL_SUBNET_V6=${EXTERNAL_SUBNET_V6:-"fd55::/64"}
+elif [[ "${IP_STACK}" == "v4v6" ]]; then
+    export EXTERNAL_SUBNET_V4=${EXTERNAL_SUBNET_V4:-"192.168.111.0/24"}
+    export EXTERNAL_SUBNET_V6=${EXTERNAL_SUBNET_V6:-"fd55::/64"}
+else
+    echo "Invalid value of IP_STACK: '${IP_STACK}'"
+    exit 1
+fi
 
 network_address INITIAL_IRONICBRIDGE_IP "$PROVISIONING_NETWORK" 9

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -90,4 +90,8 @@ else
     exit 1
 fi
 
+if [[ "${EPHEMERAL_CLUSTER}" == "minikube" ]] && [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
+    network_address MINIKUBE_BMNET_V6_IP "${EXTERNAL_SUBNET_V6}" 9
+fi
+
 network_address INITIAL_IRONICBRIDGE_IP "$PROVISIONING_NETWORK" 9

--- a/vm-setup/roles/common/defaults/main.yml
+++ b/vm-setup/roles/common/defaults/main.yml
@@ -24,7 +24,8 @@ flavors:
 # An optional prefix for node names
 ironic_prefix: ""
 
-baremetal_network_cidr: "{{ lookup('env', 'EXTERNAL_SUBNET') | default('192.168.111.0/24', true) }}"
+baremetal_network_cidr_v4: "{{ lookup('env', 'EXTERNAL_SUBNET_V4')|default('', true) }}"
+baremetal_network_cidr_v6: "{{ lookup('env', 'EXTERNAL_SUBNET_V6')|default('', true) }}"
 
 # Set this to `false` if you don't want your vms
 # to have a VNC console available.
@@ -48,12 +49,16 @@ networks:
   - name: baremetal
     bridge: baremetal
     forward_mode: "{% if manage_baremetal == 'y' %}nat{% else %}bridge{% endif %}"
-    address: "{{ baremetal_network_cidr|nthhost(1) }}"
-    netmask: "{{ baremetal_network_cidr|ipaddr('netmask') }}"
-    prefix: "{{ baremetal_network_cidr|ipaddr('prefix') }}"
-    dhcp_range:
-      - "{{ baremetal_network_cidr|nthhost(20) }}"
-      - "{{ baremetal_network_cidr|nthhost(60) }}"
+    address_v4: "{{ baremetal_network_cidr_v4|nthhost(1)|default('', true) }}"
+    netmask_v4: "{{ baremetal_network_cidr_v4|ipaddr('netmask') }}"
+    dhcp_range_v4:
+      - "{{ baremetal_network_cidr_v4|nthhost(20) }}"
+      - "{{ baremetal_network_cidr_v4|nthhost(60) }}"
+    address_v6: "{{ baremetal_network_cidr_v6|nthhost(1)|default('', true) }}"
+    prefix_v6: "{{ baremetal_network_cidr_v6|ipaddr('prefix') }}"
+    dhcp_range_v6:
+      - "{{ baremetal_network_cidr_v6|nthhost(20) }}"
+      - "{{ baremetal_network_cidr_v6|nthhost(60) }}"
     nat_port_range:
       - 1024
       - 65535
@@ -61,6 +66,7 @@ networks:
     dns:
       hosts: "{{dns_extrahosts | default([])}}"
       forwarders:
+        # Use 127.0.0.1 unless only IPv6 is enabled
         - domain: "apps.{{ cluster_domain }}"
-          addr: "{% if baremetal_network_cidr|ipv6 != False %}::1{% else %}127.0.0.1{% endif %}"
+          addr: "{% if baremetal_network_cidr_v4|ipv4 != False %}127.0.0.1{% else %}::1{% endif %}"
       srvs: "{{dns_externalsrvs | default([])}}"

--- a/vm-setup/roles/libvirt/templates/ironic_nodes.json.j2
+++ b/vm-setup/roles/libvirt/templates/ironic_nodes.json.j2
@@ -1,11 +1,11 @@
 {% set lvars = { 'host_ip' : '192.168.122.1', 'pxe_network' : False} %}
 {% for network in networks %}
-{% if (not (network.forward_mode is defined and network.forward_mode == 'nat') and lvars['pxe_network'] == False) %}
-{% if lvars.update({'pxe_network' : network.name}) %}{% endif %}
-{% endif %}
-{% if network.address is defined and lvars['host_ip'] == '192.168.122.1' %}
-{% if lvars.update({'host_ip' : network.address}) %}{% endif %}
-{% endif %}
+  {% if (not (network.forward_mode is defined and network.forward_mode == 'nat') and lvars['pxe_network'] == False) %}
+    {% if lvars.update({'pxe_network' : network.name}) %}{% endif %}
+  {% endif %}
+  {% if network.address_v4 is defined and lvars['host_ip'] == '192.168.122.1' %}
+    {% if lvars.update({'host_ip' : network.address_v4}) %}{% endif %}
+  {% endif %}
 {% endfor %}
 {
   "nodes": [

--- a/vm-setup/roles/libvirt/templates/ironic_nodes.json.j2
+++ b/vm-setup/roles/libvirt/templates/ironic_nodes.json.j2
@@ -1,10 +1,13 @@
-{% set lvars = { 'host_ip' : '192.168.122.1', 'pxe_network' : False} %}
+{% set lvars = { 'host_ip' : 'NOTSET', 'pxe_network' : False} %}
 {% for network in networks %}
   {% if (not (network.forward_mode is defined and network.forward_mode == 'nat') and lvars['pxe_network'] == False) %}
     {% if lvars.update({'pxe_network' : network.name}) %}{% endif %}
   {% endif %}
-  {% if network.address_v4 is defined and lvars['host_ip'] == '192.168.122.1' %}
+  {% if network.address_v4 is defined and network.address_v4 != '' and lvars['host_ip'] == 'NOTSET' %}
     {% if lvars.update({'host_ip' : network.address_v4}) %}{% endif %}
+  {% endif %}
+  {% if network.address_v6 is defined and network.address_v6 != '' and lvars['host_ip'] == 'NOTSET' %}
+    {% if lvars.update({'host_ip' : network.address_v6}) %}{% endif %}
   {% endif %}
 {% endfor %}
 {

--- a/vm-setup/roles/libvirt/templates/network.xml.j2
+++ b/vm-setup/roles/libvirt/templates/network.xml.j2
@@ -1,6 +1,7 @@
 {% set nat_port_range = item.nat_port_range|default([1024, 65535]) %}
-{% set netmask = item.netmask|default("") %}
-{% set prefix = item.prefix|default("") %}
+{% set netmask_v4 = item.netmask_v4|default("") %}
+{% set prefix_v6 = item.prefix_v6|default("") %}
+
 {% if item.dns.options is defined %}
 <network xmlns:dnsmasq='http://libvirt.org/schemas/network/dnsmasq/1.0'>
   <dnsmasq:options>
@@ -9,83 +10,130 @@
 {% else %}
 <network>
 {% endif %}
+
   <name>{{ item.name }}</name>
   <bridge name='{{ item.bridge }}'/>
+
 {% if item.forward_mode is defined %}
   <forward mode='{{ item.forward_mode }}'>
-{% if item.forward_mode == 'nat' %}
+  {% if item.forward_mode == 'nat' %}
     <nat>
       <port start='{{ nat_port_range[0] }}' end='{{ nat_port_range[1] }}' />
     </nat>
-{% endif %}
+  {% endif %}
   </forward>
 {% endif %}
+
 {% if item.virtualport_type is defined %}
       <virtualport type='{{ item.virtualport_type }}'/>
 {% endif %}
-{% if item.address is defined  and item.forward_mode != 'bridge' %}
-{% if item.address|ipv6 != False %}
-  <ip family="ipv6" address='{{ item.address }}' prefix='{{ prefix }}'>
-{% else %}
-  <ip address='{{ item.address }}' netmask='{{ netmask }}'>
-{% endif %}
-{% if item.dhcp_range is defined %}
+
+{# IPv4 Configuration #}
+{% if item.address_v4 is defined and item.address_v4 != '' and item.forward_mode != 'bridge' %}
+  <ip address='{{ item.address_v4 }}' netmask='{{ netmask_v4 }}'>
+  {% if item.dhcp_range_v4 is defined %}
     <dhcp>
-      <range start='{{ item.dhcp_range[0] }}' end='{{ item.dhcp_range[1] }}'/>
-{% set ns = namespace(index=0) %}
-{% for flavor in flavors %}
-{% set numflavor = lookup('vars', 'num_' + flavor + 's')|default(0)|int %}
-{% for num in range(0, numflavor) %}
-{% set ironic_name = ironic_prefix + flavor + "_" + num|string %}
-{% set hostname_format = lookup('vars', flavor + '_hostname_format', default=flavor + '-%d') %}
-{% set hostname = hostname_format % num %}
-{% if item.address|ipv6 != False %}
-      <host id='00:03:00:01:{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}' ip='{{item.dhcp_range[0]|ipmath(ns.index|int)}}'/>
-{% else %}
-      <host mac='{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}' ip='{{item.dhcp_range[0]|ipmath(ns.index|int)}}'/>
-{% endif %}
-{% set ns.index = ns.index + 1 %}
-{% endfor %}
-{% endfor %}
+      <range start='{{ item.dhcp_range_v4[0] }}' end='{{ item.dhcp_range_v4[1] }}'/>
+    {% set ns = namespace(index=0) %}
+    {% for flavor in flavors %}
+      {% set numflavor = lookup('vars', 'num_' + flavor + 's')|default(0)|int %}
+      {% for num in range(0, numflavor) %}
+        {% set ironic_name = ironic_prefix + flavor + "_" + num|string %}
+        {% set hostname_format = lookup('vars', flavor + '_hostname_format', default=flavor + '-%d') %}
+        {% set hostname = hostname_format % num %}
+      <host mac='{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}' ip='{{item.dhcp_range_v4[0]|ipmath(ns.index|int)}}'/>
+        {% set ns.index = ns.index + 1 %}
+      {% endfor %}
+    {% endfor %}
     </dhcp>
-{% endif %}
+  {% endif %}
   </ip>
-{% if item.domain is defined %}
+  {% if item.domain is defined %}
   <domain name='{{ item.domain }}' localOnly='yes'/>
-{% endif %}
-{% if item.dns is defined %}
+  {% endif %}
+  {% if item.dns is defined %}
   <dns>
-  {% for host in item.dns.hosts %}
+    {% for host in item.dns.hosts %}
     <host ip='{{ host.ip }}'>
-    {% for name in host.hostnames %}
+      {% for name in host.hostnames %}
       <hostname>{{ name }}</hostname>
-    {% endfor %}
+      {% endfor %}
     </host>
-  {% endfor %}
-  {% if item.dns.srvs is defined %}
-    {% for srv in item.dns.srvs %}
+    {% endfor %}
+    {% if item.dns.srvs is defined %}
+      {% for srv in item.dns.srvs %}
     <srv service='{{ srv.name }}' protocol='{{ srv.protocol }}' domain='{{ srv.domain }}' port='{{ srv.port }}' target='{{ srv.target }}' />
-    {% endfor %}
-  {% endif %}
-  {% if item.dns.forwarders is defined %}
-    {% for forwarder in item.dns.forwarders %}
+      {% endfor %}
+    {% endif %}
+    {% if item.dns.forwarders is defined %}
+      {% for forwarder in item.dns.forwarders %}
     <forwarder domain='{{ forwarder.domain }}' addr='{{ forwarder.addr }}' />
-    {% endfor %}
-  {% endif %}
+      {% endfor %}
+    {% endif %}
   </dns>
+  {% endif %}
 {% endif %}
+{# End IPv4 Configuration #}
+
+{# IPv6 Configuration #}
+{% if item.address_v6 is defined and item.address_v6 != '' and item.forward_mode != 'bridge' %}
+  <ip family="ipv6" address='{{ item.address_v6 }}' prefix='{{ prefix_v6 }}'>
+  {% if item.dhcp_range_v6 is defined %}
+    <dhcp>
+      <range start='{{ item.dhcp_range_v6[0] }}' end='{{ item.dhcp_range_v6[1] }}'/>
+    {% set ns = namespace(index=0) %}
+    {% for flavor in flavors %}
+      {% set numflavor = lookup('vars', 'num_' + flavor + 's')|default(0)|int %}
+      {% for num in range(0, numflavor) %}
+        {% set ironic_name = ironic_prefix + flavor + "_" + num|string %}
+        {% set hostname_format = lookup('vars', flavor + '_hostname_format', default=flavor + '-%d') %}
+        {% set hostname = hostname_format % num %}
+        <host id='00:03:00:01:{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}' ip='{{item.dhcp_range_v6[0]|ipmath(ns.index|int)}}'/>
+        {% set ns.index = ns.index + 1 %}
+      {% endfor %}
+    {% endfor %}
+    </dhcp>
+  {% endif %}
+  </ip>
+  {% if item.domain is defined %}
+  <domain name='{{ item.domain }}' localOnly='yes'/>
+  {% endif %}
+  {% if item.dns is defined %}
+  <dns>
+    {% for host in item.dns.hosts %}
+    <host ip='{{ host.ip }}'>
+      {% for name in host.hostnames %}
+      <hostname>{{ name }}</hostname>
+      {% endfor %}
+    </host>
+    {% endfor %}
+    {% if item.dns.srvs is defined %}
+      {% for srv in item.dns.srvs %}
+    <srv service='{{ srv.name }}' protocol='{{ srv.protocol }}' domain='{{ srv.domain }}' port='{{ srv.port }}' target='{{ srv.target }}' />
+      {% endfor %}
+    {% endif %}
+    {% if item.dns.forwarders is defined %}
+      {% for forwarder in item.dns.forwarders %}
+    <forwarder domain='{{ forwarder.domain }}' addr='{{ forwarder.addr }}' />
+      {% endfor %}
+    {% endif %}
+  </dns>
+  {% endif %}
 {% endif %}
+{# End IPv6 Configuration #}
+
 {% if item.portgroup is defined %}
   {% for portgroup in item.portgroup %}
   <portgroup name='{{ portgroup.name }}'>
-  {% if portgroup.vlan is defined %}
+    {% if portgroup.vlan is defined %}
     <vlan>
-    {% for vlan in portgroup.vlan %}
+      {% for vlan in portgroup.vlan %}
       <tag id='{{ vlan.tag }}'/>
-    {% endfor %}
+      {% endfor %}
     </vlan>
-  {% endif %}
+    {% endif %}
   </portgroup>
   {% endfor %}
 {% endif %}
+
 </network>

--- a/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
+++ b/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
@@ -84,7 +84,7 @@
       password = password
       domain_name = {{ item.name }}
       libvirt_uri = {{ vbmc_libvirt_uri }}
-      address = {{ baremetal_network_cidr_v4|nthhost(1) }}
+      address = {{ vbmc_address }}
       active = True
       port = {{ item.virtualbmc_port }}
   with_items: "{{ vm_nodes }}"

--- a/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
+++ b/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
@@ -38,10 +38,19 @@
     non_root_user_uid: "{{ non_root_user_uid.stdout }}"
 
 # The first network defined with an address will be used for vbmc access.
-- name: set vbmc address if there is a (nat) network defined with an address
+- name: set vbmc address (v4) if there is a (nat) network defined with an address
   set_fact:
-    vbmc_address: "{{ networks|selectattr('address', 'defined')|map(attribute='address')|list|first }}"
-  when: networks|selectattr('address', 'defined')|map(attribute='name')|list|length > 0
+    vbmc_address_v4: "{{ networks|selectattr('address_v4', 'defined')|map(attribute='address_v4')|list|first }}"
+  when: networks|selectattr('address_v4', 'defined')|map(attribute='name')|list|length > 0
+
+- name: set vbmc address (v6) if there is a (nat) network defined with an address
+  set_fact:
+    vbmc_address_v6: "{{ networks|selectattr('address_v6', 'defined')|map(attribute='address_v6')|list|first }}"
+  when: networks|selectattr('address_v6', 'defined')|map(attribute='name')|list|length > 0
+
+- name: set vbmc address from IPv4 networks if possible, otherwise IPv6
+  set_fact:
+    vbmc_address: "{% if vbmc_address_v4|ipv4 != False %}{{ vbmc_address_v4 }}{% else %}{{ vbmc_address_v6 }}{% endif %}"
 
 # The connection uri is slightly different when using qemu:///system
 # and requires the root user.
@@ -75,7 +84,7 @@
       password = password
       domain_name = {{ item.name }}
       libvirt_uri = {{ vbmc_libvirt_uri }}
-      address = {{ baremetal_network_cidr|nthhost(1) }}
+      address = {{ baremetal_network_cidr_v4|nthhost(1) }}
       active = True
       port = {{ item.virtualbmc_port }}
   with_items: "{{ vm_nodes }}"


### PR DESCRIPTION
metal3-dev-env previously included support for an IPv4 or an IPv6
baremetal libvirt network.  This patch adds the ability to also have
dual-stack (IPv4+IPv6).

There is some impact to the configuration in this change.  IPv4-only
is the default.  To use IPv6 or IPv4+IPv6, you must set the new
IP_STACK configuration variable.  It can be set to "v4", "v6", or
"v4v6".

Instead of EXTERNAL_SUBNET, the configuration now supports
EXTERNAL_SUBNET_V4 and EXTERNAL_SUBNET_V6 to allow specifying IPv4 and
IPv6 subnets at the same time.

The network.xml.j2 template is changed more than strictly necessary,
because I found the nesting of conditionals and loops difficult to
follow without any indentation.

I've validated this by ensuring that the 04_verify.sh script still
completes successfully with "v4" or "v4v6" IP_STACK mode.  With either
"v6" or "v4v6", I validated that I could configure one of the virtual
bare metal hosts with DHCPv6 and successfully get a lease.

More work is needed to actually provision an IPv6 or IPv4+IPv6
kubernetes cluster, but these changes are a prerequisite.