### PR TITLE
Set go_install_clean_full

### DIFF
--- a/vm-setup/install-package-playbook.yml
+++ b/vm-setup/install-package-playbook.yml
@@ -11,3 +11,4 @@
       vars:
         go_version: 1.14
         go_install_clean: true
+        go_install_clean_full: false


### PR DESCRIPTION
With go_install_clean=true and go_install_clean_full=false
old golang installs are cleaned up without cleaning up GOPATH

New param added to fubarhouse/ansible-role-golang here
https://github.com/fubarhouse/ansible-role-golang/pull/152

Fixed: #285