### PR TITLE
Fix exporting the image variable after override

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -131,7 +131,7 @@ function update_images(){
       kustomize edit set image $OLD_IMAGE=$LOCAL_IMAGE
     fi
     declare "$OLD_IMAGE_VAR"="$LOCAL_IMAGE"
-    export OLD_IMAGE_VAR
+    export "${OLD_IMAGE_VAR?}"
   done
 }
 


### PR DESCRIPTION
they are currrently not properly exported, so the override is ineffective for run_local_ironic.sh script