### PR TITLE
Temporary workaround for ironic issues

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -57,8 +57,11 @@ if [ "${EPHEMERAL_CLUSTER}" == "kind" ]; then
   IRONIC_HOST="${PROVISIONING_URL_HOST}"
   BMO_CONFIG="ironic-outside-config"
 else
-  IRONIC_HOST="${CLUSTER_URL_HOST}"
-  BMO_CONFIG="ironic-keepalived-config"
+  # TODO temporary hack around ironic issue, revert asap
+  #IRONIC_HOST="${CLUSTER_URL_HOST}"
+  #BMO_CONFIG="ironic-keepalived-config"
+  IRONIC_HOST="${PROVISIONING_URL_HOST}"
+  BMO_CONFIG="ironic-outside-config"
 fi
 
 function clone_repos() {
@@ -183,9 +186,11 @@ function launch_baremetal_operator() {
       kubectl scale deployment metal3-baremetal-operator -n metal3 --replicas=0
     fi
 
-    if [ "${BMO_RUN_LOCAL}" = true ] || [ "${EPHEMERAL_CLUSTER}" = kind ]; then
-      ${RUN_LOCAL_IRONIC_SCRIPT}
-    fi
+    # TODO temporary hack around ironic issue, revert asap
+    #if [ "${BMO_RUN_LOCAL}" = true ] || [ "${EPHEMERAL_CLUSTER}" = kind ]; then
+    #  ${RUN_LOCAL_IRONIC_SCRIPT}
+    #fi
+    ${RUN_LOCAL_IRONIC_SCRIPT}
 
     if [ "${BMO_RUN_LOCAL}" = true ]; then
       nohup "${SCRIPTDIR}/hack/run-bmo-loop.sh" >> bmo.out.log 2>>bmo.err.log &


### PR DESCRIPTION
Revert ASAP

This deploys ironic outside of the cluster, to control the creation of the containers.