### PR TITLE
Add firewall rules state "absent" during make clean in Metal3-dev-env 

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -46,6 +46,14 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -i vm-setup/inventory.ini \
     -b -vvv vm-setup/teardown-playbook.yml
 
+if [ "$USE_FIREWALLD" == "False" ]; then
+ ANSIBLE_FORCE_COLOR=true ansible-playbook \
+    -e "{use_firewalld: $USE_FIREWALLD}" \
+    -e "firewall_rule_state=absent" \
+    -i vm-setup/inventory.ini \
+    -b -vvv vm-setup/firewall.yml
+fi
+
 # There was a bug in this file, it may need to be recreated.
 if [[ $OS == "centos" || $OS == "rhel" ]]; then
   sudo rm -rf /etc/NetworkManager/conf.d/dnsmasq.conf

--- a/vm-setup/roles/firewall/defaults/main.yml
+++ b/vm-setup/roles/firewall/defaults/main.yml
@@ -2,6 +2,7 @@ use_firewalld: true
 baremetal_interface: baremetal
 provisioning_interface: provisioning
 vbmc_port_range: "6230:6235"
+firewall_rule_state: present
 ironic_ports:
   - "6180"
   - "5050"

--- a/vm-setup/roles/firewall/tasks/iptables.yaml
+++ b/vm-setup/roles/firewall/tasks/iptables.yaml
@@ -13,6 +13,7 @@
     match: udp
     destination_port: "{{ vbmc_port_range }}"
     jump: ACCEPT
+    state: "{{ firewall_rule_state }}"
 
 - name: "iptables: Established and related"
   iptables:
@@ -21,6 +22,7 @@
     match: conntrack
     ctstate: ESTABLISHED,RELATED
     jump: ACCEPT
+    state: "{{ firewall_rule_state }}"
 
 - name: "iptables: Ironic Ports"
   iptables:
@@ -30,6 +32,7 @@
     match: tcp
     destination_port: "{{ item }}"
     jump: ACCEPT
+    state: "{{ firewall_rule_state }}"
   loop: "{{ ironic_ports }}"
 
 - name: "iptables: Provisioning host ports"
@@ -40,6 +43,7 @@
     match: tcp
     destination_port: "{{ item }}"
     jump: ACCEPT
+    state: "{{ firewall_rule_state }}"
   loop: "{{ provisioning_host_ports }}"
 
 - name: "iptables: PXE Ports"
@@ -50,6 +54,7 @@
     match: udp
     destination_port: "{{ item }}"
     jump: ACCEPT
+    state: "{{ firewall_rule_state }}"
   loop: "{{ pxe_udp_ports }}"
 
 - name: "iptables: Ironic Endpoint Keepalived"
@@ -58,6 +63,7 @@
     in_interface: "{{ provisioning_interface }}"
     protocol: "{{ item }}"
     jump: ACCEPT
+    state: "{{ firewall_rule_state }}"
   loop: "{{ ironic_keepalived_proto }}"
 
 - name: "iptables: Allow access to baremetal network from kind"
@@ -67,4 +73,5 @@
     out_interface: "{{ baremetal_interface }}"
     destination: "192.168.111.1/24"
     jump: ACCEPT
+    state: "{{ firewall_rule_state }}"
   when: (EPHEMERAL_CLUSTER == "kind")


### PR DESCRIPTION
#298
This issue is related to the iptables rules in Metal3-dev-env. After we do `make clean`, the iptables rules are still active in the firewall. So here we keep the state absent for each iptables rule during the `make clean` process. 