### PR TITLE
Add local registry as insecure for podman

### DIFF
--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -60,6 +60,7 @@ fi
 
 if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
   sudo dnf -y install podman
+  sudo sed -i '/^\[registries\.insecure\]$/,/^\[/ s/^registries =.*/registries = ["192.168.111.1:5000"]/g' /etc/containers/registries.conf
 else
   if [[ $DISTRO == "centos7" ]]; then
     sudo dnf install -y dnf-utils \

--- a/ubuntu_install_requirements.sh
+++ b/ubuntu_install_requirements.sh
@@ -47,6 +47,7 @@ sudo apt -y update
 
 if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
   sudo apt -y install podman
+  sudo sed -i '/^\[registries\.insecure\]$/,/^\[/ s/^registries =.*/registries = ["192.168.111.1:5000"]/g' /etc/containers/registries.conf
 else
   sudo apt -y install \
     apt-transport-https \


### PR DESCRIPTION
Running ironic locally is failing because podman is unable to pull the image from local registry. This PR sets the local registry as insecure globally