### PR TITLE
Sync keepalived status with of API server

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_centos.rc
+++ b/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_centos.rc
@@ -31,11 +31,45 @@ export CTLPLANE_KUBEADM_EXTRA_CONFIG="
       - curl -sSL \"https://raw.githubusercontent.com/kubernetes/release/{{ KUBERNETES_BINARIES_CONFIG_VERSION }}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf\" | sed \"s:/usr/bin:/usr/local/bin:g\" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
       - usermod -aG docker metal3
       - systemctl enable --now docker keepalived kubelet
+      - systemctl link /etc/systemd/system/multi-user.target.wants/monitor.keepalived.service
+      - systemctl enable --now monitor.keepalived.service
     postKubeadmCommands:
       - mkdir -p /home/metal3/.kube
       - cp /etc/kubernetes/admin.conf /home/metal3/.kube/config
       - chown metal3:metal3 /home/metal3/.kube/config
     files:
+      - path: /usr/local/bin/monitor.keepalived.sh
+        owner: root:root
+        permissions: '0755'
+        content: |
+            #!/bin/bash
+            while :; do
+              curl -sk https://127.0.0.1:6443/healthz 1>&2 > /dev/null
+              isOk=\$?
+              isActive=\$(systemctl show -p ActiveState keepalived.service | cut -d'=' -f2)
+              if [ \$isOk == \"0\" ] &&  [ \$isActive != \"active\" ]; then
+                logger 'API server is healthy, however keepalvied is not running, starting keepalived'
+                echo 'API server is healthy and keepalvied is down, starting keepalived'
+                sudo systemctl start keepalived.service
+              elif [ \$isOk != \"0\" ] &&  [ \$isActive == \"active\" ]; then
+                logger 'API server is healthy, however keepalvied is not running, starting keepalived'
+                echo 'API server is not healthy and keepalvied is running, stopping keepalived'
+                sudo systemctl stop keepalived.service
+              fi
+              sleep 5
+            done
+      - path: /etc/systemd/system/multi-user.target.wants/monitor.keepalived.service
+        owner: root:root
+        content: |
+          [Unit]
+          Description=Monitors keepalived adjusts status with that of API server
+          After=syslog.target network-online.target
+          [Service]
+          Type=simple
+          Restart=always
+          ExecStart=/usr/local/bin/monitor.keepalived.sh
+          [Install]
+          WantedBy=multi-user.target
       - path: /etc/keepalived/keepalived.conf
         content: |
           ! Configuration File for keepalived

--- a/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_ubuntu.rc
+++ b/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_ubuntu.rc
@@ -37,12 +37,48 @@ export CTLPLANE_KUBEADM_EXTRA_CONFIG="
       - systemctl enable --now docker kubelet
       - if (curl -sk --max-time 10 https://{{ CLUSTER_APIENDPOINT_HOST }}:6443/healthz); then echo \"keepalived already running\";else systemctl start keepalived; fi
       - usermod -aG docker metal3
+      - systemctl link /etc/systemd/system/multi-user.target.wants/monitor.keepalived.service
+      - systemctl enable --now monitor.keepalived.service
     postKubeadmCommands:
       - mkdir -p /home/metal3/.kube
       - cp /etc/kubernetes/admin.conf /home/metal3/.kube/config
       - systemctl enable --now keepalived
       - chown metal3:metal3 /home/metal3/.kube/config
     files:
+        - path: /usr/local/bin/monitor.keepalived.sh
+          owner: root:root
+          permissions: '0755'
+          content: |
+              #!/bin/bash
+              while :; do
+                curl -sk https://127.0.0.1:6443/healthz 1>&2 > /dev/null
+                isOk=\$?
+                isActive=\$(systemctl show -p ActiveState keepalived.service | cut -d'=' -f2)
+                if [ \$isOk == \"0\" ] &&  [ \$isActive != \"active\" ]; then
+                  logger 'API server is healthy, however keepalvied is not running, starting keepalived'
+                  echo 'API server is healthy and keepalvied is down, starting keepalived'
+                  sudo systemctl start keepalived.service
+                elif [ \$isOk != \"0\" ] &&  [ \$isActive == \"active\" ]; then
+                  logger 'API server is healthy, however keepalvied is not running, starting keepalived'
+                  echo 'API server is not healthy and keepalvied is running, stopping keepalived'
+                  sudo systemctl stop keepalived.service
+                fi
+                sleep 5
+              done
+        - path: /etc/systemd/system/multi-user.target.wants/monitor.keepalived.service
+          owner: root:root
+          content: |
+              [Unit]
+              Description=Monitors keepalived adjusts status with that of API server
+              After=syslog.target network-online.target
+
+              [Service]
+              Type=simple
+              Restart=always
+              ExecStart=/usr/local/bin/monitor.keepalived.sh
+
+              [Install]
+              WantedBy=multi-user.target
         - path: /etc/keepalived/keepalived.conf
           content: |
             ! Configuration File for keepalived


### PR DESCRIPTION
During the upgrade of control plane node process, the VIP remains on a node on which no APi server is running. The VIP is not migrating to other nodes due to the node owning the VIP having higher IP. 

The purpose of this PR is to stop keepalived on a node where there is not API server running or is not healthy. It also start the keepalived when the API server becomes healthy.