### PR TITLE
Switch to pip installing virtualbmc

### DIFF
--- a/resources/vbmc/Dockerfile
+++ b/resources/vbmc/Dockerfile
@@ -1,10 +1,10 @@
 FROM docker.io/centos:centos8
 
-RUN dnf install -y python3 python3-requests && \
+RUN dnf install -y python3 python3-requests pkgconf-pkg-config python3-libvirt openssh-clients && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current && \
     dnf update -y && \
-    dnf install -y python3-virtualbmc && \
     dnf clean all && \
+    pip3 install virtualbmc && \
     rm -rf /var/cache/{yum,dnf}/*
 
-CMD /usr/bin/vbmcd --foreground
+CMD /usr/local/bin/vbmcd --foreground


### PR DESCRIPTION
pyghmi 1.5.13 is needed for a cipher fix but not
yet available in RDO. Switch to pip while we wait.