### PR TITLE
Remove interactive terminal from openstackclient.sh

### DIFF
--- a/openstackclient.sh
+++ b/openstackclient.sh
@@ -10,6 +10,6 @@ else
   MOUNTDIR="${SCRIPTDIR}/_clouds_yaml"
 fi
 
-sudo "${CONTAINER_RUNTIME}" run -ti --net=host \
+sudo "${CONTAINER_RUNTIME}" run --net=host \
   -v "${MOUNTDIR}:/etc/openstack" --rm \
   -e OS_CLOUD="${OS_CLOUD:-metal3}" "${IRONIC_CLIENT_IMAGE}" "$@"


### PR DESCRIPTION
The command is sometimes slow to exit (and sometimes has to
be killed). The problem appears to be with releasing the
interactive terminal.