### PR TITLE
Remove container images pre-pull

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -76,12 +76,6 @@ source lib/network.sh
 # shellcheck disable=SC1091
 source lib/images.sh
 
-# Pull images we'll need
-for IMAGE_VAR in IRONIC_IMAGE IPA_DOWNLOADER_IMAGE VBMC_IMAGE SUSHY_TOOLS_IMAGE DOCKER_REGISTRY_IMAGE; do
-    IMAGE=${!IMAGE_VAR}
-    sudo "${CONTAINER_RUNTIME}" pull "$IMAGE"
-done
-
 # Download IPA and CentOS 7 Images
 mkdir -p "$IRONIC_IMAGE_DIR"
 pushd "$IRONIC_IMAGE_DIR"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -334,12 +334,6 @@ function init_minikube() {
     #If the vm exists, it has already been initialized
     if [[ "$(sudo virsh list --all)" != *"minikube"* ]]; then
       sudo su -l -c "minikube start --insecure-registry 192.168.111.1:5000" "$USER"
-      # Pre-pull the image to reduce pod initialization time
-      for IMAGE_VAR in IRONIC_IMAGE IPA_DOWNLOADER_IMAGE IRONIC_INSPECTOR_IMAGE BAREMETAL_OPERATOR_IMAGE; do
-        IMAGE=${!IMAGE_VAR}
-        sudo su -l -c "minikube ssh sudo docker pull $IMAGE" "${USER}"
-      done
-      sudo su -l -c "minikube ssh sudo docker image ls" "${USER}"
       sudo su -l -c "minikube stop" "$USER"
     fi
 


### PR DESCRIPTION
Since we do not pre-bake the image anymore for CI, this pre-pull
is unnecessary and consumes a lot of time downloading twice
some images that are not even used if we use the one built locally