### PR TITLE
:Fix: Variablize ironic endpoint bridge name

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_ubuntu.rc
+++ b/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_ubuntu.rc
@@ -121,7 +121,7 @@ export CTLPLANE_KUBEADM_EXTRA_CONFIG="
               version: 2
               renderer: networkd
               bridges:
-                ironicendpoint:
+                {{ IRONIC_ENDPOINT_BRIDGE }}:
                   interfaces: [enp1s0]
                   dhcp4: yes
 "

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -28,6 +28,8 @@ CONTAINER_RUNTIME: "{{ lookup('env', 'CONTAINER_RUNTIME') | default('podman', tr
 DEFAULT_HOSTS_MEMORY: "{{ lookup('env', 'DEFAULT_HOSTS_MEMORY') | default('4096', true)}}"
 CAPI_VERSION: "{{ lookup('env', 'CAPI_VERSION') | default('v1alpha3', true)}}"
 IRONIC_IMAGE_DIR: "{{ lookup('env', 'IRONIC_IMAGE_DIR') | default('/opt/metal3-dev-env/ironic/html/images')}}"
+IRONIC_ENDPOINT_BRIDGE: "{{ lookup('env', 'CLUSTER_PROVISIONING_INTERFACE') | default('provisioning')}}"
+
 
 # Distibution specific environment variables
 IMAGE_NAME: 'bionic-server-cloudimg-amd64.img'


### PR DESCRIPTION
The ironic endpoint bridge name might change in different baremetal-operator deployments. Variablizing would make it easier to track. 