### PR TITLE
Log libvirt serial consoles to a file

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -68,4 +68,7 @@ if [[ $OS == "centos" || $OS == "rhel" ]]; then
   fi
 fi
 
+# Clean up any serial logs
+sudo rm -rf /var/log/libvirt/qemu/\*serial0.log
+
 rm -rf  "${HOME}"/.cluster-api

--- a/vm-setup/roles/libvirt/defaults/main.yml
+++ b/vm-setup/roles/libvirt/defaults/main.yml
@@ -16,6 +16,9 @@ libvirt_arch: x86_64
 libvirt_cpu_mode: host-model
 libvirt_firmware: bios
 
+# Where to log serial console output
+libvirt_log_path: "/var/log/libvirt/qemu"
+
 # how many disks should be created when using extradisks
 extradisks_list:
   - vdb

--- a/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
+++ b/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
@@ -43,7 +43,9 @@
 {% endif %}
     </interface>
 {% endfor %}
-    <serial type='pty'/>
+    <serial type='pty'>
+      <log file="{{ libvirt_log_path }}/{{ item.name }}-serial0.log" append="on"/>
+    </serial>
     <console type='pty'/>
 
 {% if enable_vnc_console|bool %}


### PR DESCRIPTION
Per the libvirt documentation[1], character devices can have an optional
log file associated with them.

This adds logging to our serial ports. Having the serial output of the
libvirt VM's can be useful for troubleshooting, especially in CI.
Failures in IPA or PXE can be detected this way.

[1] https://libvirt.org/formatdomain.html#elementsConsole