### PR TITLE
Add test-framework

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -8,51 +8,6 @@ source lib/common.sh
 # shellcheck disable=SC1091
 source lib/network.sh
 
-eval "$(go env)"
-export GOPATH
-
-# Environment variables
-# M3PATH : Path to clone the metal3 dev env repo
-# BMOPATH : Path to clone the baremetal operator repo
-# CAPM3PATH: Path to clone the CAPI operator repo
-#
-# BMOREPO : Baremetal operator repository URL
-# BMOBRANCH : Baremetal operator repository branch to checkout
-# CAPM3REPO : CAPI operator repository URL
-# CAPM3BRANCH : CAPI repository branch to checkout
-# FORCE_REPO_UPDATE : discard existing directories
-#
-# BMO_RUN_LOCAL : run the baremetal operator locally (not in Kubernetes cluster)
-# CAPM3_RUN_LOCAL : run the CAPI operator locally
-
-M3PATH="${M3PATH:-${GOPATH}/src/github.com/metal3-io}"
-BMOPATH="${BMOPATH:-${M3PATH}/baremetal-operator}"
-RUN_LOCAL_IRONIC_SCRIPT="${BMOPATH}/tools/run_local_ironic.sh"
-CAPM3PATH="${CAPM3PATH:-${M3PATH}/cluster-api-provider-metal3}"
-
-CAPI_BASE_URL="${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}"
-CAPM3_BASE_URL="${CAPM3_BASE_URL:-metal3-io/cluster-api-provider-metal3}"
-
-CAPIREPO="${CAPIREPO:-https://github.com/${CAPI_BASE_URL}}"
-CAPM3REPO="${CAPM3REPO:-https://github.com/${CAPM3_BASE_URL}}"
-
-CAPIPATH="${CAPIPATH:-${M3PATH}/cluster-api}"
-CAPM3RELEASEPATH="${CAPM3RELEASEPATH:-https://api.github.com/repos/${CAPM3_BASE_URL}/releases/latest}"
-CAPM3RELEASE="${CAPM3RELEASE:-$(get_latest_release "${CAPM3RELEASEPATH}")}"
-if [ "${CAPI_VERSION}" == "v1alpha4" ]; then
-  CAPM3BRANCH="${CAPM3BRANCH:-master}"
-else
-  CAPM3BRANCH="${CAPM3BRANCH:-release-0.3}"
-fi
-CAPIBRANCH="${CAPIBRANCH:-master}"
-
-BMOREPO="${BMOREPO:-https://github.com/metal3-io/baremetal-operator.git}"
-BMOBRANCH="${BMOBRANCH:-master}"
-FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-false}"
-
-BMO_RUN_LOCAL="${BMO_RUN_LOCAL:-false}"
-CAPM3_RUN_LOCAL="${CAPM3_RUN_LOCAL:-false}"
-
 if [ "${EPHEMERAL_CLUSTER}" == "kind" ]; then
   IRONIC_HOST="${PROVISIONING_URL_HOST}"
   BMO_CONFIG="ironic-outside-config"

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,21 @@ test:
 lint:
 	./hack/shellcheck.sh
 
+setup_env:
+	./scripts/feature_tests/setup_env.sh
+
+cleanup_env:
+	./scripts/feature_tests/cleanup_env.sh
+
+pivoting_test:
+	make -C ./scripts/feature_tests/pivoting/
+
+remediation_test:
+	make -C ./scripts/feature_tests/remediation/
+
+upgrade_test:
+	make -C ./scripts/feature_tests/upgrade/
+
+feature_tests: setup_env remediation_test cleanup_env pivoting_test
+
 .PHONY: all install_requirements configure_host launch_mgmt_cluster clean delete_mgmt_cluster host_cleanup verify test lint

--- a/scripts/feature_tests/README.md
+++ b/scripts/feature_tests/README.md
@@ -1,0 +1,99 @@
+# Feature tests framework
+
+## Build Status
+
+[![Ubuntu V1alpha3 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_feature_tests_ubuntu/badge/icon?subject=Ubuntu%20E2E%20V1alpha3)](https://jenkins.nordix.org/view/Airship/job/airship_master_feature_tests_ubuntu/)
+
+Feature tests framework is made to run a set of scripts for testing pivoting,
+remediation and upgrade functionalities of Metal3 project.
+The framework relies on already existing test scripts of each
+feature in Metal3-dev-env. The motivation behind the framework is to be able to
+test pivoting/remediation/upgrade features in Metal3-dev-env environment and
+detect breaking changes in advance.
+
+Test-framework CI can be triggered from a pull request in CAPM3, BMO,
+metal3-dev-env, project-infra, ironic-image, ironic-inspector-image and
+ironic-ipa-downloader repositories.
+It is recommended to run test-framework CI especially when
+introducing a commit related to pivoting/remediation/upgrade, to ensure that new
+changes will not break the existing functionalities.
+
+Test-framework can be triggered by leaving `/test-features` comment on a pull
+request. The folder structure of the test-framework and its related scripts
+look as following:
+
+```ini
+├── feature_tests
+│   ├── cleanup_env.sh
+│   ├── feature_test_deprovisioning.sh
+│   ├── feature_test_provisioning.sh
+│   ├── pivoting
+│   │   └── Makefile
+│   ├── remediation
+│   │   └── Makefile
+│   ├── setup_env.sh
+│   └── upgrade
+│       └── Makefile
+```
+
+Each feature has its own Makefile that will call feature specific test steps.
+`setup_env.sh` is used to build an environment, i.e. run `make`, that will give
+N (from the test-framework perspective N=4) number of ready BMH as an output.
+`cleanup_env.s` is used for intermediate cleaning between each feature test.
+`feature_test_provisioning.sh` and `feature_test_deprovisioning.sh` are used by
+each feature test to provision/deprovision cluster and BMH.
+
+When the test-framework is triggered, it will:
+
+- setup metal3-dev-env
+  - run 01_\*, 02_\*, 03_\*, 04_\* scripts
+- run remediation tests
+  - provision cluster and BMH
+  - run remediation tests
+  - deprovision cluster and BMH
+- clean up the environment
+  - run `cleanup_env.sh`
+- run upgrade tests
+  - provision cluster and BMH
+  - run remediation tests
+  - deprovision cluster and BMH
+- clean up the environment
+  - run `cleanup_env.sh`
+- run pivoting tests
+  - provision cluster and BMH
+  - run remediation tests
+  - deprovision cluster and BMH
+  - destroy the environment (i.e. run `make clean`)
+
+## Environment variables
+
+Currently the test-framework supports the following environment:
+
+```bash
+export CAPI_VERSION=v1alpha3
+export IMAGE_OS=Ubuntu
+export EXPHEMERAL_CLUSTER=kind
+export CONTAINER_RUNTIME=docker
+export NUM_NODES=4
+```
+
+## CI jobs configuration
+
+We are running two jobs for the framework testing. One is
+[master](https://jenkins.nordix.org/view/Airship/job/airship_master_feature_tests_ubuntu/)
+job which runs every day, and second one is
+[airship_*_feature_tests_ubuntu](https://jenkins.nordix.org/view/Airship/job/airship_metal3io_metal3_dev_env_feature_tests_ubuntu/)
+that can be triggered with `/test-features` phrase on a pull request. Depending
+on where from the job
+is treggered, **\*** can be:
+
+- metal3io_metal3_dev_env
+- metal3io_capi_m3
+- metal3io_bmo
+- metal3io_project_infra
+- metal3io_ironic_ipa_downloader
+- metal3io_ironic_inspector
+- metal3io_ironic_image
+- nordix_capi_m3
+- nordix_metal3_dev_env
+- nordix_bmo

--- a/scripts/feature_tests/cleanup_env.sh
+++ b/scripts/feature_tests/cleanup_env.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -x
+
+# shellcheck disable=SC1091
+source lib/logging.sh
+# shellcheck disable=SC1091
+source lib/common.sh
+# shellcheck disable=SC1091
+source lib/network.sh
+
+# Remove old SSH keys
+ssh-keygen -f /home/"${USER}"/.ssh/known_hosts -R "${CLUSTER_APIENDPOINT_IP}"
+
+# Kill and remove the running ironic containers
+for name in ironic ironic-inspector ironic-endpoint-keepalived dnsmasq httpd mariadb; do
+  sudo "${CONTAINER_RUNTIME}" ps | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" kill $name
+  sudo "${CONTAINER_RUNTIME}" ps --all | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" rm $name -f
+done
+
+pushd "${CAPIPATH}" || exit
+cd bin || exit
+./clusterctl delete --all -v5
+popd || exit
+
+pushd "${BMOPATH}" || exit
+kubectl delete -f bmhosts_crs.yaml -n "${NAMESPACE}" --timeout 10s
+popd || exit
+
+declare -a OBJECTS=("cluster" \
+"baremetalhost" \
+"kubeadmconfig" \
+"kubeadmcontrolplane" \
+"machines" \
+"metal3cluster" \
+"metal3machine" \
+"metal3machinetemplate" \
+"m3ippool" \
+"m3ipclaim" \
+"ipaddress" \
+"m3data" \
+"m3dataclaim" \
+"m3datatemplate")
+
+delete_finalizers(){
+local kind
+for name in "${OBJECTS[@]}"; do
+  kind="$(kubectl get "${name}" -n "${NAMESPACE}" -o name)"
+  for item in $kind; do
+          kubectl patch "${item}" -n "${NAMESPACE}" -p '{"metadata":{"finalizers":[]}}' --type=merge
+          kubectl delete "${item}" -n "${NAMESPACE}" --timeout 10s
+  done
+  process_status $?
+done
+}
+
+delete_finalizers
+
+# Re-create ironic containers and BMH
+pushd "${BMOPATH}" || exit
+./tools/run_local_ironic.sh
+popd || exit
+
+pushd "${CAPIPATH}" || exit
+cd bin || exit
+./clusterctl init --infrastructure=metal3:"${CAPM3RELEASE}" -v5
+popd || exit
+
+pushd "${BMOPATH}" || exit
+kubectl apply -f bmhosts_crs.yaml -n "${NAMESPACE}"
+popd || exit
+
+make -C "${SCRIPTDIR}" verify

--- a/scripts/feature_tests/feature_test_deprovisioning.sh
+++ b/scripts/feature_tests/feature_test_deprovisioning.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-METAL3_DIR="$(dirname "$(readlink -f "${0}")")/../.."
+METAL3_DIR="$(dirname "$(readlink -f "${0}")")/../../"
 
 # shellcheck disable=SC1091
 # shellcheck disable=SC1090
@@ -19,6 +19,6 @@ export ANSIBLE_HOST_KEY_CHECKING=False
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
    -e "metal3_dir=$SCRIPTDIR" \
-   -e "v1aX_integration_test_action=remediation" \
+   -e "v1aX_integration_test_action=feature_test_deprovisioning" \
    -i "${METAL3_DIR}/vm-setup/inventory.ini" \
    -b -vvv "${METAL3_DIR}/vm-setup/v1aX_integration_test.yml"

--- a/scripts/feature_tests/feature_test_provisioning.sh
+++ b/scripts/feature_tests/feature_test_provisioning.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-METAL3_DIR="$(dirname "$(readlink -f "${0}")")/../.."
+METAL3_DIR="$(dirname "$(readlink -f "${0}")")/../../"
 
 # shellcheck disable=SC1091
 # shellcheck disable=SC1090
@@ -18,7 +18,7 @@ source "${METAL3_DIR}/lib/images.sh"
 export ANSIBLE_HOST_KEY_CHECKING=False
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
-   -e "metal3_dir=$SCRIPTDIR" \
-   -e "v1aX_integration_test_action=remediation" \
-   -i "${METAL3_DIR}/vm-setup/inventory.ini" \
-   -b -vvv "${METAL3_DIR}/vm-setup/v1aX_integration_test.yml"
+  -e "metal3_dir=$SCRIPTDIR" \
+  -e "v1aX_integration_test_action=feature_test_provisioning" \
+  -i "${METAL3_DIR}/vm-setup/inventory.ini" \
+  -b -vvv "${METAL3_DIR}/vm-setup/v1aX_integration_test.yml"

--- a/scripts/feature_tests/pivoting/Makefile
+++ b/scripts/feature_tests/pivoting/Makefile
@@ -1,0 +1,14 @@
+M3PATH := "$(dirname "$(readlink -f "${0}")")../../../"
+NUM_OF_MASTER_REPLICAS := 1
+NUM_OF_WORKER_REPLICAS := 1
+
+all: provision pivoting cleanup
+
+provision:
+	./../feature_test_provisioning.sh
+
+pivoting:
+	./../../v1alphaX/pivot.sh
+
+cleanup:
+	make clean -C "${M3PATH}"

--- a/scripts/feature_tests/remediation/Makefile
+++ b/scripts/feature_tests/remediation/Makefile
@@ -1,0 +1,13 @@
+NUM_OF_MASTER_REPLICAS := 1
+NUM_OF_WORKER_REPLICAS := 1
+
+all: provision remediation deprovision
+
+provision:
+	./../feature_test_provisioning.sh
+
+remediation:
+	./../../v1alphaX/remediation.sh
+
+deprovision:
+	./../feature_test_deprovisioning.sh

--- a/scripts/feature_tests/setup_env.sh
+++ b/scripts/feature_tests/setup_env.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -x
+
+M3PATH="$(dirname "$(readlink -f "${0}")")/../.."
+
+pushd "${M3PATH}" || exit
+make

--- a/scripts/feature_tests/upgrade/Makefile
+++ b/scripts/feature_tests/upgrade/Makefile
@@ -1,0 +1,13 @@
+M3PATH := "$(dirname "$(readlink -f "${0}")")/../../"
+# This needs to be moved to upgrade.sh and different value should be set before
+# each use case.
+# NUM_OF_MASTER_REPLICAS := 1
+# NUM_OF_WORKER_REPLICAS := 1
+
+all: upgrade
+
+.PHONY: upgrade
+upgrade:
+	# when merged use: 'wget -q https://raw.githubusercontent.com/Nordix/airship-dev-tools/master/upgrade_tests/upgrade.sh'
+	wget -q https://raw.githubusercontent.com/Nordix/airship-dev-tools/02895b9eb66cff9e3cacb11ac6d7322e41a81562/upgrade_tests/upgrade.sh
+	bash upgrade.sh

--- a/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
@@ -1,4 +1,8 @@
 ---
+  - name: Define number of BMH's
+    set_fact:
+      NUMBER_OF_BMH: "{{ NUM_OF_MASTER_REPLICAS|int +  NUM_OF_WORKER_REPLICAS|int }}"
+
   - name: Remove temporary Ubuntu crs
     file:
       path: "/tmp/{{ item }}.yaml"
@@ -29,10 +33,10 @@
 
   - name: Wait until both bmh becomes ready again.
     shell: |
-        kubectl get bmh -n {{ NAMESPACE }} -o json | jq -r '.items[] |
-        select (.status.provisioning.state == "ready") |
-        .metadata.name'
+        kubectl get bmh -n {{ NAMESPACE }} -o json | jq -r '[ .items[]
+        | select (.status.provisioning.state == "ready")
+        | .metadata.name ] | length'
     register: deprovisioned_nodes
     retries: 150
     delay: 3
-    until: deprovisioned_nodes.stdout_lines ==  ["node-0", "node-1"]
+    until: deprovisioned_nodes.stdout ==  NUMBER_OF_BMH

--- a/vm-setup/roles/v1aX_integration_test/tasks/generate_templates.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/generate_templates.yml
@@ -13,7 +13,7 @@
   - name: Generate templates
     shell: >
       . {{ TEMP_GEN_DIR }}/clusterctl_env_{{ IMAGE_OS|lower }}.rc &&
-      {{ CLUSTERCTL_PATH}}/clusterctl config cluster {{ CLUSTER_NAME }}
+      {{ CLUSTERCTL_PATH }}/clusterctl config cluster {{ CLUSTER_NAME }}
       --kubernetes-version {{ KUBERNETES_VERSION }}
       --control-plane-machine-count={{ NUM_OF_MASTER_REPLICAS }}
       --worker-machine-count={{ NUM_OF_WORKER_REPLICAS }}

--- a/vm-setup/roles/v1aX_integration_test/tasks/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/main.yml
@@ -59,3 +59,21 @@
 - name: Node remediation
   include: remediation.yml
   when: v1aX_integration_test_action == "remediation"
+
+- name: "Provisioning for feature_tests"
+  include: "{{ item }}.yml"
+  with_items:
+    - provision_cluster
+    - provision_worker
+    - provision_controlplane
+    - verify
+  when: v1aX_integration_test_action == "feature_test_provisioning"
+
+- name: "Deprovisioning for feature_tests"
+  include: "{{ item }}.yml"
+  with_items:
+    - deprovision_worker
+    - deprovision_controlplane
+    - deprovision_cluster
+    - cleanup
+  when: v1aX_integration_test_action == "feature_test_deprovisioning"

--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -4,7 +4,7 @@
     with_items:
        - clusterctl.cluster.x-k8s.io=""
        - cluster.x-k8s.io/provider="metal3"
-    
+
   - name: Obtain target cluster kubeconfig
     shell: "kubectl get secrets {{ CLUSTER_NAME }}-kubeconfig -n {{ NAMESPACE }} -o json | jq -r '.data.value'| base64 -d > /tmp/target.yaml"
 
@@ -33,14 +33,14 @@
         git:
           repo: 'https://github.com/metal3-io/baremetal-operator.git'
           dest: "/home/{{ IMAGE_USERNAME }}/baremetal-operator"
-            
+
         # Replacing the name of the bridge
       - name: Replace the Provisioning Interface in ironic_ci.env
         lineinfile:
           path: /home/{{ IMAGE_USERNAME }}/baremetal-operator/deploy/ironic_ci.env
           regexp: "^PROVISIONING_INTERFACE="
           line: "PROVISIONING_INTERFACE={{ IRONIC_ENDPOINT_BRIDGE }}"
-        
+
         # Install ironic
       - name: Install ironic
         shell: "bash /home/{{ IMAGE_USERNAME }}/baremetal-operator/tools/run_local_ironic.sh"
@@ -54,7 +54,6 @@
         with_items:
           - clusterctl.cluster.x-k8s.io=""
           - cluster.x-k8s.io/provider="metal3"
- 
 
   - name: Initialize Provider component in target cluster
     shell: "{{ CLUSTERCTL_PATH }}/clusterctl init --kubeconfig /tmp/target.yaml --infrastructure metal3:{{ CAPM3RELEASE }} --target-namespace {{ NAMESPACE }} --watching-namespace {{ NAMESPACE }} -v 5"
@@ -74,9 +73,8 @@
     until: target_running_pods.stdout == ""
 
   - name: Pivot objects to target cluster
-    shell: "{{ CLUSTERCTL_PATH }}/clusterctl move --to-kubeconfig /tmp/target.yaml -n {{ NAMESPACE }} -v 10" 
+    shell: "{{ CLUSTERCTL_PATH }}/clusterctl move --to-kubeconfig /tmp/target.yaml -n {{ NAMESPACE }} -v 10"
 
-  
   - name: Check if machines become running.
     shell: |
         kubectl get machines -n {{ NAMESPACE }} -o json | jq -r '[ .items[]
@@ -87,19 +85,19 @@
       KUBECONFIG: "/tmp/target.yaml"
     retries: 10
     delay: 20
-    until: provisioned_machines.stdout == "2"
+    until: provisioned_machines.stdout == NUMBER_OF_BMH
 
   - name: Check if metal3machines become provisioned.
     shell: |
         kubectl get m3m -n {{ NAMESPACE }} -o json | jq -r '[ .items[]
-        | select (.status.ready == "true")
+        | select (.status.ready == true)
         | .metadata.name ] | length'
     register: provisioned_m3m_machines
     environment:
       KUBECONFIG: "/tmp/target.yaml"
     retries: 10
     delay: 20
-    until: provisioned_m3m_machines.stdout == "2"
+    until: provisioned_m3m_machines.stdout == NUMBER_OF_BMH
 
   - name: Check if bmh is in provisioned state
     shell: |
@@ -111,4 +109,4 @@
     register: provisioned_bmh
     retries: 10
     delay: 20
-    until: provisioned_bmh.stdout ==  "2"
+    until: provisioned_bmh.stdout ==  NUMBER_OF_BMH

--- a/vm-setup/roles/v1aX_integration_test/tasks/remediation.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/remediation.yml
@@ -1,9 +1,13 @@
 ---
-  - name: Get the name of the worker node
+  - name: Define number of BMH's
+    set_fact:
+      NUMBER_OF_BMH: "{{ NUM_OF_MASTER_REPLICAS|int +  NUM_OF_WORKER_REPLICAS|int }}"
+
+  - name: Get the name of a worker node
     shell: |
        kubectl get bmh -n "{{ NAMESPACE }}" -o json | jq -r '.items[]
-       | select(.spec.consumerRef.name | contains("{{ CLUSTER_NAME }}-workers"))
-       | .metadata.name'
+       |select(.status.provisioning.state | contains("provisioned")) |select(.spec.consumerRef.name
+       | contains("{{ CLUSTER_NAME }}-workers")) | .metadata.name'
     register: worker_node_name
 
   - name: Define WORKER_NODE variable with worker node name
@@ -18,7 +22,7 @@
     shell: |
        kubectl annotate bmh "{{ WORKER_NODE }}" -n "{{ NAMESPACE }}" reboot.metal3.io=
 
-  - name: List only shutted off VMs
+  - name: List only powered off VMs
     virt:
       command: list_vms
       state: shutdown
@@ -26,6 +30,8 @@
     retries: 50
     delay: 10
     until: WORKER_NODE_VM in shutdown_vms.list_vms
+    become: yes
+    become_user: root
 
   - name: Rebooted node status
     delegate_to: "{{ CLUSTER_APIENDPOINT_IP }}"
@@ -52,7 +58,7 @@
         retries: 150
         delay: 3
         register: ready_nodes
-        until: ready_nodes.stdout == "2"
+        until: ready_nodes.stdout == NUMBER_OF_BMH
 
   - name: List only running VMs
     virt:
@@ -62,6 +68,8 @@
     retries: 50
     delay: 10
     until: WORKER_NODE_VM in running_vms.list_vms
+    become: yes
+    become_user: root
 
   - name: Power off "{{ WORKER_NODE }}"
     shell: |
@@ -88,7 +96,7 @@
   - pause:
       minutes: 1
 
-  - name: List only shutted off VMs
+  - name: List only powered off VMs
     virt:
       command: list_vms
       state: shutdown
@@ -96,6 +104,8 @@
     retries: 50
     delay: 10
     until: WORKER_NODE_VM in shutdown_vms.list_vms
+    become: yes
+    become_user: root
 
   - name: Power on "{{ WORKER_NODE }}"
     shell: |
@@ -109,6 +119,8 @@
     retries: 50
     delay: 10
     until: WORKER_NODE_VM in running_vms.list_vms
+    become: yes
+    become_user: root
 
   - name: Powered on node status
     delegate_to: "{{ CLUSTER_APIENDPOINT_IP }}"
@@ -126,4 +138,4 @@
         retries: 150
         delay: 3
         register: ready_nodes
-        until: ready_nodes.stdout == "2"
+        until: ready_nodes.stdout == NUMBER_OF_BMH

--- a/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
@@ -1,4 +1,9 @@
 ---
+
+  - name: Define number of BMH's
+    set_fact:
+      NUMBER_OF_BMH: "{{ NUM_OF_MASTER_REPLICAS|int +  NUM_OF_WORKER_REPLICAS|int }}"
+
   - name: Wait until cluster becomes provisioned.
     shell: "kubectl get cluster -n metal3 -o json | jq -r '.items[] | .status.phase'"
     register: provisioned_cluster
@@ -7,7 +12,7 @@
     until: (provisioned_cluster.stdout == "provisioned") or
            (provisioned_cluster.stdout == "Provisioned")
 
-  - name: Wait until both BMHs become provisioned.
+  - name: Wait until "{{ NUMBER_OF_BMH }}" BMHs become provisioned.
     shell: |
         kubectl get bmh -n metal3 -o json | jq -r '[ .items[]
         | select (.status.provisioning.state == "provisioned")
@@ -15,9 +20,9 @@
     register: provisioned_bmh
     retries: 150
     delay: 20
-    until: provisioned_bmh.stdout ==  "2"
+    until: provisioned_bmh.stdout == NUMBER_OF_BMH
 
-  - name: Wait until both machines become running.
+  - name: Wait until "{{ NUMBER_OF_BMH }}" machines become running.
     shell: |
         kubectl get machines -n metal3 -o json | jq -r '[ .items[]
         | select (.status.phase == "Running" or .status.phase == "running")
@@ -25,11 +30,12 @@
     register: provisioned_machines
     retries: 150
     delay: 20
-    until: provisioned_machines.stdout == "2"
+    until: provisioned_machines.stdout == NUMBER_OF_BMH
 
-  - name: Define username variable as metal3 for target node
+  - name: Define username variable as "{{ IMAGE_USERNAME }}" for target node
     set_fact:
       username: "{{ IMAGE_USERNAME }}"
+
   - name: Verification test
     delegate_to: "{{ CLUSTER_APIENDPOINT_IP }}"
     vars:
@@ -91,18 +97,18 @@
       - name: Add IP_AUTODETECTION_METHOD in calico config Ubuntu
         blockinfile:
           path: /tmp/calico.yaml
-          insertafter: "{{ POD_CIDR }}"  
+          insertafter: "{{ POD_CIDR }}"
           block: |
              # for indentation
                          - name: IP_AUTODETECTION_METHOD
                            value: "interface=enp2s0"
         when:
           ansible_distribution == "Ubuntu"
-        
+
       - name: Add IP_AUTODETECTION_METHOD in calico config Centos
         blockinfile:
           path: /tmp/calico.yaml
-          insertafter: "{{ POD_CIDR }}"  
+          insertafter: "{{ POD_CIDR }}"
           block: |
              # for indentation
                          - name: IP_AUTODETECTION_METHOD
@@ -141,5 +147,5 @@
         failed_when: >
           (ready_nodes.stderr != "") or
           (ready_nodes.rc != 0) or
-          (ready_nodes.stdout != "2")
-        until: ready_nodes.stdout == "2"
+          (ready_nodes.stdout != NUMBER_OF_BMH)
+        until: ready_nodes.stdout == NUMBER_OF_BMH

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -37,7 +37,6 @@ CAPI_VERSION: "{{ lookup('env', 'CAPI_VERSION') | default('v1alpha3', true)}}"
 IRONIC_IMAGE_DIR: "{{ lookup('env', 'IRONIC_IMAGE_DIR') | default('/opt/metal3-dev-env/ironic/html/images')}}"
 IRONIC_ENDPOINT_BRIDGE: "{{ lookup('env', 'CLUSTER_PROVISIONING_INTERFACE') | default('provisioning')}}"
 
-
 # Distibution specific environment variables
 IMAGE_NAME: 'bionic-server-cloudimg-amd64.img'
 IMAGE_LOCATION: 'https://cloud-images.ubuntu.com/bionic/current'


### PR DESCRIPTION
This patch introduces scripts that will be used to run pivoting, remediation and upgrade test scripts on the CI.
Related to this : 
- [#107](https://github.com/metal3-io/project-infra/pull/107) - Jenkins changes
- [#4933](https://gerrit.nordix.org/c/infra/cicd/+/4934) - JJB jobs
- [#329](https://github.com/metal3-io/metal3-dev-env/pull/329) - remediation test script
- [#328](https://github.com/metal3-io/metal3-dev-env/pull/328) - pivoting test script



Co-authored-by: Kashif Khan <kashif.khan@est.tech>
Co-authored-by: Jaakko Kuuskoski <jaakko.kuuskoski@est.tech>