### PR TITLE
Remove hardcoded IPs for external subnet

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -106,6 +106,7 @@ fi
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "{use_firewalld: $USE_FIREWALLD}" \
+    -e "external_subnet_v4: ${EXTERNAL_SUBNET_V4}" \
     -i vm-setup/inventory.ini \
     -b -vvv vm-setup/firewall.yml
 
@@ -162,7 +163,7 @@ for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
   #shellcheck disable=SC2086
   export $IMAGE_VAR="${IMAGE##*/}:latest"
   #shellcheck disable=SC2086
-  export $IMAGE_VAR="192.168.111.1:5000/localimages/${!IMAGE_VAR}"
+  export $IMAGE_VAR="${REGISTRY}/localimages/${!IMAGE_VAR}"
   sudo "${CONTAINER_RUNTIME}" build -t "${!IMAGE_VAR}" . -f "${DOCKERFILE}"
   cd - || exit
   if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -107,7 +107,7 @@ function patch_clusterctl(){
   pushd "${CAPM3PATH}"
   if [ -n "${CAPM3_LOCAL_IMAGE}" ]; then
     CAPM3_IMAGE_NAME="${CAPM3_LOCAL_IMAGE##*/}"
-    export MANIFEST_IMG="192.168.111.1:5000/localimages/$CAPM3_IMAGE_NAME"
+    export MANIFEST_IMG="${REGISTRY}/localimages/$CAPM3_IMAGE_NAME"
     export MANIFEST_TAG="latest"
     make set-manifest-image
   fi
@@ -125,7 +125,7 @@ function update_images(){
     IMAGE=${!IMAGE_VAR}
     #shellcheck disable=SC2086
     IMAGE_NAME="${IMAGE##*/}:latest"
-    LOCAL_IMAGE="192.168.111.1:5000/localimages/$IMAGE_NAME"
+    LOCAL_IMAGE="${REGISTRY}/localimages/$IMAGE_NAME"
 
     OLD_IMAGE_VAR="${IMAGE_VAR%_LOCAL_IMAGE}_IMAGE"
     # Strip the tag for image replacement
@@ -204,7 +204,7 @@ function launch_kind() {
   apiVersion: kind.x-k8s.io/v1alpha4
   containerdConfigPatches:
   - |-
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."192.168.111.1:5000"]
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."${REGISTRY}"]
       endpoint = ["http://${reg_ip}:5000"]
 EOF
 }

--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -58,9 +58,14 @@ if [[ $DISTRO == "centos7" ]]; then
   sudo dnf -y upgrade --exclude=oniguruma
 fi
 
+# We need the network variables, but can only source lib/network.sh after
+# installing and setting up python
+# shellcheck disable=SC1091
+source lib/network.sh
+
 if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
   sudo dnf -y install podman
-  sudo sed -i '/^\[registries\.insecure\]$/,/^\[/ s/^registries =.*/registries = ["192.168.111.1:5000"]/g' /etc/containers/registries.conf
+  sudo sed -i "/^\[registries\.insecure\]$/,/^\[/ s/^registries =.*/registries = [\"${REGISTRY}\"]/g" /etc/containers/registries.conf
 else
   if [[ $DISTRO == "centos7" ]]; then
     sudo dnf install -y dnf-utils \
@@ -71,7 +76,7 @@ else
       https://download.docker.com/linux/centos/docker-ce.repo
       cat <<EOF > daemon.json
 {
-  "insecure-registries" : ["192.168.111.1:5000"]
+  "insecure-registries" : ["${REGISTRY}"]
 }
 EOF
     sudo chown root:root daemon.json

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -49,6 +49,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
 if [ "$USE_FIREWALLD" == "False" ]; then
  ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "{use_firewalld: $USE_FIREWALLD}" \
+    -e "external_subnet_v4: ${EXTERNAL_SUBNET_V4}" \
     -e "firewall_rule_state=absent" \
     -i vm-setup/inventory.ini \
     -b -vvv vm-setup/firewall.yml

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -333,7 +333,7 @@ differs(){
 function init_minikube() {
     #If the vm exists, it has already been initialized
     if [[ "$(sudo virsh list --all)" != *"minikube"* ]]; then
-      sudo su -l -c "minikube start --insecure-registry 192.168.111.1:5000" "$USER"
+      sudo su -l -c "minikube start --insecure-registry ${REGISTRY}" "$USER"
       sudo su -l -c "minikube stop" "$USER"
     fi
 

--- a/ubuntu_bridge_network_configuration.sh
+++ b/ubuntu_bridge_network_configuration.sh
@@ -29,7 +29,7 @@ if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
        sudo brctl addbr baremetal
        # sudo ifconfig baremetal 192.168.111.1 netmask 255.255.255.0 up
        # Use ip command. ifconfig commands are deprecated now.
-       sudo ip addr add dev baremetal 192.168.111.1/24
+       sudo ip addr add dev baremetal "${EXTERNAL_SUBNET_V4_HOST}/${EXTERNAL_SUBNET_V4_CIDR}"
        sudo ip link set baremetal up
      fi
 

--- a/vm-setup/roles/firewall/defaults/main.yml
+++ b/vm-setup/roles/firewall/defaults/main.yml
@@ -1,6 +1,7 @@
 use_firewalld: true
 baremetal_interface: baremetal
 provisioning_interface: provisioning
+external_subnet_v4: "192.168.111.0/24"
 vbmc_port_range: "6230:6235"
 firewall_rule_state: present
 ironic_ports:

--- a/vm-setup/roles/firewall/tasks/iptables.yaml
+++ b/vm-setup/roles/firewall/tasks/iptables.yaml
@@ -71,7 +71,7 @@
     chain: FORWARD
     action: insert
     out_interface: "{{ baremetal_interface }}"
-    destination: "192.168.111.1/24"
+    destination: "{{ external_subnet_v4 }}"
     jump: ACCEPT
     state: "{{ firewall_rule_state }}"
   when: (EPHEMERAL_CLUSTER == "kind")


### PR DESCRIPTION
The external subnet is configurable, but it was still hardcoded in some
places. Especially the registry running on the host was hardcoded.

Now the IP of the host can be set as a parameter (defaults to the first
host in the EXTERNAL_SUBNET_V4).

Closes #316 