### PR TITLE
Fix BMO local image bug and update kustomize version

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -48,9 +48,11 @@ if [ "$KUBECTL_LOCAL" != "$KUBECTL_LATEST" ]; then
 fi
 
 if ! command -v kustomize 2>/dev/null ; then
-    curl -Lo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F"${KUSTOMIZE_VERSION}"/kustomize_kustomize."${KUSTOMIZE_VERSION}"_linux_amd64
+    curl -L -O "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+    tar -xzvf "kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
     chmod +x kustomize
     sudo mv kustomize /usr/local/bin/.
+    rm "kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
 fi
 
 # Clean-up any old ironic containers

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -118,7 +118,8 @@ function patch_clusterctl(){
     BMO_IMAGE_NAME="${BAREMETAL_OPERATOR_LOCAL_IMAGE##*/}"
     export MANIFEST_IMG_BMO="192.168.111.1:5000/localimages/$BMO_IMAGE_NAME"
     export MANIFEST_TAG_BMO="latest"
-    make set-manifest-image
+    # TODO set the image when BMO is part of CAPM3
+    #make set-manifest-image-bmo
   fi
   
   make release-manifests

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -120,10 +120,10 @@ else
   export EPHEMERAL_CLUSTER="minikube"
 fi
 #Kustomize version
-export KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-"v3.2.3"}
+export KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-"v3.6.1"}
 
 #Kind version
-export KIND_VERSION=${KIND_VERSION:-"v0.7.0"}
+export KIND_VERSION=${KIND_VERSION:-"v0.8.1"}
 
 # Test and verification related variables
 SKIP_RETRIES="${SKIP_RETRIES:-false}"

--- a/vm-setup/roles/v1aX_integration_test/tasks/generate_templates.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/generate_templates.yml
@@ -11,8 +11,13 @@
       dest: "{{ TEMP_GEN_DIR }}/clusterctl_env_{{ IMAGE_OS|lower }}.rc"
 
   - name: Generate templates
-    shell: |
-      . {{ TEMP_GEN_DIR }}/clusterctl_env_{{ IMAGE_OS|lower }}.rc && {{ CLUSTERCTL_PATH}}/clusterctl config cluster {{ CLUSTER_NAME }} --kubernetes-version {{ KUBERNETES_VERSION }} --control-plane-machine-count={{ NUM_OF_MASTER_REPLICAS }} --worker-machine-count={{ NUM_OF_WORKER_REPLICAS }} > {{ TEMP_GEN_DIR }}/manifests.yaml
+    shell: >
+      . {{ TEMP_GEN_DIR }}/clusterctl_env_{{ IMAGE_OS|lower }}.rc &&
+      {{ CLUSTERCTL_PATH}}/clusterctl config cluster {{ CLUSTER_NAME }}
+      --kubernetes-version {{ KUBERNETES_VERSION }}
+      --control-plane-machine-count={{ NUM_OF_MASTER_REPLICAS }}
+      --worker-machine-count={{ NUM_OF_WORKER_REPLICAS }}
+      --target-namespace=metal3 > {{ TEMP_GEN_DIR }}/manifests.yaml
 
   - name: Create a base dir
     file:

--- a/vm-setup/roles/v1aX_integration_test/templates/kustomization_empty.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/kustomization_empty.yaml
@@ -1,3 +1,2 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: metal3


### PR DESCRIPTION
currently having a local image for BMO triggers a call to
make set-manifest-image for CAPM3, without the CAPM3 image
variables being properly set, hence rendering an invalid
kustomize patch in the BMO PR testing