### PR TITLE
✨ Adapt metal3-dev-env to BMO as part of CAPM3 deployment

### DIFF
--- a/04_verify.sh
+++ b/04_verify.sh
@@ -100,7 +100,7 @@ check_k8s_entity() {
       -n "${NS}" -o json)"
     process_status $?
 
-    # Check the replicabaremetalclusters.s
+    # Check the replicabaremetalclusters
     if [[ "${BMO_RUN_LOCAL}" != true ]] && [[ "${CAPM3_RUN_LOCAL}" != true ]]
     then
       RESULT_STR="${name} ${TYPE} replicas correct"
@@ -198,6 +198,24 @@ EXPTD_V1ALPHA3_RS="cluster.x-k8s.io/provider:infrastructure-metal3:capm3-system 
   cluster.x-k8s.io/provider:bootstrap-kubeadm:capi-webhook-system \
   cluster.x-k8s.io/provider:control-plane-kubeadm:capi-webhook-system \
   name:metal3-baremetal-operator:metal3"
+EXPTD_V1ALPHA4_DEPLOYMENTS="capm3-system:capm3-controller-manager \
+  capi-system:capi-controller-manager \
+  capi-kubeadm-bootstrap-system:capi-kubeadm-bootstrap-controller-manager \
+  capi-kubeadm-control-plane-system:capi-kubeadm-control-plane-controller-manager \
+  capi-webhook-system:capi-controller-manager \
+  capi-webhook-system:capi-kubeadm-bootstrap-controller-manager \
+  capi-webhook-system:capi-kubeadm-control-plane-controller-manager \
+  capi-webhook-system:capm3-controller-manager \
+  capm3-system:capm3-metal3-baremetal-operator"
+EXPTD_V1ALPHA4_RS="cluster.x-k8s.io/provider:infrastructure-metal3:capm3-system \
+  cluster.x-k8s.io/provider:cluster-api:capi-system \
+  cluster.x-k8s.io/provider:bootstrap-kubeadm:capi-kubeadm-bootstrap-system \
+  cluster.x-k8s.io/provider:control-plane-kubeadm:capi-kubeadm-control-plane-system \
+  cluster.x-k8s.io/provider:infrastructure-metal3:capi-webhook-system \
+  cluster.x-k8s.io/provider:cluster-api:capi-webhook-system \
+  cluster.x-k8s.io/provider:bootstrap-kubeadm:capi-webhook-system \
+  cluster.x-k8s.io/provider:control-plane-kubeadm:capi-webhook-system \
+  name:metal3-baremetal-operator:capm3-system"
 BRIDGES="provisioning baremetal"
 EXPTD_CONTAINERS="httpd-infra registry vbmc sushy-tools"
 
@@ -236,8 +254,13 @@ done
 echo ""
 
 # Verify v1alpha3+ Operators, Deployments, Replicasets
-iterate check_k8s_entity deployments "${EXPTD_V1ALPHA3_DEPLOYMENTS}"
-iterate check_k8s_rs "${EXPTD_V1ALPHA3_RS}"
+if [ "${CAPI_VERSION}" != "v1alpha3" ]; then
+  iterate check_k8s_entity deployments "${EXPTD_V1ALPHA4_DEPLOYMENTS}"
+  iterate check_k8s_rs "${EXPTD_V1ALPHA4_RS}"
+else
+  iterate check_k8s_entity deployments "${EXPTD_V1ALPHA3_DEPLOYMENTS}"
+  iterate check_k8s_rs "${EXPTD_V1ALPHA3_RS}"
+fi
 # Verify the baremetal hosts
 ## Fetch the BM CRs
 RESULT_STR="Fetch Baremetalhosts"

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -157,7 +157,14 @@ fi
 
 network_address INITIAL_IRONICBRIDGE_IP "$PROVISIONING_NETWORK" 9
 
-export DEPLOY_KERNEL_URL=${DEPLOY_KERNEL_URL:-"http://${PROVISIONING_IP}:6180/images/ironic-python-agent.kernel"}
-export DEPLOY_RAMDISK_URL=${DEPLOY_RAMDISK_URL:-"http://${PROVISIONING_IP}:6180/images/ironic-python-agent.initramfs"}
-export IRONIC_URL=${IRONIC_URL:-"http://${PROVISIONING_IP}:6385/v1/"}
-export IRONIC_INSPECTOR_URL=${IRONIC_INSPECTOR_URL:-"http://${PROVISIONING_IP}:5050/v1/"}
+if [ "${EPHEMERAL_CLUSTER}" == "minikube" ]; then
+  export DEPLOY_KERNEL_URL=${DEPLOY_KERNEL_URL:-"http://${CLUSTER_URL_HOST}:6180/images/ironic-python-agent.kernel"}
+  export DEPLOY_RAMDISK_URL=${DEPLOY_RAMDISK_URL:-"http://${CLUSTER_URL_HOST}:6180/images/ironic-python-agent.initramfs"}
+  export IRONIC_URL=${IRONIC_URL:-"http://${CLUSTER_URL_HOST}:6385/v1/"}
+  export IRONIC_INSPECTOR_URL=${IRONIC_INSPECTOR_URL:-"http://${CLUSTER_URL_HOST}:5050/v1/"}
+else
+  export DEPLOY_KERNEL_URL=${DEPLOY_KERNEL_URL:-"http://${PROVISIONING_URL_HOST}:6180/images/ironic-python-agent.kernel"}
+  export DEPLOY_RAMDISK_URL=${DEPLOY_RAMDISK_URL:-"http://${PROVISIONING_URL_HOST}:6180/images/ironic-python-agent.initramfs"}
+  export IRONIC_URL=${IRONIC_URL:-"http://${PROVISIONING_URL_HOST}:6385/v1/"}
+  export IRONIC_INSPECTOR_URL=${IRONIC_INSPECTOR_URL:-"http://${PROVISIONING_URL_HOST}:5050/v1/"}
+fi

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -29,7 +29,7 @@ BAREMETALV6_POOL_RANGE_START: "{{ lookup('env', 'BAREMETALV6_POOL_RANGE_START') 
 BAREMETALV6_POOL_RANGE_END: "{{ lookup('env', 'BAREMETALV6_POOL_RANGE_END') | default('fd55::200', true) }}"
 EXTERNAL_SUBNET_V6_PREFIX: "{{ lookup('env', 'EXTERNAL_SUBNET_V6_PREFIX') | default('64', true) }}"
 EXTERNAL_SUBNET_V6_HOST: "{{ lookup('env', 'EXTERNAL_SUBNET_V6_HOST') | default('fd55::1', true) }}"
-IRONIC_HOST_IP: "{{ lookup('env', 'IRONIC_HOST_IP') | default('172.22.0.1', true) }}"
+IRONIC_HOST_IP: "{{ lookup('env', 'IRONIC_HOST_IP') | default('172.22.0.2', true) }}"
 DEPLOY_KERNEL_URL: "{{ lookup('env', 'DEPLOY_KERNEL_URL') }}"
 DEPLOY_RAMDISK_URL: "{{ lookup('env', 'DEPLOY_RAMDISK_URL') }}"
 IRONIC_URL: "{{ lookup('env', 'IRONIC_URL') }}"


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR adapts metal3-dev-env, so that it will deploy BMO as part of CAPM3/ This PR is needed to have a fully functional pivoting workflow.

Related to:
- Proposal: [metal3-docs/pull/91](https://github.com/metal3-io/metal3-docs/pull/91)
- Documentation: [baremetal-operator/pull/541](https://github.com/metal3-io/baremetal-operator/pull/541)
- [cluster-api-provider-metal3/pull/68](https://github.com/metal3-io/cluster-api-provider-metal3/pull/68)
- [baremetal-operator/pull/522](https://github.com/metal3-io/baremetal-operator/pull/522) 
