### PR TITLE
Fix CAPI_VERSION variable

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -80,6 +80,14 @@ function get_latest_release() {
     echo "$(curl -sL "${1}"  | jq -r '.tag_name')"
 }
 
+# CAPI version
+export CAPI_VERSION=${CAPI_VERSION:-"v1alpha3"}
+CAPI_VERSION_LIST="v1alpha3 v1alpha4"
+if ! echo "${CAPI_VERSION_LIST}" | grep -wq "${CAPI_VERSION}"; then
+  echo "Invalid CAPI version : ${CAPI_VERSION}. Not in : ${CAPI_VERSION_LIST}"
+  exit 1
+fi
+
 M3PATH="${M3PATH:-${GOPATH}/src/github.com/metal3-io}"
 BMOPATH="${BMOPATH:-${M3PATH}/baremetal-operator}"
 # shellcheck disable=SC2034
@@ -137,14 +145,6 @@ export BAREMETAL_OPERATOR_IMAGE=${BAREMETAL_OPERATOR_IMAGE:-"quay.io/metal3-io/b
 
 # Config for OpenStack CLI
 export OPENSTACK_CONFIG=$HOME/.config/openstack/clouds.yaml
-
-# CAPI version
-export CAPI_VERSION=${CAPI_VERSION:-"v1alpha3"}
-CAPI_VERSION_LIST="v1alpha3 v1alpha4"
-if ! echo "${CAPI_VERSION_LIST}" | grep -wq "${CAPI_VERSION}"; then
-  echo "Invalid CAPI version : ${CAPI_VERSION}. Not in : ${CAPI_VERSION_LIST}"
-  exit 1
-fi
 
 # CAPM3 controller image
 if [ "${CAPI_VERSION}" == "v1alpha3" ]; then


### PR DESCRIPTION
Default [value](https://github.com/metal3-io/metal3-dev-env/blob/26399b1135761cf5d6dbd8631434cc47afb5e8e9/lib/common.sh#L142) of `CAPI_VERSION` is set after the [condition](https://github.com/metal3-io/metal3-dev-env/blob/26399b1135761cf5d6dbd8631434cc47afb5e8e9/lib/common.sh#L98) related to `CAPI_VERSION`. Since variable doesn't have a default value yet in the condition, metal3-dev-env is failing when running it locally.

```

Creating inventory entry Provider="infrastructure-metal3" Version="v0.3.1" TargetNamespace="capm3-system"

Your management cluster has been initialized successfully!

You can now create your first workload cluster by running the following:

  clusterctl config cluster [name] --kubernetes-version [version] | kubectl apply -f -

+ popd
~/go/src/github.com/metal3-io/cluster-api-provider-metal3 ~/metal3-dev-env
+ rm -rf capm3-MbY0xZfUBY
+ '[' false == true ']'
+ popd
~/metal3-dev-env
./04_verify.sh
Logging to ./logs/04_verify-2020-06-09-115832.log
lib/common.sh: line 98: CAPI_VERSION: unbound variable
Makefile:13: recipe for target 'verify' failed
make: *** [verify] Error 1

```