### PR TITLE
Fix exporting variables for provisioning

### DIFF
--- a/scripts/feature_tests/README.md
+++ b/scripts/feature_tests/README.md
@@ -2,7 +2,7 @@
 
 ## Build Status
 
-[![Ubuntu V1alpha3 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_feature_tests_ubuntu/badge/icon?subject=Ubuntu%20E2E%20V1alpha3)](https://jenkins.nordix.org/view/Airship/job/airship_master_feature_tests_ubuntu/)
+[![Ubuntu V1alpha3 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_feature_tests_ubuntu/badge/icon?subject=Feature-tests)](https://jenkins.nordix.org/view/Airship/job/airship_master_feature_tests_ubuntu/)
 
 Feature tests framework is made to run a set of scripts for testing pivoting,
 remediation and upgrade functionalities of Metal3 project.
@@ -67,7 +67,8 @@ When the test-framework is triggered, it will:
 
 ## Environment variables
 
-Currently the test-framework supports the following environment:
+Currently the test-framework uses the following environment variables
+by default:
 
 ```bash
 export CAPI_VERSION=v1alpha3

--- a/scripts/feature_tests/pivoting/Makefile
+++ b/scripts/feature_tests/pivoting/Makefile
@@ -1,6 +1,6 @@
 M3PATH := "$(dirname "$(readlink -f "${0}")")../../../"
-NUM_OF_MASTER_REPLICAS := 1
-NUM_OF_WORKER_REPLICAS := 1
+export NUM_OF_MASTER_REPLICAS := 1
+export NUM_OF_WORKER_REPLICAS := 1
 
 all: provision pivoting cleanup
 

--- a/scripts/feature_tests/remediation/Makefile
+++ b/scripts/feature_tests/remediation/Makefile
@@ -1,5 +1,5 @@
-NUM_OF_MASTER_REPLICAS := 1
-NUM_OF_WORKER_REPLICAS := 1
+export NUM_OF_MASTER_REPLICAS := 1
+export NUM_OF_WORKER_REPLICAS := 1
 
 all: provision remediation deprovision
 

--- a/scripts/feature_tests/upgrade/Makefile
+++ b/scripts/feature_tests/upgrade/Makefile
@@ -1,8 +1,8 @@
 M3PATH := "$(dirname "$(readlink -f "${0}")")/../../"
 # This needs to be moved to upgrade.sh and different value should be set before
 # each use case.
-# NUM_OF_MASTER_REPLICAS := 1
-# NUM_OF_WORKER_REPLICAS := 1
+# export NUM_OF_MASTER_REPLICAS := 1
+# export NUM_OF_WORKER_REPLICAS := 1
 
 all: upgrade
 

--- a/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
@@ -18,7 +18,7 @@
         | select (.status.provisioning.state == "provisioned")
         | .metadata.name ] | length'
     register: provisioned_bmh
-    retries: 150
+    retries: 200
     delay: 20
     until: provisioned_bmh.stdout == NUMBER_OF_BMH
 


### PR DESCRIPTION
NUM_OF_MASTER_REPLICAS  and NUM_OF_WORKER_REPLICAS variables value isn't passed to  clusterctl command in [here](https://github.com/metal3-io/metal3-dev-env/blob/ad8b9f630ee515a82b1d9cc0628f41db83fe5054/vm-setup/roles/v1aX_integration_test/tasks/generate_templates.yml#L18), and clustertl is using default values ( i.e. 1 for both of the variables) from [/vars/main.yml](https://github.com/metal3-io/metal3-dev-env/blob/ad8b9f630ee515a82b1d9cc0628f41db83fe5054/vm-setup/roles/v1aX_integration_test/vars/main.yml#L12). Exporting those variables in Makefile of each feature will allow to provision correct number of BMHs as given in Makefile.

Also increase timeout to wait for BMHs to be provisioned so that the task doesn't fail because of the timeout when provisioning 4 BMHs.