### PR TITLE
Add HA cluster remediation tests

### DIFF
--- a/scripts/feature_tests/remediation/Makefile
+++ b/scripts/feature_tests/remediation/Makefile
@@ -1,4 +1,4 @@
-export NUM_OF_MASTER_REPLICAS := 1
+export NUM_OF_MASTER_REPLICAS := 3
 export NUM_OF_WORKER_REPLICAS := 1
 
 all: provision remediation deprovision

--- a/vm-setup/roles/v1aX_integration_test/tasks/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Install openshift client in CentOS 8 using pip3
   pip:
     executable: "pip3"

--- a/vm-setup/roles/v1aX_integration_test/tasks/power_cycle.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/power_cycle.yml
@@ -1,0 +1,65 @@
+---
+  - name: Power off "{{ NODE }}"
+    shell: |
+       kubectl annotate bmh "{{ NODE }}" -n "{{ NAMESPACE }}" reboot.metal3.io/poweroff=
+
+  - name: Wait until powered off "{{ WORKER_NODE }}" becomes NotReady
+    delegate_to: "{{ CLUSTER_APIENDPOINT_IP }}"
+    vars:
+      ansible_user: "{{ IMAGE_USERNAME }}"
+      ansible_ssh_private_key_file: "{{ SSH_PRIVATE_KEY }}"
+      ansible_python_interpreter: /usr/bin/python3
+    shell: kubectl get nodes | grep -w NotReady | awk '{print $1}'
+    environment:
+      KUBECONFIG: "/home/{{ IMAGE_USERNAME }}/.kube/config"
+    retries: 150
+    delay: 3
+    register: not_ready_nodes
+    until: NODE in not_ready_nodes.stdout_lines
+    become: yes
+    become_user: "{{ IMAGE_USERNAME }}"
+
+  - pause:
+      minutes: 1
+
+  - name: List only powered off VMs
+    virt:
+      command: list_vms
+      state: shutdown
+    register: shutdown_vms
+    retries: 50
+    delay: 10
+    until: NODE_VM in shutdown_vms.list_vms
+    become: yes
+    become_user: root
+
+  - name: Power on "{{ NODE }}"
+    shell: |
+       kubectl annotate bmh "{{ NODE }}" -n "{{ NAMESPACE }}" reboot.metal3.io/poweroff-
+
+  - name: List only running VMs
+    virt:
+      command: list_vms
+      state: running
+    register: running_vms
+    retries: 50
+    delay: 10
+    until: NODE_VM in running_vms.list_vms
+    become: yes
+    become_user: root
+
+  - name: Wait until powered on "{{ NODE }}" becomes Ready
+    delegate_to: "{{ CLUSTER_APIENDPOINT_IP }}"
+    vars:
+      ansible_user: "{{ IMAGE_USERNAME }}"
+      ansible_ssh_private_key_file: "{{ SSH_PRIVATE_KEY }}"
+      ansible_python_interpreter: /usr/bin/python3
+    shell: kubectl get nodes | grep -w Ready | awk '{print $1}'
+    environment:
+      KUBECONFIG: "/home/{{ IMAGE_USERNAME }}/.kube/config"
+    retries: 150
+    delay: 3
+    register: ready_nodes
+    until: NODE in ready_nodes.stdout_lines
+    become: yes
+    become_user: "{{ IMAGE_USERNAME }}"

--- a/vm-setup/roles/v1aX_integration_test/tasks/remediation.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/remediation.yml
@@ -1,8 +1,4 @@
 ---
-  - name: Define number of BMH's
-    set_fact:
-      NUMBER_OF_BMH: "{{ NUM_OF_MASTER_REPLICAS|int +  NUM_OF_WORKER_REPLICAS|int }}"
-
   - name: Get the name of a worker node
     shell: |
        kubectl get bmh -n "{{ NAMESPACE }}" -o json | jq -r '.items[]
@@ -10,14 +6,32 @@
        | contains("{{ CLUSTER_NAME }}-workers")) | .metadata.name'
     register: worker_node_name
 
-  - name: Define WORKER_NODE variable with worker node name
-    set_fact:
+  - name: Get the names of master nodes
+    shell: |
+       kubectl get bmh -n "{{ NAMESPACE }}" -o json | jq -r '.items[]
+       |select(.status.provisioning.state | contains("provisioned")) |select(.spec.consumerRef.name
+       | contains("{{ CLUSTER_NAME }}-controlplane")) | .metadata.name'
+    register: master_nodes_name
+
+  - set_fact:
       WORKER_NODE: "{{ worker_node_name.stdout }}"
+      MASTER_NODE_0: "{{ master_nodes_name.stdout_lines.0 }}"
+      MASTER_NODE_1: "{{ master_nodes_name.stdout_lines.1 }}"
+      MASTER_NODE_2: "{{ master_nodes_name.stdout_lines.2 }}"
 
-  - name: Get the name of the worker libvirt VM
-    set_fact:
+  - set_fact:
       WORKER_NODE_VM: "{{ WORKER_NODE | replace('-','_') }}"
+      MASTER_NODE_0_VM: "{{ MASTER_NODE_0 | replace('-','_') }}"
+      MASTER_NODE_1_VM: "{{ MASTER_NODE_1 | replace('-','_') }}"
+      MASTER_NODE_2_VM: "{{ MASTER_NODE_2 | replace('-','_') }}"
 
+  - name: Get IPs of master nodes from baremetal network
+    shell: |
+       kubectl get bmh "{{ MASTER_NODE_0 }}" -n metal3 -o json | jq -r '.status.hardware.nics
+       | '.[]' | select(.name|test("enp2s0")) | .ip'
+    register: MASTER_0_IP
+
+  # Reboot a single worker node
   - name: Reboot "{{ WORKER_NODE }}"
     shell: |
        kubectl annotate bmh "{{ WORKER_NODE }}" -n "{{ NAMESPACE }}" reboot.metal3.io=
@@ -42,23 +56,23 @@
     become: yes
     become_user: "{{ IMAGE_USERNAME }}"
     block:
-      - name: Wait until rebooted k8s node "{{ WORKER_NODE }}" becomes NotReady
-        shell: kubectl get nodes | grep -w NotReady | wc -l
+      - name: Wait until rebooted worker "{{ WORKER_NODE }}" becomes NotReady
+        shell: kubectl get nodes | grep -w NotReady | awk '{print $1}'
         environment:
           KUBECONFIG: "/home/{{ IMAGE_USERNAME }}/.kube/config"
         retries: 150
         delay: 3
         register: not_ready_nodes
-        until: not_ready_nodes.stdout == "1"
+        until: WORKER_NODE in not_ready_nodes.stdout_lines
 
-      - name: Wait until rebooted k8s node becomes Ready again
-        shell: kubectl get nodes | grep -w Ready | wc -l
+      - name: Wait until rebooted worker becomes Ready again
+        shell: kubectl get nodes | grep -w Ready | awk '{print $1}'
         environment:
           KUBECONFIG: "/home/{{ IMAGE_USERNAME }}/.kube/config"
         retries: 150
         delay: 3
         register: ready_nodes
-        until: ready_nodes.stdout == NUMBER_OF_BMH
+        until: WORKER_NODE in ready_nodes.stdout_lines
 
   - name: List only running VMs
     virt:
@@ -71,30 +85,30 @@
     become: yes
     become_user: root
 
-  - name: Power off "{{ WORKER_NODE }}"
-    shell: |
-       kubectl annotate bmh "{{ WORKER_NODE }}" -n "{{ NAMESPACE }}" reboot.metal3.io/poweroff=
-
-  - name: Powered off node status
-    delegate_to: "{{ CLUSTER_APIENDPOINT_IP }}"
+  # Power cycle a single worker node
+  - name: Power cycle a single worker node
+    include: power_cycle.yml
     vars:
-      ansible_user: "{{ IMAGE_USERNAME }}"
-      ansible_ssh_private_key_file: "{{ SSH_PRIVATE_KEY }}"
-      ansible_python_interpreter: /usr/bin/python3
-    become: yes
-    become_user: "{{ IMAGE_USERNAME }}"
-    block:
-      - name: Wait until powered off k8s node "{{ WORKER_NODE }}" becomes NotReady
-        shell: kubectl get nodes | grep -w NotReady | wc -l
-        environment:
-          KUBECONFIG: "/home/{{ IMAGE_USERNAME }}/.kube/config"
-        retries: 150
-        delay: 3
-        register: not_ready_nodes
-        until: not_ready_nodes.stdout == "1"
+      NODE: '{{ WORKER_NODE }}'
+      NODE_VM: "{{ WORKER_NODE_VM }}"
+
+  # Power cycle a single master node
+  - name: Power cycle a single master node
+    include: power_cycle.yml
+    vars:
+      NODE: '{{ MASTER_NODE_0 }}'
+      NODE_VM: "{{ MASTER_NODE_0_VM }}"
+
+  # Power cycle two master nodes
+  - name: Power off "{{ MASTER_NODE_1 }}" and "{{ MASTER_NODE_2 }}"
+    shell: |
+       kubectl annotate bmh "{{ item }}" -n "{{ NAMESPACE }}" reboot.metal3.io/poweroff=
+    with_items:
+      - "{{ MASTER_NODE_1 }}"
+      - "{{ MASTER_NODE_2 }}"
 
   - pause:
-      minutes: 1
+     minutes: 1
 
   - name: List only powered off VMs
     virt:
@@ -103,13 +117,36 @@
     register: shutdown_vms
     retries: 50
     delay: 10
-    until: WORKER_NODE_VM in shutdown_vms.list_vms
+    until:
+      - MASTER_NODE_1_VM in shutdown_vms.list_vms
+      - MASTER_NODE_2_VM in shutdown_vms.list_vms
     become: yes
     become_user: root
 
-  - name: Power on "{{ WORKER_NODE }}"
+  - name: Power on masters
     shell: |
-       kubectl annotate bmh "{{ WORKER_NODE }}" -n "{{ NAMESPACE }}" reboot.metal3.io/poweroff-
+       kubectl annotate bmh "{{ item }}" -n "{{ NAMESPACE }}" reboot.metal3.io/poweroff-
+    with_items:
+      - "{{ MASTER_NODE_1 }}"
+      - "{{ MASTER_NODE_2 }}"
+
+  - name: Wait until powered on master nodes become Ready
+    delegate_to: "{{ MASTER_0_IP.stdout }}"
+    vars:
+      ansible_user: "{{ IMAGE_USERNAME }}"
+      ansible_ssh_private_key_file: "{{ SSH_PRIVATE_KEY }}"
+      ansible_python_interpreter: /usr/bin/python3
+    shell: kubectl get nodes | grep -w Ready | awk '{print $1}'
+    environment:
+      KUBECONFIG: "/home/{{ IMAGE_USERNAME }}/.kube/config"
+    retries: 150
+    delay: 3
+    register: ready_master
+    until:
+      - MASTER_NODE_1 in ready_master.stdout_lines
+      - MASTER_NODE_2 in ready_master.stdout_lines
+    become: yes
+    become_user: "{{ IMAGE_USERNAME }}"
 
   - name: List only running VMs
     virt:
@@ -118,24 +155,8 @@
     register: running_vms
     retries: 50
     delay: 10
-    until: WORKER_NODE_VM in running_vms.list_vms
+    until:
+      - MASTER_NODE_1_VM in running_vms.list_vms
+      - MASTER_NODE_2_VM in running_vms.list_vms
     become: yes
     become_user: root
-
-  - name: Powered on node status
-    delegate_to: "{{ CLUSTER_APIENDPOINT_IP }}"
-    vars:
-      ansible_user: "{{ IMAGE_USERNAME }}"
-      ansible_ssh_private_key_file: "{{ SSH_PRIVATE_KEY }}"
-      ansible_python_interpreter: /usr/bin/python3
-    become: yes
-    become_user: "{{ IMAGE_USERNAME }}"
-    block:
-      - name: Wait until powered on k8s node "{{ WORKER_NODE }}" becomes Ready
-        shell: kubectl get nodes | grep -w Ready | wc -l
-        environment:
-          KUBECONFIG: "/home/{{ IMAGE_USERNAME }}/.kube/config"
-        retries: 150
-        delay: 3
-        register: ready_nodes
-        until: ready_nodes.stdout == NUMBER_OF_BMH

--- a/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
@@ -19,7 +19,7 @@
         | .metadata.name ] | length'
     register: provisioned_bmh
     retries: 200
-    delay: 20
+    delay: 30
     until: provisioned_bmh.stdout == NUMBER_OF_BMH
 
   - name: Wait until "{{ NUMBER_OF_BMH }}" machines become running.


### PR DESCRIPTION
This patch adds a couples of Ansible tasks to test remediation of masters in HA cluster scenario and modifies existing remediation tests to reduce the duplication.