### PR TITLE
Fix ansible version for centos to 2.9.8

### DIFF
--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -37,10 +37,11 @@ fi
 
 # Install required packages
 sudo dnf -y install \
-  ansible \
   redhat-lsb-core \
   python3-pip \
   wget
+
+sudo pip3 install ansible==2.9.8
 
 if [[ $DISTRO == "centos7" ]]; then
   # Install pip since it is used by the k8s Ansible module


### PR DESCRIPTION
Latest Ansible version in Centos is not working properly in metal3-dev-env.  This PR fixes the ansible version to 2.9.8 for Centos to fix the issue for now and get the CI going. This needs further investigation.  An issue has been created to track this. 

Issue #353 