### PR TITLE
Add new "mixed" vm_driver

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -91,7 +91,8 @@
 #export TEST_MAX_TIME=120
 
 #
-# Set the driver. The default value is 'ipmi'
+# Set the driver. The default value is 'mixed' (alternate nodes between ipmi
+# and redfish).
 #
 #export BMC_DRIVER="redfish"
 

--- a/vm-setup/roles/firewall/defaults/main.yml
+++ b/vm-setup/roles/firewall/defaults/main.yml
@@ -3,6 +3,7 @@ baremetal_interface: baremetal
 provisioning_interface: provisioning
 external_subnet_v4: "192.168.111.0/24"
 vbmc_port_range: "6230:6235"
+sushy_port: 8000
 firewall_rule_state: present
 ironic_ports:
   - "6180"

--- a/vm-setup/roles/firewall/tasks/firewalld.yaml
+++ b/vm-setup/roles/firewall/tasks/firewalld.yaml
@@ -48,3 +48,11 @@
     permanent: yes
     state: enabled
     immediate: yes
+
+- name: "firewalld: sushy Port"
+  firewalld:
+    zone: libvirt
+    port: "{{ sushy_port }}/tcp"
+    permanent: yes
+    state: enabled
+    immediate: yes

--- a/vm-setup/roles/firewall/tasks/iptables.yaml
+++ b/vm-setup/roles/firewall/tasks/iptables.yaml
@@ -15,6 +15,16 @@
     jump: ACCEPT
     state: "{{ firewall_rule_state }}"
 
+- name: "iptables: sushy Port"
+  iptables:
+    chain: INPUT
+    in_interface: "{{ baremetal_interface }}"
+    protocol: tcp
+    match: tcp
+    destination_port: "{{ sushy_port }}"
+    jump: ACCEPT
+    state: "{{ firewall_rule_state }}"
+
 - name: "iptables: Established and related"
   iptables:
     chain: FORWARD

--- a/vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml
@@ -126,7 +126,7 @@
 
 - name: set_fact BMC Driver
   set_fact:
-    vm_driver: "{{ lookup('env', 'BMC_DRIVER') | default('ipmi', true) }}"
+    vm_driver: "{{ lookup('env', 'BMC_DRIVER') | default('mixed', true) }}"
 
 
 # Generate the ironic node inventory files.  Note that this

--- a/vm-setup/roles/libvirt/templates/ironic_nodes.json.j2
+++ b/vm-setup/roles/libvirt/templates/ironic_nodes.json.j2
@@ -13,22 +13,33 @@
 {
   "nodes": [
   {% for node in vm_nodes %}
+
+    {% set vm_driver_tmp = vm_driver -%}
+    {# If vm_driver == mixed we alternate between ipmi and refish to test both #}
+    {% if vm_driver == 'mixed' -%}
+      {% if loop.index is divisibleby 2 -%}
+        {% set vm_driver_tmp = 'redfish' -%}
+      {% else -%}
+        {% set vm_driver_tmp = 'ipmi' -%}
+      {% endif -%}
+    {% endif -%}
+
     {
       "name": "{{ node.name|replace('_', '-') }}",
-      "driver": "{{ vm_driver }}",
+      "driver": "{{ vm_driver_tmp }}",
       "resource_class": "baremetal",
       "driver_info": {
         "username": "admin",
         "password": "password",
-        {% if vm_driver =='redfish' -%}
+        {% if vm_driver_tmp =='redfish' -%}
         "port": "8000",
-        "address": "{{vm_driver}}+http://{{ lvars['host_ip'] | ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
-        {% elif vm_driver == 'redfish-virtualmedia' -%}
+        "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
+        {% elif vm_driver_tmp == 'redfish-virtualmedia' -%}
         "port": "8000",
-        "address": "{{vm_driver}}+http://{{ lvars['host_ip'] | ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
+        "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
         {% else -%}
         "port": "{{ node.virtualbmc_port }}",
-        "address": "{{vm_driver}}://{{lvars['host_ip'] | ipwrap }}:{{node.virtualbmc_port}}",
+        "address": "{{vm_driver_tmp}}://{{lvars['host_ip'] | ipwrap }}:{{node.virtualbmc_port}}",
         {% endif -%}
         "deploy_kernel": "http://{{ provisioning_url_host }}/images/ironic-python-agent.kernel",
         "deploy_ramdisk": "http://{{ provisioning_url_host }}/images/ironic-python-agent.initramfs"


### PR DESCRIPTION
Add a new mode for the power driver that uses both
redfish and ipmi. Adding node with both types of BMC
will allow us to CI both in a single CI job.