### PR TITLE
Setup process might run failure in the first time and need re-run aga…

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -283,12 +283,14 @@ else
   if [[ "${PROVISIONING_IPV6}" == "true" ]]; then
     sudo su -l -c 'minikube ssh "sudo ip -6 addr add '"$CLUSTER_PROVISIONING_IP/$PROVISIONING_CIDR"' dev eth2"' "${USER}"
   else
-    if [[ ! $(sudo su -l -c "minikube ssh sudo brctl show | grep $CLUSTER_PROVISIONING_INTERFACE" "${USER}") ]]; then
-      sudo su -l -c "minikube ssh sudo brctl addbr $CLUSTER_PROVISIONING_INTERFACE" "${USER}"
-      sudo su -l -c "minikube ssh sudo ip link set $CLUSTER_PROVISIONING_INTERFACE up" "${USER}"
-      sudo su -l -c "minikube ssh sudo brctl addif $CLUSTER_PROVISIONING_INTERFACE eth2" "${USER}"
-      sudo su -l -c "minikube ssh sudo ip addr add $INITIAL_IRONICBRIDGE_IP/$PROVISIONING_CIDR dev $CLUSTER_PROVISIONING_INTERFACE" "${USER}"
+    if sudo su -l -c "minikube ssh sudo brctl show" "${USER}" | grep -q "$CLUSTER_PROVISIONING_INTERFACE"; then
+      sudo su -l -c "minikube ssh sudo ip link set $CLUSTER_PROVISIONING_INTERFACE down" "${USER}"
+      sudo su -l -c "minikube ssh sudo brctl delbr $CLUSTER_PROVISIONING_INTERFACE" "${USER}"
     fi
+    sudo su -l -c "minikube ssh sudo brctl addbr $CLUSTER_PROVISIONING_INTERFACE" "${USER}"
+    sudo su -l -c "minikube ssh sudo ip link set $CLUSTER_PROVISIONING_INTERFACE up" "${USER}"
+    sudo su -l -c "minikube ssh sudo brctl addif $CLUSTER_PROVISIONING_INTERFACE eth2" "${USER}"
+    sudo su -l -c "minikube ssh sudo ip addr add $INITIAL_IRONICBRIDGE_IP/$PROVISIONING_CIDR dev $CLUSTER_PROVISIONING_INTERFACE" "${USER}"
   fi
 fi
 

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -283,10 +283,12 @@ else
   if [[ "${PROVISIONING_IPV6}" == "true" ]]; then
     sudo su -l -c 'minikube ssh "sudo ip -6 addr add '"$CLUSTER_PROVISIONING_IP/$PROVISIONING_CIDR"' dev eth2"' "${USER}"
   else
-	  sudo su -l -c "minikube ssh sudo brctl addbr $CLUSTER_PROVISIONING_INTERFACE" "${USER}"
-	  sudo su -l -c "minikube ssh sudo ip link set $CLUSTER_PROVISIONING_INTERFACE up" "${USER}"
-	  sudo su -l -c "minikube ssh sudo brctl addif $CLUSTER_PROVISIONING_INTERFACE eth2" "${USER}"
-	  sudo su -l -c "minikube ssh sudo ip addr add $INITIAL_IRONICBRIDGE_IP/$PROVISIONING_CIDR dev $CLUSTER_PROVISIONING_INTERFACE" "${USER}"
+    if [[ ! $(sudo su -l -c "minikube ssh sudo brctl show | grep $CLUSTER_PROVISIONING_INTERFACE" "${USER}") ]]; then
+      sudo su -l -c "minikube ssh sudo brctl addbr $CLUSTER_PROVISIONING_INTERFACE" "${USER}"
+      sudo su -l -c "minikube ssh sudo ip link set $CLUSTER_PROVISIONING_INTERFACE up" "${USER}"
+      sudo su -l -c "minikube ssh sudo brctl addif $CLUSTER_PROVISIONING_INTERFACE eth2" "${USER}"
+      sudo su -l -c "minikube ssh sudo ip addr add $INITIAL_IRONICBRIDGE_IP/$PROVISIONING_CIDR dev $CLUSTER_PROVISIONING_INTERFACE" "${USER}"
+    fi
   fi
 fi
 

--- a/ubuntu_bridge_network_configuration.sh
+++ b/ubuntu_bridge_network_configuration.sh
@@ -7,10 +7,14 @@ source lib/logging.sh
 # shellcheck disable=SC1091
 source lib/common.sh
 
-if [ "$MANAGE_PRO_BRIDGE" == "y" ] && [[ ! $(brctl show | grep provisioning) ]]; then
+if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
      # Adding an IP address in the libvirt definition for this network results in
      # dnsmasq being run, we don't want that as we have our own dnsmasq, so set
      # the IP address here
+     if brctl show | grep -q 'provisioning'; then
+         sudo ip link set provisioning down
+	 sudo brctl delbr provisioning
+     fi
      sudo brctl addbr provisioning
      # sudo ifconfig provisioning 172.22.0.1 netmask 255.255.255.0 up
      # Use ip command. ifconfig commands are deprecated now.

--- a/ubuntu_bridge_network_configuration.sh
+++ b/ubuntu_bridge_network_configuration.sh
@@ -7,7 +7,7 @@ source lib/logging.sh
 # shellcheck disable=SC1091
 source lib/common.sh
 
-if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
+if [ "$MANAGE_PRO_BRIDGE" == "y" ] && [[ ! $(brctl show | grep provisioning) ]]; then
      # Adding an IP address in the libvirt definition for this network results in
      # dnsmasq being run, we don't want that as we have our own dnsmasq, so set
      # the IP address here


### PR DESCRIPTION
…in, the second run  was broken due to the bridge was created in previous time. So this patch will skip creating the network bridge if exists.