### PR TITLE
Add static IP on Ironic endpoint for CAPM3 v1alpha4 ubuntu templates

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
@@ -65,6 +65,12 @@ spec:
         object: machine
       - key: local_hostname
         object: machine
+    ipAddressesFromIPPool:
+      - key: provisioningIP
+        name: provisioning-pool
+    prefixesFromIPPool:
+      - key: provisioningCIDR
+        name: provisioning-pool
   networkData:
     links:
       ethernets:
@@ -77,17 +83,14 @@ spec:
           macAddress:
             fromHostInterface: enp2s0
     networks:
-      ipv4:
-        - id: provisioning
-          link: enp1s0
-          ipAddressFromIPPool: provisioning-pool
 {% if IP_STACK == 'v4' or IP_STACK == 'v4v6' %}
+      ipv4:
         - id: baremetalv4
           link: enp2s0
           ipAddressFromIPPool: baremetalv4-pool
           routes:
             - network: 0.0.0.0
-              netmask: 0
+              prefix: 0
               gateway:
                 fromIPPool: baremetalv4-pool
 {% endif %}
@@ -98,7 +101,7 @@ spec:
           ipAddressFromIPPool: baremetalv6-pool
           routes:
             - network: 0::0
-              netmask: 0
+              prefix: 0
               gateway:
                 fromIPPool: baremetalv6-pool
 {% endif %}

--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
@@ -70,6 +70,12 @@ spec:
         object: machine
       - key: local_hostname
         object: machine
+    ipAddressesFromIPPool:
+      - key: provisioningIP
+        name: provisioning-pool
+    prefixesFromIPPool:
+      - key: provisioningCIDR
+        name: provisioning-pool
   networkData:
     links:
       ethernets:
@@ -82,17 +88,14 @@ spec:
           macAddress:
             fromHostInterface: enp2s0
     networks:
-      ipv4:
-        - id: provisioning
-          link: enp1s0
-          ipAddressFromIPPool: provisioning-pool
 {% if IP_STACK == 'v4' or IP_STACK == 'v4v6' %}
+      ipv4:
         - id: baremetalv4
           link: enp2s0
           ipAddressFromIPPool: baremetalv4-pool
           routes:
             - network: 0.0.0.0
-              netmask: 0
+              prefix: 0
               gateway:
                 fromIPPool: baremetalv4-pool
 {% endif %}
@@ -103,7 +106,7 @@ spec:
           ipAddressFromIPPool: baremetalv6-pool
           routes:
             - network: 0::0
-              netmask: 0
+              prefix: 0
               gateway:
                 fromIPPool: baremetalv6-pool
 {% endif %}

--- a/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_ubuntu.rc
+++ b/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_ubuntu.rc
@@ -145,7 +145,8 @@ export CTLPLANE_KUBEADM_EXTRA_CONFIG="
             bridges:
               {{ IRONIC_ENDPOINT_BRIDGE }}:
                 interfaces: [enp1s0]
-                dhcp4: yes
+                addresses: 
+                - {{ "{{ ds.meta_data.provisioningIP }}" }}/{{ "{{ ds.meta_data.provisioningCIDR }}" }}  
       - path : /etc/docker/daemon.json
         owner: root:root
         permissions: '0644'
@@ -210,7 +211,8 @@ export WORKERS_KUBEADM_EXTRA_CONFIG="
               bridges:
                 {{ IRONIC_ENDPOINT_BRIDGE }}:
                   interfaces: [enp1s0]
-                  dhcp4: yes
+                  addresses: 
+                  - {{ "{{ ds.meta_data.provisioningIP }}" }}/{{ "{{ ds.meta_data.provisioningCIDR }}" }}  
         - path : /etc/docker/daemon.json
           owner: root:root
           permissions: '0644'


### PR DESCRIPTION
The current setting for CAPM3 v1alpha4 templates has bugs where it adds IP on enp1s0 interface for ubuntu. This results in IP route unreachable error. This PR adds the static IP assignment on the ironic-endpoint bridge and removes the IP assignment from enp1s0 for ubuntu. 

This PR also fixes a bug in Metal3DataTemplate regarding a field name. 