### PR TITLE
Add veth interface to keep provisioning bridge up

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -178,10 +178,17 @@ VBMC_IMAGE=${VBMC_LOCAL_IMAGE:-$VBMC_IMAGE}
 SUSHY_TOOLS_IMAGE=${SUSHY_TOOLS_LOCAL_IMAGE:-$SUSHY_TOOLS_IMAGE}
 
 # Start httpd container
-#shellcheck disable=SC2086
-sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name httpd-infra \
-     ${POD_NAME_INFRA} -v "$IRONIC_DATA_DIR":/shared --entrypoint /bin/runhttpd\
-     "${IRONIC_IMAGE}"
+if [[ $OS == ubuntu ]]; then
+  #shellcheck disable=SC2086
+  sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name httpd-infra ${POD_NAME_INFRA} \
+      -v "$IRONIC_DATA_DIR":/shared --entrypoint /bin/runhttpd \
+      --env "PROVISIONING_INTERFACE=ironicendpoint" "${IRONIC_IMAGE}"
+else
+  #shellcheck disable=SC2086
+  sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name httpd-infra ${POD_NAME_INFRA} \
+      -v "$IRONIC_DATA_DIR":/shared --entrypoint /bin/runhttpd \
+      "${IRONIC_IMAGE}"
+fi
 
 # Start vbmc and sushy containers
 #shellcheck disable=SC2086

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -146,6 +146,9 @@ function deploy_kustomization() {
 
 function launch_baremetal_operator() {
     pushd "${BMOPATH}"
+    # This is a temporary fix to pass the CI.
+    # TODO: remove the line when this change is actually made in BMO.
+    sed -i "/PROVISIONING_INTERFACE*/c\PROVISIONING_INTERFACE=ironicendpoint" deploy/ironic_ci.env
 
     if [ "${CAPI_VERSION}" != "v1alpha3" ]; then
       kubectl create namespace metal3

--- a/ubuntu_bridge_network_configuration.sh
+++ b/ubuntu_bridge_network_configuration.sh
@@ -6,16 +6,28 @@ set -xe
 source lib/logging.sh
 # shellcheck disable=SC1091
 source lib/common.sh
+# shellcheck disable=SC1091
+source lib/network.sh
 
 if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
      # Adding an IP address in the libvirt definition for this network results in
      # dnsmasq being run, we don't want that as we have our own dnsmasq, so set
-     # the IP address here
+     # the IP address here.
+     # Create a veth iterface peer.
+     sudo ip link add ironicendpoint type veth peer name ironic-peer
+     # Create provisioning bridge.
      sudo brctl addbr provisioning
      # sudo ifconfig provisioning 172.22.0.1 netmask 255.255.255.0 up
      # Use ip command. ifconfig commands are deprecated now.
-     sudo ip addr add dev provisioning "$PROVISIONING_IP"/"$PROVISIONING_CIDR"
      sudo ip link set provisioning up
+     if [[ "${PROVISIONING_IPV6}" == "true" ]]; then
+        sudo ip -6 addr add "$PROVISIONING_IP"/"$PROVISIONING_CIDR" dev ironicendpoint
+      else
+        sudo ip addr add dev ironicendpoint "$PROVISIONING_IP"/"$PROVISIONING_CIDR"
+     fi
+     sudo brctl addif provisioning ironic-peer
+     sudo ip link set ironicendpoint up
+     sudo ip link set ironic-peer up
 
      # Need to pass the provision interface for bare metal
      if [ "$PRO_IF" ]; then

--- a/vm-setup/roles/firewall/defaults/main.yml
+++ b/vm-setup/roles/firewall/defaults/main.yml
@@ -9,6 +9,7 @@ ironic_ports:
   - "5050"
   - "6385"
   - "9999"
+  - "80"
 provisioning_host_ports:
   # Caching HTTP Server
   - "80"

--- a/vm-setup/roles/libvirt/tasks/network_teardown_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/network_teardown_tasks.yml
@@ -14,12 +14,14 @@
   with_items: "{{ networks }}"
   become: true
 
-- name: Delete bridges on Ubuntu
+- name: Delete bridges and veth interfaces on Ubuntu
   shell: |
      sudo ip link set baremetal down
      sudo ip link set provisioning down
+     sudo ip link set ironicendpoint down
      brctl delbr baremetal | true
      brctl delbr provisioning | true
+     sudo ip link del ironicendpoint | true
 
   when:
     - ansible_distribution == 'Ubuntu'


### PR DESCRIPTION
During cleanup process (deprovisioning of BMHs) in feature tests, libvirt VMs are turned off which results in loss of provisioning bridge. Since the bridge is down, next provisioning is failing because 172.22.0.1 ironic endpoint is not there. Creating veth will keep the provisioning bridge up and running and make sure that the ironic endpoint will be there.