### PR TITLE
Bump python to 3.8 and install sushy-tools from git

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -1,7 +1,7 @@
-FROM registry.hub.docker.com/library/python:3.7
+FROM registry.hub.docker.com/library/python:3.8
 
 RUN apt update && \
     apt install -y libvirt-dev && \
-    pip3 install sushy-tools==0.10.0 libvirt-python
+    pip3 install git+https://opendev.org/openstack/sushy-tools.git@ff2be838b9da25998202a93f2120d1350f2a1f6e libvirt-python
 
 CMD sushy-emulator -i :: -p 8000 --config /root/sushy/conf.py


### PR DESCRIPTION
This installs sushy-tools from git, pinned at the sha that contains
non-IDE virtual media support.