### PR TITLE
WIP: Add mTLS authentication for the Openstack CLI

### DIFF
--- a/clouds.yaml.template
+++ b/clouds.yaml.template
@@ -3,3 +3,6 @@ clouds:
     auth_type: none
     baremetal_endpoint_override: http://__CLUSTER_URL_HOST__:6385
     baremetal_introspection_endpoint_override: http://__CLUSTER_URL_HOST__:5050
+    cacert: /etc/openstack/ca.crt
+    cert: /etc/openstack/client.crt
+    key: /etc/openstack/client.key

--- a/openstackclient.sh
+++ b/openstackclient.sh
@@ -1,14 +1,48 @@
 #!/bin/bash
 
+CA_ISSUER="ca-issuer"
+CLIENT_NAME="openstack-cli"
+CLIENT_SECRET="openstack-cli-mtls"
+
 DIR="$(dirname "$(readlink -f "$0")")"
 # shellcheck source=lib/common.sh
 source "${DIR}/lib/common.sh"
+# shellcheck source=lib/network.sh
+source "${DIR}/lib/network.sh"
 
 if [ -d "${PWD}/_clouds_yaml" ]; then
   MOUNTDIR="${PWD}/_clouds_yaml"
 else
   MOUNTDIR="${SCRIPTDIR}/_clouds_yaml"
 fi
+
+cat <<EOF | kubectl apply -f - || exit 1
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: ${CLIENT_NAME}
+  namespace: metal3
+spec:
+  secretName: ${CLIENT_SECRET}
+  duration: 7200h # 30d
+  renewBefore: 120h # 5d
+  commonName: ${CLIENT_NAME}
+  isCA: false
+  keySize: 2048
+  keyAlgorithm: rsa
+  keyEncoding: pkcs1
+  usages:
+    - client auth
+  ipAddresses:
+    - ${CLUSTER_URL_HOST}
+  issuerRef:
+    name: ${CA_ISSUER}
+    kind: Issuer
+EOF
+kubectl wait -n metal3 "certificates/${CLIENT_NAME}" --for condition=Ready || exit 1
+kubectl get secret -n metal3 "${CLIENT_SECRET}" --template='{{index .data "ca.crt" | base64decode}}' > "${MOUNTDIR}/ca.crt"
+kubectl get secret -n metal3 "${CLIENT_SECRET}" --template='{{index .data "tls.crt" | base64decode}}' > "${MOUNTDIR}/client.crt"
+kubectl get secret -n metal3 "${CLIENT_SECRET}" --template='{{index .data "tls.key" | base64decode}}' > "${MOUNTDIR}/client.key"
 
 sudo "${CONTAINER_RUNTIME}" run --net=host \
   -v "${MOUNTDIR}:/etc/openstack" --rm \


### PR DESCRIPTION
To be able to use the Openstack CLI when ironic is secured with mTLS, we
need to get a client certificate for the CLI from cert-manager, download
the certificates and adapt the configuration of the Openstack CLI.

**WIP:** Right now, this assumes that metal3-dev-env will always be deployed with mTLS enabled. If this should be optional, the script needs to differentiate between those cases.