### PR TITLE
Avoid printing skipped Ansible tasks

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -187,6 +187,9 @@ TEST_MAX_TIME="${TEST_MAX_TIME:-240}"
 FAILS=0
 RESULT_STR=""
 
+# Avoid printing skipped Ansible tasks
+export ANSIBLE_DISPLAY_SKIPPED_HOSTS=no
+
 # Verify requisites/permissions
 # Connect to system libvirt
 export LIBVIRT_DEFAULT_URI=qemu:///system


### PR DESCRIPTION
Avoid printing skipped Ansible tasks output, since we now have too many tasks that run depending on certain condition but still print out some output that's not relevant. This will help to have a bit clearer output both on the CI & local run.