### PR TITLE
Pin sushy-tools to 0.11.0

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -2,6 +2,6 @@ FROM registry.hub.docker.com/library/python:3.8
 
 RUN apt update && \
     apt install -y libvirt-dev && \
-    pip3 install git+https://opendev.org/openstack/sushy-tools.git@ff2be838b9da25998202a93f2120d1350f2a1f6e libvirt-python
+    pip3 install sushy-tools==0.11.0 libvirt-python
 
 CMD sushy-emulator -i :: -p 8000 --config /root/sushy/conf.py


### PR DESCRIPTION
When we pinned to the git sha, it was missing another bugfix[1]. This
just goes back to using a release now that all the fixes we need are in
0.11.0.

[1] https://review.opendev.org/gitweb?p=openstack%2Fsushy-tools.git;a=commitdiff;h=dea62db5d293946efd16a246f213e6330bc1f94a