### PR TITLE
Bug fix: Assign 172.22.0.2 address to ironic BMO configmap. 

### DIFF
--- a/lib/network.sh
+++ b/lib/network.sh
@@ -157,14 +157,7 @@ fi
 
 network_address INITIAL_IRONICBRIDGE_IP "$PROVISIONING_NETWORK" 9
 
-if [ "${EPHEMERAL_CLUSTER}" == "minikube" ]; then
-  export DEPLOY_KERNEL_URL=${DEPLOY_KERNEL_URL:-"http://${CLUSTER_URL_HOST}:6180/images/ironic-python-agent.kernel"}
-  export DEPLOY_RAMDISK_URL=${DEPLOY_RAMDISK_URL:-"http://${CLUSTER_URL_HOST}:6180/images/ironic-python-agent.initramfs"}
-  export IRONIC_URL=${IRONIC_URL:-"http://${CLUSTER_URL_HOST}:6385/v1/"}
-  export IRONIC_INSPECTOR_URL=${IRONIC_INSPECTOR_URL:-"http://${CLUSTER_URL_HOST}:5050/v1/"}
-else
-  export DEPLOY_KERNEL_URL=${DEPLOY_KERNEL_URL:-"http://${PROVISIONING_URL_HOST}:6180/images/ironic-python-agent.kernel"}
-  export DEPLOY_RAMDISK_URL=${DEPLOY_RAMDISK_URL:-"http://${PROVISIONING_URL_HOST}:6180/images/ironic-python-agent.initramfs"}
-  export IRONIC_URL=${IRONIC_URL:-"http://${PROVISIONING_URL_HOST}:6385/v1/"}
-  export IRONIC_INSPECTOR_URL=${IRONIC_INSPECTOR_URL:-"http://${PROVISIONING_URL_HOST}:5050/v1/"}
-fi
+export DEPLOY_KERNEL_URL=${DEPLOY_KERNEL_URL:-"http://${CLUSTER_URL_HOST}:6180/images/ironic-python-agent.kernel"}
+export DEPLOY_RAMDISK_URL=${DEPLOY_RAMDISK_URL:-"http://${CLUSTER_URL_HOST}:6180/images/ironic-python-agent.initramfs"}
+export IRONIC_URL=${IRONIC_URL:-"http://${CLUSTER_URL_HOST}:6385/v1/"}
+export IRONIC_INSPECTOR_URL=${IRONIC_INSPECTOR_URL:-"http://${CLUSTER_URL_HOST}:5050/v1/"}


### PR DESCRIPTION
During the metal3-dev-env building using v1alpha4 the capm3-ironic-bmo-configmap is using 172.22.0.1 instead of 172.22.0.2. So when we are doing the pivoting with v1alpha4 the BMO is giving error and it's looking for ironicendpoint on 172.22.0.1.  Here is the fix for this error so that the BMO is always looking for .02 address instead of .01 address. 