### PR TITLE
Remove metal3 namespace from Calico manifest

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
@@ -120,7 +120,6 @@
         k8s:
           state: present
           src: "/tmp/calico.yaml"
-          namespace: "{{ NAMESPACE }}"
         register: install_cni
 
       # Check for pods & nodes on the target cluster


### PR DESCRIPTION
Metal3 namespace is not in use in target cluster. This PR removed metal3 namespace from Calico manifest in verify.yml 