### PR TITLE
Verify retrieval of kubelet and kubeadm configuration files

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_centos.rc
+++ b/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_centos.rc
@@ -45,8 +45,8 @@ export CTLPLANE_KUBEADM_EXTRA_CONFIG="
       - chmod a+x kubeadm kubelet kubectl
       - mv kubeadm kubelet kubectl /usr/local/bin/
       - mkdir -p /etc/systemd/system/kubelet.service.d
-      - curl -sSL \"https://raw.githubusercontent.com/kubernetes/release/{{ KUBERNETES_BINARIES_CONFIG_VERSION }}/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service\" | sed \"s:/usr/bin:/usr/local/bin:g\" > /etc/systemd/system/kubelet.service
-      - curl -sSL \"https://raw.githubusercontent.com/kubernetes/release/{{ KUBERNETES_BINARIES_CONFIG_VERSION }}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf\" | sed \"s:/usr/bin:/usr/local/bin:g\" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+      - retrieve.configuration.files.sh \"https://raw.githubusercontent.com/kubernetes/release/{{ KUBERNETES_BINARIES_CONFIG_VERSION }}/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service\" /etc/systemd/system/kubelet.service
+      - retrieve.configuration.files.sh \"https://raw.githubusercontent.com/kubernetes/release/{{ KUBERNETES_BINARIES_CONFIG_VERSION }}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf\" /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
       - usermod -aG docker {{ IMAGE_USERNAME }}
       - systemctl enable --now docker keepalived kubelet
       - systemctl link /etc/systemd/system/multi-user.target.wants/monitor.keepalived.service
@@ -57,6 +57,24 @@ export CTLPLANE_KUBEADM_EXTRA_CONFIG="
       - cp /etc/kubernetes/admin.conf /home/{{ IMAGE_USERNAME }}/.kube/config
       - chown {{ IMAGE_USERNAME }}:{{ IMAGE_USERNAME }} /home/{{ IMAGE_USERNAME }}/.kube/config
     files:
+      - path: /usr/local/bin/retrieve.configuration.files.sh
+        owner: root:root
+        permissions: '0755'
+        content: |
+            #!/bin/bash
+            set -e
+            url=\"\${1}\"
+            dst=\"\${2}\"
+            filename=\"\$(basename \${url})\"
+            tmpfile=\"/tmp/\${filename}\"
+            curl -sSL -w \"%{http_code}\" \"\${url}\" | sed \"s:/usr/bin:/usr/local/bin:g\" > /tmp/\"\${filename}\"
+            http_status=\$(cat \"\${tmpfile}\" | tail -n 1)
+            if [ \"\${http_status}\" != \"200\" ]; then
+              echo \"Error: unable to retrieve \${filename} file\";
+              exit 1;
+            else
+              cat \"\${tmpfile}\"| sed '\$d' > \"\${dst}\";
+            fi
       - path: /usr/local/bin/monitor.keepalived.sh
         owner: root:root
         permissions: '0755'
@@ -159,11 +177,29 @@ export WORKERS_KUBEADM_EXTRA_CONFIG="
         - chmod a+x kubeadm kubelet kubectl
         - mv kubeadm kubelet kubectl /usr/local/bin/
         - mkdir -p /etc/systemd/system/kubelet.service.d
-        - curl -sSL \"https://raw.githubusercontent.com/kubernetes/release/{{ KUBERNETES_BINARIES_CONFIG_VERSION }}/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service\" | sed \"s:/usr/bin:/usr/local/bin:g\" > /etc/systemd/system/kubelet.service
-        - curl -sSL \"https://raw.githubusercontent.com/kubernetes/release/{{ KUBERNETES_BINARIES_CONFIG_VERSION }}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf\" | sed \"s:/usr/bin:/usr/local/bin:g\" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+        - retrieve.configuration.files.sh \"https://raw.githubusercontent.com/kubernetes/release/{{ KUBERNETES_BINARIES_CONFIG_VERSION }}/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service\" /etc/systemd/system/kubelet.service
+        - retrieve.configuration.files.sh \"https://raw.githubusercontent.com/kubernetes/release/{{ KUBERNETES_BINARIES_CONFIG_VERSION }}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf\" /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
         - usermod -aG docker {{ IMAGE_USERNAME }}
         - systemctl enable --now docker kubelet
       files:
+        - path: /usr/local/bin/retrieve.configuration.files.sh
+          owner: root:root
+          permissions: '0755'
+          content: |
+              #!/bin/bash
+              set -e
+              url=\"\${1}\"
+              dst=\"\${2}\"
+              filename=\"\$(basename \${url})\"
+              tmpfile=\"/tmp/\${filename}\"
+              curl -sSL -w \"%{http_code}\" \"\${url}\" | sed \"s:/usr/bin:/usr/local/bin:g\" > /tmp/\"\${filename}\"
+              http_status=\$(cat \"\${tmpfile}\" | tail -n 1)
+              if [ \"\${http_status}\" != \"200\" ]; then
+                echo \"Error: unable to retrieve \${filename} file\";
+                exit 1;
+              else
+                cat \"\${tmpfile}\"| sed '\$d' > \"\${dst}\";
+              fi
         - path: /etc/sysconfig/network-scripts/ifcfg-eth1
           owner: root:root
           permissions: '0644'

--- a/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_ubuntu.rc
+++ b/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_ubuntu.rc
@@ -52,8 +52,8 @@ export CTLPLANE_KUBEADM_EXTRA_CONFIG="
       - chmod a+x kubeadm kubelet kubectl
       - mv kubeadm kubelet kubectl /usr/local/bin/
       - mkdir -p /etc/systemd/system/kubelet.service.d
-      - curl -sSL \"https://raw.githubusercontent.com/kubernetes/release/{{ KUBERNETES_BINARIES_CONFIG_VERSION }}/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service\" | sed \"s:/usr/bin:/usr/local/bin:g\" > /etc/systemd/system/kubelet.service
-      - curl -sSL \"https://raw.githubusercontent.com/kubernetes/release/{{ KUBERNETES_BINARIES_CONFIG_VERSION }}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf\" | sed \"s:/usr/bin:/usr/local/bin:g\" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+      - retrieve.configuration.files.sh \"https://raw.githubusercontent.com/kubernetes/release/{{ KUBERNETES_BINARIES_CONFIG_VERSION }}/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service\" /etc/systemd/system/kubelet.service
+      - retrieve.configuration.files.sh \"https://raw.githubusercontent.com/kubernetes/release/{{ KUBERNETES_BINARIES_CONFIG_VERSION }}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf\" /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
       - systemctl enable --now docker kubelet
       - if (curl -sk --max-time 10 https://{{ CLUSTER_APIENDPOINT_HOST }}:6443/healthz); then echo \"keepalived already running\";else systemctl start keepalived; fi
       - usermod -aG docker {{ IMAGE_USERNAME }}
@@ -65,6 +65,24 @@ export CTLPLANE_KUBEADM_EXTRA_CONFIG="
       - systemctl enable --now keepalived
       - chown {{ IMAGE_USERNAME }}:{{ IMAGE_USERNAME }} /home/{{ IMAGE_USERNAME }}/.kube/config
     files:
+      - path: /usr/local/bin/retrieve.configuration.files.sh
+        owner: root:root
+        permissions: '0755'
+        content: |
+            #!/bin/bash
+            set -e
+            url=\"\${1}\"
+            dst=\"\${2}\"
+            filename=\"\$(basename \${url})\"
+            tmpfile=\"/tmp/\${filename}\"
+            curl -sSL -w \"%{http_code}\" \"\${url}\" | sed \"s:/usr/bin:/usr/local/bin:g\" > /tmp/\"\${filename}\"
+            http_status=\$(cat \"\${tmpfile}\" | tail -n 1)
+            if [ \"\${http_status}\" != \"200\" ]; then
+              echo \"Error: unable to retrieve \${filename} file\";
+              exit 1;
+            else
+              cat \"\${tmpfile}\"| sed '\$d' > \"\${dst}\";
+            fi
       - path: /usr/local/bin/monitor.keepalived.sh
         owner: root:root
         permissions: '0755'
@@ -186,8 +204,8 @@ export WORKERS_KUBEADM_EXTRA_CONFIG="
         - chmod a+x kubeadm kubelet kubectl
         - mv kubeadm kubelet kubectl /usr/local/bin/
         - mkdir -p /etc/systemd/system/kubelet.service.d
-        - curl -sSL \"https://raw.githubusercontent.com/kubernetes/release/{{KUBERNETES_BINARIES_CONFIG_VERSION}}/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service\" | sed \"s:/usr/bin:/usr/local/bin:g\" > /etc/systemd/system/kubelet.service
-        - curl -sSL \"https://raw.githubusercontent.com/kubernetes/release/{{KUBERNETES_BINARIES_CONFIG_VERSION}}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf\" | sed \"s:/usr/bin:/usr/local/bin:g\" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+        - retrieve.configuration.files.sh \"https://raw.githubusercontent.com/kubernetes/release/{{ KUBERNETES_BINARIES_CONFIG_VERSION }}/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service\" /etc/systemd/system/kubelet.service
+        - retrieve.configuration.files.sh \"https://raw.githubusercontent.com/kubernetes/release/{{ KUBERNETES_BINARIES_CONFIG_VERSION }}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf\" /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
         - systemctl enable --now docker kubelet
         - usermod -aG docker {{ IMAGE_USERNAME }}
       files:
@@ -204,6 +222,24 @@ export WORKERS_KUBEADM_EXTRA_CONFIG="
                         dhcp4: false
                 version: 2
 {% endif %}
+        - path: /usr/local/bin/retrieve.configuration.files.sh
+          owner: root:root
+          permissions: '0755'
+          content: |
+              #!/bin/bash
+              set -e
+              url=\"\${1}\"
+              dst=\"\${2}\"
+              filename=\"\$(basename \${url})\"
+              tmpfile=\"/tmp/\${filename}\"
+              curl -sSL -w \"%{http_code}\" \"\${url}\" | sed \"s:/usr/bin:/usr/local/bin:g\" > /tmp/\"\${filename}\"
+              http_status=\$(cat \"\${tmpfile}\" | tail -n 1)
+              if [ \"\${http_status}\" != \"200\" ]; then
+                echo \"Error: unable to retrieve \${filename} file\";
+                exit 1;
+              else
+                cat \"\${tmpfile}\"| sed '\$d' > \"\${dst}\";
+              fi
         - path : /etc/netplan/52-ironicendpoint.yaml
           owner: root:root
           permissions: '0644'


### PR DESCRIPTION
As we have it now, the kubelet and kubeadm configurations are pulled from an external server.
If and when the server responds with error, the provisioning fails.

The purpose of this PR is to verify the successful download of the configuration files and log the error when a failure occurs.