### PR TITLE
Remove PROVISIONING_INTERFACE customization

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -146,10 +146,7 @@ function deploy_kustomization() {
 
 function launch_baremetal_operator() {
     pushd "${BMOPATH}"
-    # This is a temporary fix to pass the CI.
-    # TODO: remove the line when this change is actually made in BMO.
-    sed -i "/PROVISIONING_INTERFACE*/c\PROVISIONING_INTERFACE=ironicendpoint" deploy/ironic_ci.env
-
+    
     if [ "${CAPI_VERSION}" != "v1alpha3" ]; then
       kubectl create namespace metal3
     else


### PR DESCRIPTION
Currently we are replacing PROVISIONING_INTERFACE with sed in Metal3-dev-env. [#572](https://github.com/metal3-io/baremetal-operator/pull/572) does the same in ironic_ci.env. This patch removes that modification from metal3-dev-env since it will be taken care by BMO repo itself. 

