### PR TITLE
Fallback to first network if other not found

### DIFF
--- a/vm-setup/roles/libvirt/templates/ironic_nodes.json.j2
+++ b/vm-setup/roles/libvirt/templates/ironic_nodes.json.j2
@@ -10,6 +10,9 @@
     {% if lvars.update({'host_ip' : network.address_v6}) %}{% endif %}
   {% endif %}
 {% endfor %}
+{% if lvars['pxe_network'] == False %}
+  {% if lvars.update({'pxe_network': networks[0].name}) %}{% endif %}
+{% endif %}
 {
   "nodes": [
   {% for node in vm_nodes %}


### PR DESCRIPTION
ironic_nodes.json tries to pick a non-NAT network for the provisioning
interface. If we don't find one, we should fall back to the first
network we found.

This is relevant for the virtual media case, where we need any
valid MAC address to make the link between BMH and Ironic node. In most cases
on real hardware using virtual media, Ironic can make the link by detecting
the BMC URI, but in sushy-tools it can't do that.