### PR TITLE
CI: add upgrade combined test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ lint:
 setup_env:
 	./scripts/feature_tests/setup_env.sh
 
+setup_env_ug:
+	./scripts/feature_tests/setup_env.sh "ug"
+
 cleanup_env:
 	./scripts/feature_tests/cleanup_env.sh
 
@@ -42,5 +45,7 @@ upgrade_test:
 	make -C ./scripts/feature_tests/upgrade/
 
 feature_tests: setup_env remediation_test cleanup_env pivoting_test
+
+feature_tests_upgrade: setup_env_ug upgrade_test
 
 .PHONY: all install_requirements configure_host launch_mgmt_cluster clean delete_mgmt_cluster host_cleanup verify test lint

--- a/scripts/feature_tests/README.md
+++ b/scripts/feature_tests/README.md
@@ -78,6 +78,14 @@ export CONTAINER_RUNTIME=docker
 export NUM_NODES=4
 ```
 
+Environment variables needed for upgrade tests running clusterctl,
+set as default values:
+
+```bash
+export CAPM3RELEASE=v0.3.2
+export CAPIRELEASE=v0.3.4
+```
+
 ## CI jobs configuration
 
 We are running two jobs for the framework testing. One is

--- a/scripts/feature_tests/setup_env.sh
+++ b/scripts/feature_tests/setup_env.sh
@@ -4,5 +4,9 @@ set -x
 
 M3PATH="$(dirname "$(readlink -f "${0}")")/../.."
 
+if [[ "${1}" == "ug" ]]; then
+  export CAPM3RELEASE="v0.3.2"
+  export CAPIRELEASE="v0.3.4"
+fi
 pushd "${M3PATH}" || exit
 make

--- a/scripts/feature_tests/upgrade/README.md
+++ b/scripts/feature_tests/upgrade/README.md
@@ -1,6 +1,6 @@
 # Upgrade script naming scheme
 
-* nodes: ```<i>cp | <j>w; i=1..n, j=0..n```
+* nodes: ```<i>cp | <j>w; i=1..n, j=0..n```; cp = control plane, w = worker
 * what: bootDiskImage | k8sVer | k8sBin
 * How: scaleInWorkers | scaleOutWorkers
 * other: extraNode

--- a/scripts/feature_tests/upgrade/combined_tests/1cp_1w_bootDiskImageANDK8sControllers_clusterLevel_upgrade.sh
+++ b/scripts/feature_tests/upgrade/combined_tests/1cp_1w_bootDiskImageANDK8sControllers_clusterLevel_upgrade.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+
+set -x
+
+IRONIC_IMAGE_TAG=master
+
+METAL3_DEV_ENV_DIR="$(dirname "$(readlink -f "${0}")")/../../../../"
+# shellcheck disable=SC1091
+# shellcheck disable=SC1090
+source "${METAL3_DEV_ENV_DIR}/scripts/feature_tests/upgrade/upgrade_common.sh"
+
+echo '' >~/.ssh/known_hosts
+
+start_logging "${1}"
+# Provision original nodes
+set_number_of_master_node_replicas 1
+set_number_of_worker_node_replicas 1
+
+provision_controlplane_node
+
+controlplane_is_provisioned
+controlplane_has_correct_replicas 1
+
+# apply CNI
+apply_cni
+
+provision_worker_node
+worker_has_correct_replicas 1
+
+# ----------- upgrade controlplane components ---------------
+cleanup_clusterctl_configuration
+
+buildClusterctl
+
+# Install initial version folder structure
+pushd /tmp/cluster-api-clone || exit
+cmd/clusterctl/hack/local-overrides.py
+popd || exit
+
+create_clusterctl_configuration
+
+createNextVersionControllers
+
+makeCrdChanges
+
+# show upgrade plan
+clusterctl upgrade plan
+# do upgrade
+clusterctl upgrade plan | grep "upgrade apply" | xargs | xargs clusterctl
+# shellcheck disable=SC2082
+# Verify upgrade
+upgraded_controllers_count=$(kubectl api-resources | grep -Ec "kcp2020|ma2020")
+upgraded_bootstrap_crd_count=$(kubectl get crds \
+  kubeadmconfigs.bootstrap.cluster.x-k8s.io -o json | jq '.spec.names.singular' | wc -l)
+upgraded_capm3_controller_count=$(kubectl api-resources | grep -c m3c2020)
+
+if [ "${upgraded_controllers_count}" -ne 2 ]; then
+  log_error "Failed to upgrade cluster-api and controlplane components"
+  log_test_result "1cp_1w_bootDiskImageANDK8sCotrollers_clusterLevel_upgrade.sh" "fail"
+  exit 1
+fi
+if [ "${upgraded_bootstrap_crd_count}" -ne 1 ]; then
+  log_error "Failed to upgrade control-plane-kubeadm components"
+  log_test_result "1cp_1w_bootDiskImageANDK8sCotrollers_clusterLevel_upgrade.sh" "fail"
+  exit 1
+fi
+
+if [ "${upgraded_capm3_controller_count}" -ne 1 ]; then
+  log_error "Failed to upgrade infrastructure components"
+  log_test_result "1cp_1w_bootDiskImageANDK8sCotrollers_clusterLevel_upgrade.sh" "fail"
+  exit 1
+fi
+
+sleep 30 # Wait for the controllers to be up and running
+
+health_controllers=$(kubectl get pods -A | grep -E "capm3-system|capi-kubeadm|metal3" |
+  grep -vc 'Running')
+if [ "${health_controllers}" -ne 0 ]; then
+  log_error "Some of the upgraded controlplane components are not healthy"
+  log_test_result "1cp_1w_bootDiskImageANDK8sCotrollers_clusterLevel_upgrade.sh" "fail"
+  exit 1
+fi
+
+# ----------- upgrade ironic image ------
+
+# Upgrade container images
+for container in ironic ironic-dnsmasq ironic-httpd mariadb; do
+  kubectl set image deployments metal3-ironic \
+    $container=quay.io/metal3-io/ironic:"${IRONIC_IMAGE_TAG}" -n "${NAMESPACE}"
+done
+kubectl set image deployments metal3-ironic \
+  ironic-inspector=quay.io/metal3-io/ironic-inspector:"${IRONIC_IMAGE_TAG}" -n "${NAMESPACE}"
+
+updated_ironic_image_count=$(kubectl get deployments metal3-ironic -n "${NAMESPACE}" -o json |
+  jq '.spec.template.spec.containers[].image' | grep -c "${IRONIC_IMAGE_TAG}")
+
+if [ "${updated_ironic_image_count}" -lt 5 ]; then
+  echo "All ironic images are not updated properly"
+  exit 1
+fi
+
+sleep 60 # wait until images are downloaded
+
+# Check if old and new ironic pods are running, wait until the old terminates
+ironic_pod_count=$(kubectl get pods -n "${NAMESPACE}" -o name | grep -c metal3-ironic)
+ironic_pod=$(kubectl get pods -n "${NAMESPACE}" -o name | grep metal3-ironic)
+
+if [ "${ironic_pod_count}" -gt 1 ]; then
+  for i in {1..300}; do
+	  sleep 15
+	  ironic_pod_count=$(kubectl get pods -n "${NAMESPACE}" -o name | grep -c metal3-ironic)
+	  if [ "${ironic_pod_count}" -eq 1 ]; then
+		  ironic_pod=$(kubectl get pods -n "${NAMESPACE}" -o name | grep metal3-ironic)
+		  break
+	  fi
+    if [[ "${i}" -ge 300 ]]; then
+      ironic_pod=$(kubectl get pods -n "${NAMESPACE}" -o name | grep metal3-ironic)
+      log_error " Ironic pods failed: ${ironic_pod}"
+      exit 1
+    fi
+  done
+else
+  echo "New ironic pod id: ${ironic_pod}"
+fi
+
+# Check that ironic containers are running
+for container in ironic ironic-inspector ironic-dnsmasq ironic-httpd mariadb; do
+  running_containers_count=$(
+    kubectl get "${ironic_pod}" -n "${NAMESPACE}" -o json |
+      jq ".status.containerStatuses[] | select(.name == \"${container}\") | .state" |
+      grep -ic running
+  )
+  if [ "${running_containers_count}" -eq 0 ]; then
+    echo "Upgrade of ironic image for container ${container} has failed"
+    exit 1
+  fi
+done
+
+# ----------- upgrade boot disk image and kubernetes version ------
+echo "Create a new metal3MachineTemplate with new node image for both \
+controlplane and worker nodes"
+cp_Metal3MachineTemplate_OUTPUT_FILE="/tmp/cp_new_image.yaml"
+wr_Metal3MachineTemplate_OUTPUT_FILE="/tmp/wr_new_image.yaml"
+CLUSTER_UID=$(kubectl get clusters -n "${NAMESPACE}" test1 -o json | jq '.metadata.uid' |
+  cut -f2 -d\")
+generate_metal3MachineTemplate "test1-new-controlplane-image" "${CLUSTER_UID}" \
+  "${cp_Metal3MachineTemplate_OUTPUT_FILE}"
+generate_metal3MachineTemplate "test1-new-workers-image" "${CLUSTER_UID}" \
+  "${wr_Metal3MachineTemplate_OUTPUT_FILE}"
+
+kubectl apply -f "${cp_Metal3MachineTemplate_OUTPUT_FILE}"
+kubectl apply -f "${wr_Metal3MachineTemplate_OUTPUT_FILE}"
+
+# controllers
+kubectl get kcp -n "${NAMESPACE}" test1 -o json |
+  jq ".spec.infrastructureTemplate.name=\"test1-new-controlplane-image\" |
+  .spec.version=\"${UPGRADED_K8S_VERSION_2}\"" |
+  kubectl apply -f-
+kubectl get machinedeployment -n "${NAMESPACE}" test1 -o json |
+  jq ".spec.strategy.rollingUpdate.maxSurge=1|.spec.strategy.rollingUpdate.maxUnavailable=0 |
+  .spec.template.spec.version=\"${UPGRADED_K8S_VERSION_2}\"" |
+  kubectl apply -f-
+sleep 10
+
+# Verify kubernetes version upgrade
+verify_kubernetes_version_upgrade "${UPGRADED_K8S_VERSION_2}" 2
+
+# Verify new boot disk image usage
+cp_nodes_using_new_bootDiskImage 1
+wr_nodes_using_new_bootDiskImage 1
+
+# Verify nodes are freed
+expected_free_nodes 2
+
+# verify that extra nodes are not removed
+controlplane_has_correct_replicas 1
+worker_has_correct_replicas 1
+
+# Report result
+echo "Boot disk upgrade of both controlplane and worker nodes has succeeded."
+log_test_result "1cp_1w_bootDiskImageANDK8sCotrollers_clusterLevel_upgrade.sh" "pass"
+
+# Test cleanup
+cleanup_clusterctl_configuration
+deprovision_cluster
+wait_for_cluster_deprovisioned
+
+set -x

--- a/scripts/feature_tests/upgrade/upgrade.sh
+++ b/scripts/feature_tests/upgrade/upgrade.sh
@@ -46,11 +46,10 @@ pushd "${METAL3_DEV_ENV_DIR}/scripts/feature_tests/upgrade/controlplane_upgrade"
 source 3cp_1w_k8sVer_bootDiskImage_scaleInWorker_upgrade.sh
 popd || exit
 
-# This needs to be replaced by 1cp_1w_bootDiskImageANDK8sCotrollers_clusterLevel_upgrade.sh
 # Run controlplane components upgrade tests | This should be the last one
-pushd "${METAL3_DEV_ENV_DIR}/scripts/feature_tests/upgrade/controlplane_components_upgrade" || exit
+pushd "${METAL3_DEV_ENV_DIR}/scripts/feature_tests/upgrade/combined_tests" || exit
 # shellcheck disable=SC1091
-source upgrade_CAPI_and_CAPM3_with_clusterctl.sh
+source 1cp_1w_bootDiskImageANDK8sControllers_clusterLevel_upgrade.sh
 popd || exit
 
 set +x

--- a/scripts/feature_tests/upgrade/upgrade_common.sh
+++ b/scripts/feature_tests/upgrade/upgrade_common.sh
@@ -13,7 +13,7 @@ export UPGRADED_BINARY_VERSION="v1.18.1"
 export CLUSTER_APIENDPOINT_IP=${CLUSTER_APIENDPOINT_IP:-"192.168.111.249"}
 export NUM_NODES=${NUM_NODES:-"4"}
 
-export CAPM3RELEASE=${CAPM3RELEASE:-"v0.3.0"}
+export CAPM3RELEASE=${CAPM3RELEASE:-"v0.3.2"}
 export CAPIRELEASE=${CAPIRELEASE:-"v0.3.4"}
 
 export IMAGE_URL=${IMAGE_URL:-"http://172.22.0.1/images/bionic-server-cloudimg-amd64-raw.img"}
@@ -378,7 +378,7 @@ cat <<EOF >clusterctl-settings-metal3.json
    "name": "infrastructure-metal3",
     "config": {
       "componentsFile": "infrastructure-components.yaml",
-      "nextVersion": "v0.3.0"
+      "nextVersion": "v0.3.2"
     }
 }
 EOF
@@ -408,7 +408,7 @@ function createNextVersionControllers() {
         /home/"${USER}"/.cluster-api/overrides/bootstrap-kubeadm/v0.3.6
     cp -r /home/"${USER}"/.cluster-api/overrides/control-plane-kubeadm/v0.3.0 \
         /home/"${USER}"/.cluster-api/overrides/control-plane-kubeadm/v0.3.6
-    cp -r /home/"${USER}"/.cluster-api/overrides/infrastructure-metal3/v0.3.0 \
+    cp -r /home/"${USER}"/.cluster-api/overrides/infrastructure-metal3/v0.3.2 \
         /home/"${USER}"/.cluster-api/overrides/infrastructure-metal3/v0.3.6
 
 }

--- a/vm-setup/roles/v1aX_integration_test/tasks/generate_templates.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/generate_templates.yml
@@ -32,3 +32,6 @@
       - cluster
       - controlplane
       - workers
+    environment:
+      CAPM3RELEASE: "{{ CAPM3RELEASE }}"
+      CAPIRELEASE: "{{ CAPIRELEASE }}"


### PR DESCRIPTION
-1cp_1w_bootDiskImageANDK8sControllers_clusterLevel_upgrade.sh
This test script runs the provider components upgrade using clusterctl, ironic image upgrade and image upgrade for control plane and worker nodes.