### PR TITLE
force hosts to use legacy boot mode

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -193,6 +193,7 @@ function make_bm_hosts() {
            -password "$password" \
            -user "$user" \
            -boot-mac "$mac" \
+           -boot-mode "legacy" \
            "$name"
     done
 }

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -200,8 +200,8 @@ function make_bm_hosts() {
 
 function apply_bm_hosts() {
     pushd "${BMOPATH}"
-    list_nodes | make_bm_hosts > bmhosts_crs.yaml
-    kubectl apply -f bmhosts_crs.yaml -n metal3
+    list_nodes | make_bm_hosts > "${WORKING_DIR}/bmhosts_crs.yaml"
+    kubectl apply -f "${WORKING_DIR}/bmhosts_crs.yaml" -n metal3
     popd
 }
 


### PR DESCRIPTION
The CI infrastructure does not support UEFI booting, yet. Set the boot mode
to legacy so that when the baremetal-operator change to make the default
UEFI is merged these tools will still work.

This change depends on https://github.com/metal3-io/baremetal-operator/pull/605