### PR TITLE
Fix bmhosts_crs path issue

### DIFF
--- a/scripts/feature_tests/cleanup_env.sh
+++ b/scripts/feature_tests/cleanup_env.sh
@@ -23,7 +23,7 @@ cd bin || exit
 popd || exit
 
 pushd "${BMOPATH}" || exit
-kubectl delete -f bmhosts_crs.yaml -n "${NAMESPACE}" --timeout 10s
+kubectl delete -f "${WORKING_DIR}/bmhosts_crs.yaml" -n "${NAMESPACE}" --timeout 10s
 popd || exit
 
 declare -a OBJECTS=("cluster" \
@@ -67,7 +67,7 @@ cd bin || exit
 popd || exit
 
 pushd "${BMOPATH}" || exit
-kubectl apply -f bmhosts_crs.yaml -n "${NAMESPACE}"
+kubectl apply -f "${WORKING_DIR}/bmhosts_crs.yaml" -n "${NAMESPACE}"
 popd || exit
 
 make -C "${SCRIPTDIR}" verify


### PR DESCRIPTION
Feature-test is failing when applying/deleting `bmhosts_crs.yaml` file since it can't find it in current path. And that's because recently `bmhosts_crs.yaml` path was updated.