### PR TITLE
Use local registry for images and pre-populate them.

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -109,6 +109,12 @@ if [ ! -f "${IMAGE_NAME}" ] ; then
 fi
 popd
 
+# Pulling all the images except any local image.
+for IMAGE_VAR in $(env | grep -v "_LOCAL_IMAGE=" | grep "_IMAGE=" | grep -o "^[^=]*") ; do
+  IMAGE="${!IMAGE_VAR}"
+  sudo "${CONTAINER_RUNTIME}" pull "${IMAGE}" 
+ done
+
 # Start image downloader container
 #shellcheck disable=SC2086
 sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name ipa-downloader ${POD_NAME} \


### PR DESCRIPTION
As part of setting up Metal3-dev-env, we download a lot of container images. they should be pushed to the local registry and then used everywhere as the local registry image. The changes will prevent always re-downloading images from internet and also speed up  deployments.