### PR TITLE
Preload kind container image

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -57,6 +57,7 @@ elif [ "${EPHEMERAL_CLUSTER}" == "kind" ]; then
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/"${KIND_VERSION}"/kind-"$(uname)"-amd64
         chmod +x ./kind
         sudo mv kind /usr/local/bin/.
+        sudo "${CONTAINER_RUNTIME}" pull kindest/node:"${KUBERNETES_VERSION}"
     fi
 fi
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -199,7 +199,7 @@ else
   export CAPM3_IMAGE=${CAPM3_IMAGE:-"quay.io/metal3-io/cluster-api-provider-metal3:master"}
 fi
 
-#default hosts memory
+# default hosts memory
 export DEFAULT_HOSTS_MEMORY=${DEFAULT_HOSTS_MEMORY:-4096}
 
 # Cluster.
@@ -215,7 +215,7 @@ else
   echo "Management cluster forced to be minikube when container runtime is not docker"
   export EPHEMERAL_CLUSTER="minikube"
 fi
-#Kustomize version
+# Kustomize version
 export KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-"v3.6.1"}
 
 #Kind version


### PR DESCRIPTION
This patch downloads kind image in advance to minimize the time that CI takes to build Metal3-dev-env.
Currently we are attaching a volume to the VM on each CI run, which includes all the necessary packages that we normally install during 01_* script. Downloading kind image in 01_* script will make sure that the container image is already in the volume that we attach to the CI VM. As such, there will not be a need to download it again when executing `kind create cluster .... `command. Of course this path doesn't improve the time when running Metal3-dev-env locally and only meant for the CI improvement. 