### PR TITLE
Uplift calico version to latest

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
@@ -41,7 +41,7 @@
   # Install Calico
   - name: Download Calico manifest
     get_url:
-      url: https://docs.projectcalico.org/v3.9/manifests/calico.yaml
+      url: https://docs.projectcalico.org/manifests/calico.yaml
       dest: /tmp/
       mode: '664'
     register: calico_manifest


### PR DESCRIPTION
This PR uplifts calico version to latest for target cluster. With v3.9 we hit the problem of volume mount. Latest calico version seem to solve this issue. 