### PR TITLE
Fix CAPM3 Makefile target

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -84,16 +84,23 @@ function patch_clusterctl(){
   else
     BMO_IMAGE_NAME_WITH_TAG="${BAREMETAL_OPERATOR_IMAGE##*/}"
   fi
+  
   # Split the image to CAPM3_IMAGE_NAME AND CAPM3_IMAGE_TAG, if any tag exist
   BMO_IMAGE_NAME="${BMO_IMAGE_NAME_WITH_TAG%%:*}"
   BMO_IMAGE_TAG="${BMO_IMAGE_NAME_WITH_TAG##*:}"
+
   # Assign the image tag to latest if there is no tag in the image
   if [ "${BMO_IMAGE_NAME}" == "${BMO_IMAGE_TAG}" ]; then
     BMO_IMAGE_TAG="latest"
   fi
+
   export MANIFEST_IMG_BMO="${REGISTRY}/localimages/$BMO_IMAGE_NAME"
   export MANIFEST_TAG_BMO="$BMO_IMAGE_TAG"
-  make set-manifest-image-bmo
+  
+  if [ "${CAPM3_VERSION}" != "v1alpha3" ]; then
+    make set-manifest-image-bmo
+  fi
+  
   make release-manifests
 
   rm -rf "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"


### PR DESCRIPTION
v1alpha3 master CI jobs ([Ubuntu](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a3_integration_test_ubuntu/297/console)/[Centos](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a3_integration_test_centos/270/console)) are failing due to incorrect CAPM3 branch set up before calling `make set-manifest-image-bmo`.

```
+ make set-manifest-image-bmo
make[1]: Entering directory '/home/****/go/src/github.com/metal3-io/cluster-api-provider-metal3'
make[1]: *** No rule to make target 'set-manifest-image-bmo'.  Stop.
make[1]: Leaving directory '/home/****/go/src/github.com/metal3-io/cluster-api-provider-metal3'
make: *** [Makefile:10: launch_mgmt_cluster] Error 2
```


We are calling `set-manifest-image-bmo` Makefile target in CAPM3 no matter what version of  CAPM3_VERSION variable is set. Since `set-manifest-image-bmo` target is only available in CAPM3 master branch (i.e. CAPM3_VERSION=v1alpha4), CI is when calling non-existing Makefile target.