### PR TITLE
Bug fix: Start local image registry container if it is in exited status.

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -124,9 +124,13 @@ fi
 
 # Local registry for images
 reg_state=$(sudo "$CONTAINER_RUNTIME" inspect registry --format  "{{.State.Status}}" || echo "error")
-if [[ "$reg_state" != "running" ]]; then
- sudo "${CONTAINER_RUNTIME}" rm registry -f || true
- sudo "${CONTAINER_RUNTIME}" run -d -p 5000:5000 --name registry "$DOCKER_REGISTRY_IMAGE"
+
+# ubuntu_install_requirements.sh script restarts docker daemon which causes local registry container to be in exited state.
+if [[ "$reg_state" == "exited" ]]; then
+  sudo "${CONTAINER_RUNTIME}" start registry  
+elif [[ "$reg_state" != "running" ]]; then
+  sudo "${CONTAINER_RUNTIME}" rm registry -f || true
+  sudo "${CONTAINER_RUNTIME}" run -d -p 5000:5000 --name registry "$DOCKER_REGISTRY_IMAGE"
 fi
 
 # Pushing images to local registry

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -68,7 +68,7 @@ function patch_clusterctl(){
   else
     CAPM3_IMAGE_NAME_WITH_TAG="${CAPM3_IMAGE##*/}"
   fi
-  # CAPM3_IMAGE include tag so split them to CAPM3_IMAGE_NAME AND CAPM3_IMAGE_TAG, if any tag exist
+  # Split the image CAPM3_IMAGE_NAME AND CAPM3_IMAGE_TAG, if any tag exist
   CAPM3_IMAGE_NAME="${CAPM3_IMAGE_NAME_WITH_TAG%%:*}"
   CAPM3_IMAGE_TAG="${CAPM3_IMAGE_NAME_WITH_TAG##*:}"
   # Assign the image tag to latest if there is no tag in the image
@@ -85,7 +85,7 @@ function patch_clusterctl(){
     BMO_IMAGE_NAME_WITH_TAG="${BAREMETAL_OPERATOR_IMAGE##*/}"
   fi
   
-  # Split the image to CAPM3_IMAGE_NAME AND CAPM3_IMAGE_TAG, if any tag exist
+  # Split the image to BMO_IMAGE_NAME AND BMO_IMAGE_TAG, if any tag exist
   BMO_IMAGE_NAME="${BMO_IMAGE_NAME_WITH_TAG%%:*}"
   BMO_IMAGE_TAG="${BMO_IMAGE_NAME_WITH_TAG##*:}"
 


### PR DESCRIPTION
During the "Make" process the we restart the docker daemon in `ubuntu_install_requirements.sh` script which causes the local image registry container to be in exited state. So metal3-dev-env deployment is failing during rerun. This PR will solve the issue #430 