### PR TITLE
Small fix: Deleting unused variables in Metal3-dev-env

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -63,8 +63,6 @@ IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.md5sum"
 IMAGE_NAME_CENTOS: "{{ lookup('env', 'IMAGE_NAME') | default('CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64.qcow2', true)}}"
 RAW_IMAGE_NAME_CENTOS: "{{ lookup('env', 'IMAGE_RAW_NAME') | default('CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64-raw.img', true)}}"
 IMAGE_LOCATION_CENTOS: 'https://cloud.centos.org/centos/8/x86_64/images'
-IMAGE_URL_CENTOS: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME_CENTOS }}"
-IMAGE_CHECKSUM_CENTOS: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME_CENTOS }}.md5sum"
 
 provision_cluster_actions:
     - "ci_test_provision"


### PR DESCRIPTION
Deleting unused variables: IMAGE_URL_CENTOS and IMAGE_CHECKSUM_CENTOS