### PR TITLE
Export CONTAINER_RUNTIME so subshells can use it

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -43,9 +43,9 @@ NODE_HOSTNAME_FORMAT=${NODE_HOSTNAME_FORMAT:-"node-%d"}
 OS=$(awk -F= '/^ID=/ { print $2 }' /etc/os-release | tr -d '"')
 # Container runtime
 if [[ "${OS}" == ubuntu ]]; then
-  CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"docker"}
+  export CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"docker"}
 else
-  CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"podman"}
+  export CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"podman"}
 fi
 
 if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then


### PR DESCRIPTION
The container runtime used in the dev-env is decided by the environment variable CONTAINER_RUNTIME. By default, its value is Docker when the host is Ubuntu, and it is Podman when the host is Centos. This variable is set in lib/common.sh, and every script that sources this file has the right value of this variable. However, the dev-env also calls some scripts from other repos (e.g. Baremetal operator) that don't source the file, and they use the wrong container runtime. This leads to that when we run the dev-env on Ubuntu where Podman is not installed, but it tries to use Podman, resulting in an error.