### PR TITLE
Bug Fix: Local registry connection error during Metal3 deployment.

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -132,6 +132,7 @@ elif [[ "$reg_state" != "running" ]]; then
   sudo "${CONTAINER_RUNTIME}" rm registry -f || true
   sudo "${CONTAINER_RUNTIME}" run -d -p 5000:5000 --name registry "$DOCKER_REGISTRY_IMAGE"
 fi
+sleep 5
 
 # Pushing images to local registry
 for IMAGE_VAR in $(env | grep -v "_LOCAL_IMAGE=" | grep "_IMAGE=" | grep -o "^[^=]*") ; do
@@ -143,7 +144,7 @@ for IMAGE_VAR in $(env | grep -v "_LOCAL_IMAGE=" | grep "_IMAGE=" | grep -o "^[^
   sudo "${CONTAINER_RUNTIME}" tag "${IMAGE}" "${LOCAL_IMAGE}" 
   
   if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
-    sudo "${CONTAINER_RUNTIME}" push --tls-verify=false "${LOCAL_IMAGE}" "${LOCAL_IMAGE}"
+    sudo "${CONTAINER_RUNTIME}" push --tls-verify=false "${LOCAL_IMAGE}"
   else
     sudo "${CONTAINER_RUNTIME}" push "${LOCAL_IMAGE}"
   fi
@@ -187,7 +188,7 @@ for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
   sudo "${CONTAINER_RUNTIME}" build -t "${!IMAGE_VAR}" . -f "${DOCKERFILE}"
   cd - || exit
   if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
-    sudo "${CONTAINER_RUNTIME}" push --tls-verify=false "${!IMAGE_VAR}" "${!IMAGE_VAR}"
+    sudo "${CONTAINER_RUNTIME}" push --tls-verify=false "${!IMAGE_VAR}"
   else
     sudo "${CONTAINER_RUNTIME}" push "${!IMAGE_VAR}"
   fi


### PR DESCRIPTION
This PR will fix the issue #440 . Here we have added a delay for 5s, when the local registry is in exited state and the script starts local registry. It solved the issue regarding the local registry connection error in local environment building. We have tested the script with different delays such as 30s, 20s, 10s and 5s. In each and every delays the deployment was running without any error and choose the minimum delay 5s for Metal3-dev-env.  The CI run will have also 5s delay because of this change.