### PR TITLE
Update Centos to use Metal3DataTemplate

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-cluster.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-cluster.yaml
@@ -37,7 +37,7 @@ spec:
     port: ${ API_ENDPOINT_PORT }
   noCloudProvider: true
 ---
-{% if CAPM3_VERSION != "v1alpha3" and IMAGE_OS != "Centos" %}
+{% if CAPM3_VERSION != "v1alpha3" %}
 apiVersion: ipam.metal3.io/v1alpha1
 kind: IPPool
 metadata:

--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
@@ -48,7 +48,7 @@ spec:
         checksum: ${ IMAGE_CHECKSUM }
         checksumType: ${ IMAGE_CHECKSUM_TYPE }
         format: ${ IMAGE_FORMAT }
-{% if CAPM3_VERSION != "v1alpha3" and IMAGE_OS != "Centos" %}
+{% if CAPM3_VERSION != "v1alpha3" %}
       dataTemplate:
         name: ${ CLUSTER_NAME }-controlplane-template
 ---

--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
@@ -52,7 +52,7 @@ spec:
         checksum: ${ IMAGE_CHECKSUM }
         checksumType: ${ IMAGE_CHECKSUM_TYPE }
         format: ${ IMAGE_FORMAT }
-{% if CAPM3_VERSION != "v1alpha3" and IMAGE_OS != "Centos" %}
+{% if CAPM3_VERSION != "v1alpha3" %}
       dataTemplate:
         name: ${ CLUSTER_NAME }-workers-template
 ---

--- a/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_centos.rc
+++ b/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_centos.rc
@@ -29,7 +29,9 @@ export CTLPLANE_KUBEADM_EXTRA_CONFIG="
       sshAuthorizedKeys:
       - {{ SSH_PUB_KEY_CONTENT }}
     preKubeadmCommands:
+{% if CAPM3_VERSION == "v1alpha3" %}
       - ifup eth1
+{% endif %}
       - dnf update -y
       - dnf install -y ebtables socat conntrack-tools
       - dnf install python3 -y
@@ -129,6 +131,7 @@ export CTLPLANE_KUBEADM_EXTRA_CONFIG="
                   {{ CLUSTER_APIENDPOINT_HOST }}
               }
           }
+{% if CAPM3_VERSION == "v1alpha3" %}
       - path: /etc/sysconfig/network-scripts/ifcfg-eth1
         owner: root:root
         permissions: '0644'
@@ -138,6 +141,7 @@ export CTLPLANE_KUBEADM_EXTRA_CONFIG="
           ONBOOT=yes
           TYPE=Ethernet
           USERCTL=no
+{% endif %}
       - path: /etc/yum.repos.d/kubernetes.repo
         owner: root:root
         permissions: '0644'
@@ -164,7 +168,9 @@ export WORKERS_KUBEADM_EXTRA_CONFIG="
         sshAuthorizedKeys:
         - {{ SSH_PUB_KEY_CONTENT }}
       preKubeadmCommands:
+{% if CAPM3_VERSION == "v1alpha3" %}
         - ifup eth1
+{% endif %}
         - dnf update -y
         - dnf install -y ebtables conntrack-tools socat
         - dnf install python3 -y
@@ -200,6 +206,7 @@ export WORKERS_KUBEADM_EXTRA_CONFIG="
               else
                 cat \"\${tmpfile}\"| sed '\$d' > \"\${dst}\";
               fi
+{% if CAPM3_VERSION == "v1alpha3" %}
         - path: /etc/sysconfig/network-scripts/ifcfg-eth1
           owner: root:root
           permissions: '0644'
@@ -209,6 +216,7 @@ export WORKERS_KUBEADM_EXTRA_CONFIG="
             ONBOOT=yes
             TYPE=Ethernet
             USERCTL=no
+{% endif %}
         - path: /etc/yum.repos.d/kubernetes.repo
           owner: root:root
           permissions: '0644'


### PR DESCRIPTION
Currently Centos setup does not use Metal3DataTemplate and that's why the node name is the same as BMH name. This patch will update a setup so that Centos will also use Metal3DataTemplate to override the node name.