### PR TITLE
Add support for tilt based deployments

### DIFF
--- a/04_verify.sh
+++ b/04_verify.sh
@@ -11,6 +11,10 @@ source lib/network.sh
 # shellcheck disable=SC1091
 source lib/images.sh
 
+if [ "${EPHEMERAL_CLUSTER}" == "tilt" ]; then
+  exit 0
+fi
+
 check_bm_hosts() {
     local FAILS_CHECK="${FAILS}"
     local NAME ADDRESS USER PASSWORD MAC CRED_NAME CRED_SECRET \

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ You can check a list of all the environment variables [here](vars.md)
 ./03_launch_mgmt_cluster.sh
 ```
 
+or
+
+```sh
+make
+```
+
 ### Deploy the target cluster
 
 ```sh
@@ -93,3 +99,48 @@ You can check a list of all the environment variables [here](vars.md)
 ```sh
 kubectl delete cluster "${CLUSTER_NAME:-"test1"}" -n metal3
 ```
+
+### Deploying with Tilt
+
+It is possible to use Tilt to run the CAPI and CAPM3 components. For this, run:
+
+```sh
+export EPHEMERAL_CLUSTER="tilt"
+make
+```
+
+Then clone the Cluster API Provider Metal3 repository, and follow the
+[instructions](https://github.com/metal3-io/cluster-api-provider-metal3/blob/master/docs/dev-setup.md#tilt-development-environment).
+That will mostly be the three following blocks of commands.
+
+```sh
+source lib/common.sh
+source lib/network.sh
+source lib/images.sh
+```
+
+and go to the CAPM3 repository and run
+
+```sh
+make tilt-settings
+```
+
+Please refer to the CAPM3 instructions to include BMO and IPAM. Then run :
+
+```sh
+make tilt-up
+```
+
+Once the cluster is running, you can create the BareMetalHosts :
+
+```sh
+kubectl create namespace metal3
+kubectl apply -n metal3 -f /opt/metal3-dev-env/bmhosts_crs.yaml
+```
+
+Afterwards, you can deploy a target cluster.
+
+If you are running tilt on a remote machine, you can forward the web interface
+by adding the following parameter to the ssh command `-L 10350:127.0.0.1:10350`
+
+Then you can access the Tilt dashboard locally [here](http://127.0.0.1:10350)

--- a/config_example.sh
+++ b/config_example.sh
@@ -152,3 +152,10 @@
 # %d format field that will be replaced with an integer representing the number
 # of the node.
 # export NODE_HOSTNAME_FORMAT="node-%d"
+
+# Ephemeral cluster used as management cluster for cluster API
+# (can be "kind", "minikube" or "tilt"). Only "minikube" is supported with
+# CentOS
+# Selecting "tilt" does not deploy a management cluster, it is left up to the
+# user
+# export EPHEMERAL_CLUSTER=minikube

--- a/lib/releases.sh
+++ b/lib/releases.sh
@@ -19,8 +19,8 @@ function get_latest_release() {
 }
 
 
-CAPM3RELEASEPATH="${CAPM3RELEASEPATH:-https://api.github.com/repos/${CAPM3_BASE_URL}/releases}"
-CAPIRELEASEPATH="${CAPIRELEASEPATH:-https://api.github.com/repos/${CAPI_BASE_URL}/releases}"
+CAPM3RELEASEPATH="${CAPM3RELEASEPATH:-https://api.github.com/repos/${CAPM3_BASE_URL:-metal3-io/cluster-api-provider-metal3}/releases}"
+CAPIRELEASEPATH="${CAPIRELEASEPATH:-https://api.github.com/repos/${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}/releases}"
 
 if [ "${CAPM3_VERSION}" == "v1alpha4" ]; then
   export CAPM3RELEASE="${CAPM3RELEASE:-$(get_latest_release "${CAPM3RELEASEPATH}" "v0.4.")}"

--- a/vars.md
+++ b/vars.md
@@ -9,7 +9,7 @@ assured that they are persisted.
 
 | Name | Option | Allowed values | Default |
 | :------ | :------- | :--------------- | :-------- |
-| EPHEMERAL_CLUSTER | Tool for running management/ephemeral cluster. | minikube, kind | Ubuntu default is kind, while CentOS is minikube. |
+| EPHEMERAL_CLUSTER | Tool for running management/ephemeral cluster. | minikube, kind, tilt | Ubuntu default is kind. Only minikube is supported on CentOS |
 | EXTERNAL_SUBNET                | This is the subnet used on the "baremetal" libvirt network, created as the primary network interface for the virtual bare metalhosts.                                                                                                                    | CIDR                               | 192.168.111.0/24                                             |
 | SSH_PUB_KEY                    | This SSH key will be automatically injected into the provisioned host by the provision_host.sh script.                                                                                                                                                   |                           | ~/.ssh/id_rsa.pub                                            |
 | CONTAINER_RUNTIME              | Select the Container Runtime                                                                                                                                                                                                                             | "docker", "podman"                   | "podman"                                                     |


### PR DESCRIPTION
When selecting Tilt as ephemeral cluster, the management cluster
deployment will be left up to the user, and ironic will be running
locally.

This allows to use a Tilt setup to develop within the Metal3-dev-env setup