### PR TITLE
Add support for TLS setup for Ironic

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -159,3 +159,6 @@
 # Selecting "tilt" does not deploy a management cluster, it is left up to the
 # user
 # export EPHEMERAL_CLUSTER=minikube
+
+# Secure Ironic deployment with TLS ("true" or "false")
+# export IRONIC_TLS_SETUP="true"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -147,6 +147,7 @@ export VBMC_IMAGE=${VBMC_IMAGE:-"quay.io/metal3-io/vbmc"}
 export SUSHY_TOOLS_IMAGE=${SUSHY_TOOLS_IMAGE:-"quay.io/metal3-io/sushy-tools"}
 
 # Ironic vars
+export IRONIC_TLS_SETUP=${IRONIC_TLS_SETUP:-"true"}
 export IPA_DOWNLOADER_IMAGE=${IPA_DOWNLOADER_IMAGE:-"quay.io/metal3-io/ironic-ipa-downloader"}
 export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic"}
 export IRONIC_CLIENT_IMAGE=${IRONIC_CLIENT_IMAGE:-"quay.io/metal3-io/ironic-client"}

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -163,5 +163,10 @@ network_address INITIAL_IRONICBRIDGE_IP "$PROVISIONING_NETWORK" 9
 
 export DEPLOY_KERNEL_URL=${DEPLOY_KERNEL_URL:-"http://${CLUSTER_URL_HOST}:6180/images/ironic-python-agent.kernel"}
 export DEPLOY_RAMDISK_URL=${DEPLOY_RAMDISK_URL:-"http://${CLUSTER_URL_HOST}:6180/images/ironic-python-agent.initramfs"}
-export IRONIC_URL=${IRONIC_URL:-"http://${CLUSTER_URL_HOST}:6385/v1/"}
-export IRONIC_INSPECTOR_URL=${IRONIC_INSPECTOR_URL:-"http://${CLUSTER_URL_HOST}:5050/v1/"}
+if [ "${IRONIC_TLS_SETUP}" == "true" ]; then
+  export IRONIC_URL=${IRONIC_URL:-"https://${CLUSTER_URL_HOST}:6385/v1/"}
+  export IRONIC_INSPECTOR_URL=${IRONIC_INSPECTOR_URL:-"https://${CLUSTER_URL_HOST}:5050/v1/"}
+else
+  export IRONIC_URL=${IRONIC_URL:-"http://${CLUSTER_URL_HOST}:6385/v1/"}
+  export IRONIC_INSPECTOR_URL=${IRONIC_INSPECTOR_URL:-"http://${CLUSTER_URL_HOST}:5050/v1/"}
+fi

--- a/vars.md
+++ b/vars.md
@@ -43,3 +43,8 @@ assured that they are persisted.
 | VM_EXTRADISKS            | Add extra disks to the virtual machines provisioned. By default the size of the extra disk is set in the libvirt Ansible role to 8 GB        | "true", "false" | "false" |
 | DEFAULT_HOSTS_MEMORY     | Set the default memory size in MB for the virtual machines provisioned.        |  | 4096 |
 | CLUSTER_NAME             | Set the name of the target cluster |  | test1 |
+| IRONIC_TLS_SETUP | Enable TLS for Ironic and inspector | "true", "false" | "true" |
+| IRONIC_CA_CERT_B64 | Base 64 encoded CA certificate of Ironic |  |   |
+| IRONIC_CACERT_FILE | path to the CA certificate of Ironic |  | /opt/metal3-dev-env/certs/ironicCA.pem |
+| IRONIC_CERT_FILE | path to the certificate of Ironic |  | /opt/metal3-dev-env/certs/ironic.crt |
+| IRONIC_KEY_FILE | path to the certificate key of Ironic |  | /opt/metal3-dev-env/certs/ironicCA.key |


### PR DESCRIPTION
This PR introduces a TLS setup for Ironic. It requires the following PRs to be merged :

- https://github.com/metal3-io/cluster-api-provider-metal3/pull/133
- https://github.com/metal3-io/baremetal-operator/pull/631
- https://github.com/metal3-io/ironic-inspector-image/pull/62
- https://github.com/metal3-io/ironic-image/pull/198