### PR TITLE
Move upgrade tests to the target cluster

### DIFF
--- a/scripts/feature_tests/upgrade/1cp_1w_bootDiskImage_cluster_upgrade.sh
+++ b/scripts/feature_tests/upgrade/1cp_1w_bootDiskImage_cluster_upgrade.sh
@@ -12,9 +12,14 @@ echo '' >~/.ssh/known_hosts
 start_logging "${1}"
 # Provision original nodes
 set_number_of_master_node_replicas 1
-set_number_of_worker_node_replicas 1
+set_number_of_worker_node_replicas 3 # Temporary solution for moving all BMHs
 
 provision_controlplane_node
+
+# Get kubeconfig before pivoting | will be overriden when pivoting
+# Relevant when re-using the cluster for successive tests
+kubectl get secrets "${CLUSTER_NAME}"-kubeconfig -n "${NAMESPACE}" -o json | jq -r '.data.value'| base64 -d > /tmp/kubeconfig-"${CLUSTER_NAME}".yaml
+export KUBECONFIG=/tmp/kubeconfig-"${CLUSTER_NAME}".yaml
 
 controlplane_is_provisioned
 controlplane_has_correct_replicas 1
@@ -23,8 +28,20 @@ controlplane_has_correct_replicas 1
 apply_cni
 
 provision_worker_node
+worker_has_correct_replicas 3
+
+# Do pivoting
+# This will be replace by a bash script specific to pivoting from upgrade scripts
+export ACTION="upgrading"
+pushd "/home/ubuntu/metal3-dev-env/scripts/feature_tests/pivoting/"
+make pivoting
+popd
+
+# All bmh resources are moved, now scale back workers to 1
+scale_workers_to 1
 worker_has_correct_replicas 1
 
+#  ----------------------- peform upgrade tasks ----------------------
 # Change boot disk image
 echo "Create a new metal3MachineTemplate with new node image for both \
 controlplane and worker nodes"
@@ -69,7 +86,16 @@ worker_has_correct_replicas 1
 echo "Boot disk upgrade of both controlplane and worker nodes has succeeded."
 log_test_result "1cp_1w_bootDiskImage_cluster_upgrade.sh" "pass"
 
+# ------------------pivot back here ----------------------- #
+# This needs to be replaced by a script that does pivot-back
+export ACTION="pivotBack"
+pushd "/home/ubuntu/metal3-dev-env/scripts/feature_tests/pivoting/"
+make pivoting
+popd
 # Test cleanup
+
+unset KUBECONFIG # point to ~/.kube/config
+
 deprovision_cluster
 wait_for_cluster_deprovisioned
 

--- a/scripts/feature_tests/upgrade/controlplane_components_upgrade/upgrade_CAPI_and_CAPM3_with_clusterctl.sh
+++ b/scripts/feature_tests/upgrade/controlplane_components_upgrade/upgrade_CAPI_and_CAPM3_with_clusterctl.sh
@@ -67,3 +67,6 @@ cleanup_clusterctl_configuration
 echo "Successfully upgraded cluster-api, controlplane and controlplane-kubeadm components"
 log_test_result "upgrade_CAPI_and_CAPM3_with_clusterctl.sh" "pass"
 set +x
+
+
+# This test case is no longer relevant as it is included in the combined tests


### PR DESCRIPTION
Moving upgrade tests so that they are done after pivoting. This requires changing the tests in two ways.
- Remove provisioning steps as the CP and worker nodes already provisioned before pivoting.
- Use `kubeconfig` of the target cluster for running `kubectl `and `clusterctl` commands.