### PR TITLE
*: allow for fetching Flatcar images

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -171,6 +171,13 @@ if [ ! -f "${IMAGE_NAME}" ] ; then
       IMAGE_BASE_NAME="${IMAGE_NAME%.*}"
       export IMAGE_RAW_NAME="${IMAGE_BASE_NAME}-raw.img"
     fi
+    if [ "$(echo "${IMAGE_NAME}" | rev | cut -d . -f 1 | rev)" == "bz2" ] ; then
+        bunzip2 "${IMAGE_NAME}"
+	IMAGE_NAME="$(basename "${IMAGE_NAME}" .bz2)"
+	export IMAGE_NAME
+	IMAGE_BASE_NAME="${IMAGE_NAME%.*}"
+	export IMAGE_RAW_NAME="${IMAGE_BASE_NAME}-raw.img"
+    fi
     qemu-img convert -O raw "${IMAGE_NAME}" "${IMAGE_RAW_NAME}"
     md5sum "${IMAGE_RAW_NAME}" | awk '{print $1}' > "${IMAGE_RAW_NAME}.md5sum"
 fi

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ And the following environment variables need to be set for **Ubuntu**:
 export IMAGE_OS=Ubuntu
 ```
 
+And the following environment variables need to be set for **Flatcar**:
+
+```sh
+export IMAGE_OS=Flatcar
+```
+
 You can check a list of all the environment variables [here](vars.md)
 
 ### Deploy the metal3 Dev env

--- a/lib/images.sh
+++ b/lib/images.sh
@@ -11,6 +11,9 @@ elif [[ "${IMAGE_OS}" == "FCOS" ]]; then
 elif [[ "${IMAGE_OS}" == "Centos" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-CENTOS_8.2_NODE_IMAGE_K8S_v1.19.3.qcow2}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://artifactory.nordix.org/artifactory/airship/images/k8s_v1.19.3}
+elif [[ "${IMAGE_OS}" == "Flatcar" ]]; then
+  export IMAGE_NAME=${IMAGE_NAME:-flatcar_production_qemu_image.img.bz2}
+  export IMAGE_LOCATION=${IMAGE_LOCATION:-https://stable.release.flatcar-linux.net/amd64-usr/current/}
 else
   export IMAGE_NAME=${IMAGE_NAME:-cirros-0.5.1-x86_64-disk.img}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-http://download.cirros-cloud.net/0.5.1}


### PR DESCRIPTION
Signed-off-by: Vincent Batts <vbatts@kinvolk.io>


This is an initial pass for provisioning the image with Flatcar Container Linux. 
I could test all the way through steps 01, 02, and 03.
Then it seems I'm troubleshooting a nested vt-x issue, because then the dev machine goes unresponsive right as `node_1` is brought up.