### PR TITLE
Fix Calico setup for Centos nodes

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
@@ -72,6 +72,8 @@
           # for indentation
                       - name: IP_AUTODETECTION_METHOD
                         value: "interface=eth1"
+                      - name: FELIX_IPTABLESBACKEND
+                        value: "NFT"
     when:
       ansible_distribution == "CentOS"
 


### PR DESCRIPTION
In Centos based target clusters the following error were seen while deploying Cert Manager:

```
error creating core-only manager: Get "https://10.96.0.1:443/api?timeout=32s": dial tcp 10.96.0.1:443: i/o timeout
```
This was caused by Calico as described [here](https://github.com/projectcalico/calico/issues/2322#issuecomment-515554705) 

This PR fixes the problem as suggested in the Calico issue. 