### PR TITLE
Add Missing IP in Metal3 Data Template for Centos

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
@@ -94,6 +94,16 @@ spec:
               prefix: 0
               gateway:
                 fromIPPool: baremetalv4-pool
+{% if IMAGE_OS == 'Centos' %}                
+        - id: provision
+          link: enp1s0
+          ipAddressFromIPPool: provisioning-pool
+          routes:
+            - network: 0.0.0.0
+              prefix: 0
+              gateway:
+                fromIPPool: provisioning-pool
+{% endif %}                
 {% endif %}
 {% if IP_STACK == 'v6' or IP_STACK == 'v4v6'%}
       ipv6:

--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
@@ -98,6 +98,16 @@ spec:
               prefix: 0
               gateway:
                 fromIPPool: baremetalv4-pool
+{% if IMAGE_OS == 'Centos' %}                
+        - id: provision
+          link: enp1s0
+          ipAddressFromIPPool: provisioning-pool
+          routes:
+            - network: 0.0.0.0
+              prefix: 0
+              gateway:
+                fromIPPool: provisioning-pool
+{% endif %}                
 {% endif %}
 {% if IP_STACK == 'v6' or IP_STACK == 'v4v6'%}
       ipv6:


### PR DESCRIPTION
This PR adds missing provisioning IP in Metal3 Data Template for the Centos target nodes. 