### PR TITLE
Introduce 'repivoting' action

### DIFF
--- a/scripts/feature_tests/pivoting/Makefile
+++ b/scripts/feature_tests/pivoting/Makefile
@@ -2,13 +2,16 @@ M3PATH := "$(dirname "$(readlink -f "${0}")")../../../"
 export NUM_OF_MASTER_REPLICAS := 1
 export NUM_OF_WORKER_REPLICAS := 1
 
-all: provision pivoting deprovision
+all: provision pivoting repivoting deprovision
 
 provision:
 	./../feature_test_provisioning.sh
 
 pivoting:
 	./pivot.sh
+
+repivoting:
+	./repivot.sh
 
 deprovision:
 	./../feature_test_deprovisioning.sh

--- a/scripts/feature_tests/pivoting/repivot.sh
+++ b/scripts/feature_tests/pivoting/repivot.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+METAL3_DIR="$(dirname "$(readlink -f "${0}")")/../../.."
+
+export ACTION="repivoting"
+
+"${METAL3_DIR}"/scripts/run.sh

--- a/vm-setup/roles/v1aX_integration_test/tasks/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/main.yml
@@ -51,11 +51,11 @@
 
 - name: pivot
   include: move.yml
-  when: v1aX_integration_test_action == "pivoting" or v1aX_integration_test_action == "upgrading"
+  when: v1aX_integration_test_action in pivot_actions
 
 - name: repivot
   include: move_back.yml
-  when: v1aX_integration_test_action == "pivoting"
+  when: v1aX_integration_test_action == "repivoting"
 
 - name: Deprovision worker nodes
   k8s:

--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -1,4 +1,8 @@
 ---
+  - name: Define number of BMH's
+    set_fact:
+      NUMBER_OF_BMH: "{{ NUM_OF_MASTER_REPLICAS|int +  NUM_OF_WORKER_REPLICAS|int }}"
+
   - name: Remove ironic container from source cluster (Ephemeral Cluster is kind)
     docker_container:
       name: "{{ item }}"

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -92,6 +92,9 @@ verify_actions:
     - "ci_test_provision"
     - "feature_test_provisioning"
     - "pivoting"
+pivot_actions:
+    - "pivoting"    
+    - "upgrading"
 cleanup_actions:
     - "ci_test_deprovision"
     - "feature_test_deprovisioning"


### PR DESCRIPTION
Changes introduced in #461 was still performing pivoting and repivoting using the same actions `pivoting`. Upgrade feature test requires now to have a flexibility when to repivot and not do the repivot only when `pivoting` action is called. This PR introduces a new action and make target named `repivoting`.