### PR TITLE
Update ubuntu node Image

### DIFF
--- a/lib/images.sh
+++ b/lib/images.sh
@@ -3,7 +3,7 @@
 # Image url and checksum
 IMAGE_OS=${IMAGE_OS:-Centos}
 if [[ "${IMAGE_OS}" == "Ubuntu" ]]; then
-  export IMAGE_NAME=${IMAGE_NAME:-UBUNTU_NODE_IMAGE_K8S_v1.18.8.qcow2}
+  export IMAGE_NAME=${IMAGE_NAME:-UBUNTU_20.04_NODE_IMAGE_K8S_v1.18.8.qcow2}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://artifactory.nordix.org/artifactory/airship/images/k8s_v1.18.8/}
 elif [[ "${IMAGE_OS}" == "FCOS" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-fedora-coreos-30.20191014.0-openstack.x86_64.qcow2}

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -54,7 +54,7 @@ IRONIC_IMAGE_DIR: "{{ lookup('env', 'IRONIC_IMAGE_DIR') | default('/opt/metal3-d
 IRONIC_ENDPOINT_BRIDGE: "{{ lookup('env', 'CLUSTER_PROVISIONING_INTERFACE') | default('provisioning', true)}}"
 
 # Distibution specific environment variables
-IMAGE_NAME: "{{ lookup('env', 'IMAGE_NAME') | default('UBUNTU_NODE_IMAGE_K8S_v1.18.8.qcow2', true)}}"
+IMAGE_NAME: "{{ lookup('env', 'IMAGE_NAME') | default('UBUNTU_20.04_NODE_IMAGE_K8S_v1.18.8.qcow2', true)}}"
 RAW_IMAGE_NAME: "{{ lookup('env', 'IMAGE_RAW_NAME') | default('focal-server-cloudimg-amd64-raw.img', true)}}"
 IMAGE_LOCATION: "{{ lookup('env', 'IMAGE_LOCATION') | default('https://artifactory.nordix.org/artifactory/airship/images/k8s_v1.18.8/', true)}}"
 IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"


### PR DESCRIPTION
This PR updates the ubuntu node Image to `UBUNTU_20.04_NODE_IMAGE_K8S_v1.18.8` which is a shrink and resized version of the previous node image and when converted to `raw` image, this image is supposed to take up much less space ~3GB in compared to ~20GB before