### PR TITLE
Separate pivoting action for priority  upgrade use case.

### DIFF
--- a/scripts/feature_tests/pivoting/Makefile
+++ b/scripts/feature_tests/pivoting/Makefile
@@ -15,3 +15,6 @@ repivoting:
 
 deprovision:
 	./../feature_test_deprovisioning.sh
+
+upgrading:
+	./upgrade.sh

--- a/scripts/feature_tests/pivoting/upgrade.sh
+++ b/scripts/feature_tests/pivoting/upgrade.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export NUM_OF_MASTER_REPLICAS=3
+export NUM_OF_WORKER_REPLICAS=1
+
+METAL3_DIR="$(dirname "$(readlink -f "${0}")")/../../.."
+
+export ACTION="upgrading"
+
+"${METAL3_DIR}"/scripts/run.sh


### PR DESCRIPTION
This PR will add separate script for calling pivoting with correct variables for priority upgrade use case. With current pivoting configuration, the upgrade script was unable to use the pivoting action during our upgrade tests because of dependency on these (`NUM_OF_MASTER_REPLICAS=1` and `NUM_OF_WORKER_REPLICAS=1`) two variables. In case of upgrading, the priority use case use different values. The repivoting has no dependency and can use it in upgrading use case by calling `make repivoting`.  So with the help of this PR we can call the pivoting from our upgrade script using `make upgrading`.
