### PR TITLE
Remove route configuration from controlplane and worker templates in Centos

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
@@ -98,11 +98,6 @@ spec:
         - id: provision
           link: enp1s0
           ipAddressFromIPPool: provisioning-pool
-          routes:
-            - network: 0.0.0.0
-              prefix: 0
-              gateway:
-                fromIPPool: provisioning-pool
 {% endif %}                
 {% endif %}
 {% if IP_STACK == 'v6' or IP_STACK == 'v4v6'%}

--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
@@ -102,11 +102,6 @@ spec:
         - id: provision
           link: enp1s0
           ipAddressFromIPPool: provisioning-pool
-          routes:
-            - network: 0.0.0.0
-              prefix: 0
-              gateway:
-                fromIPPool: provisioning-pool
 {% endif %}                
 {% endif %}
 {% if IP_STACK == 'v6' or IP_STACK == 'v4v6'%}


### PR DESCRIPTION
In the master [airship_master_v1a4_integration_test_centos](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a4_integration_test_centos/272/) job logs we are seeing below logs:

```
Starting Network Manager...
[   40.924617] cloud-init[907]:   File "/usr/lib/python3.6/site-packages/cloudinit/stages.py", line 672, in apply_network_config
[   40.938487] cloud-init[907]:     return self.distro.apply_network_config(netcfg, bring_up=bring_up)
[   40.947606] cloud-init[907]:   File "/usr/lib/python3.6/site-packages/cloudinit/distros/__init__.py", line 178, in apply_network_config
[   40.959294] cloud-init[907]:     dev_names = self._write_network_config(netconfig)
[   40.966740] cloud-init[907]:   File "/usr/lib/python3.6/site-packages/cloudinit/distros/rhel.py", line 65, in _write_network_config
[   40.977635] cloud-init[907]:     return self._supported_write_network_config(netconfig)
[   40.985181] cloud-init[907]:   File "/usr/lib/python3.6/site-packages/cloudinit/distros/__init__.py", line 93, in _supported_write_network_config
[   40.996763] cloud-init[907]:     renderer.render_network_config(network_config)
[   41.008722] cloud-init[907]:   File "/usr/lib/python3.6/site-packages/cloudinit/net/renderer.py", line 56, in render_network_config
[   41.019246] cloud-init[907]:     templates=templates, target=target)
[   41.025608] cloud-init[907]:   File "/usr/lib/python3.6/site-packages/cloudinit/net/sysconfig.py", line 662, in render_network_state
[   41.036248] cloud-init[907]:     templates=templates).items():
[   41.041828] cloud-init[907]:   File "/usr/lib/python3.6/site-packages/cloudinit/net/sysconfig.py", line 635, in _render_sysconfig
[   41.052328] cloud-init[907]:     cls._render_physical_interfaces(network_state, iface_contents)
[   41.060342] cloud-init[907]:   File "/usr/lib/python3.6/site-packages/cloudinit/net/sysconfig.py", line 494, in _render_physical_interfaces
[   41.071664] cloud-init[907]:     cls._render_subnet_routes(iface_cfg, route_cfg, iface_subnets)
[   41.079867] cloud-init[907]:   File "/usr/lib/python3.6/site-packages/cloudinit/net/sysconfig.py", line 422, in _render_subnet_routes
[   41.090755] cloud-init[907]:     is_ipv6 = subnet.get('ipv6') or is_ipv6_addr(route['gateway'])
[   41.098726] cloud-init[907]: KeyError: 'gateway'
[   41.103338] cloud-init[907]: ------------------------------------------------------------
```
and this PR should fix it.  