### PR TITLE
Update docker version for centos nodes

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_centos.rc
+++ b/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_centos.rc
@@ -38,7 +38,7 @@ export CTLPLANE_KUBEADM_EXTRA_CONFIG="
       - dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
       - setenforce 0
       - sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
-      - dnf install docker-ce-3:18.09.1-3.el7 docker-ce-cli-1:18.09.1-3.el7 --disableexcludes=kubernetes --nobest -y
+      - dnf install docker-ce docker-ce-cli --disableexcludes=kubernetes --nobest -y
       - >-
         dnf install gcc kernel-headers kernel-devel keepalived
         device-mapper-persistent-data lvm2 -y
@@ -177,7 +177,7 @@ export WORKERS_KUBEADM_EXTRA_CONFIG="
         - dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
         - setenforce 0
         - sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
-        - dnf install docker-ce-3:18.09.1-3.el7 docker-ce-cli-1:18.09.1-3.el7 --disableexcludes=kubernetes --nobest -y
+        - dnf install docker-ce docker-ce-cli --disableexcludes=kubernetes --nobest -y
         - echo  \"Installing kubernetes binaries\"
         - curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/{kubeadm,kubelet,kubectl}
         - chmod a+x kubeadm kubelet kubectl


### PR DESCRIPTION
Centos based CI is failing because of the following:

```
 Docker CE Stable - x86_64                       383  B/s | 3.8 kB     00:10
[  706.024158] cloud-init[1396]: No match for argument: docker-ce-3:18.09.1-3.el7
[  706.028249] cloud-init[1396]: No match for argument: docker-ce-cli-1:18.09.1-3.el7
[  706.036206] cloud-init[1396]: Error: Unable to find a match: docker-ce-3:18.09.1-3.el7 docker-ce-cli-1:18.09.1-3.el7
```
Uplifting docker version to check if this problem is mitigated