### PR TITLE
Extend the waiting time for BMH deprovisioning

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
@@ -38,7 +38,7 @@
         | .metadata.name ] | length'
     register: deprovisioned_nodes
     retries: 150
-    delay: 3
+    delay: 10
     until: deprovisioned_nodes.stdout ==  NUM_NODES
 
   - name: Wait until no metal3machines are remaining


### PR DESCRIPTION
We are sometimes close to timeout (or over) in some cases
even if the cleaning actually completes properly right after.
This extends the wait period to avoid false positive.

/cc @fmuyassarov 
/cc @kashifest 