### PR TITLE
Fix small issue when install clusterctl

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -104,7 +104,7 @@ function install_clusterctl() {
 
 if ! [ -x "$(command -v clusterctl)" ]; then
   install_clusterctl
-elif [ "$(clusterctl version | grep -o -P '(?<=GitVersion:).*?(?=,)')" != "${CAPIRELEASE}" ]; then
+elif [ "$(clusterctl version | grep -o -P '(?<=GitVersion:).*?(?=,)')" != "\"${CAPIRELEASE}\"" ]; then
   sudo rm /usr/local/bin/clusterctl
   install_clusterctl
 fi


### PR DESCRIPTION
Now the code will always force install clusterctl even when installed clusterctl vesion
equals to target version

Assume CAPIRELEASE is v0.3.9, installed clusterctl version is also v0.3.9
$ clusterctl version
clusterctl version: &version.Info{Major:"0", Minor:"3", GitVersion:"v0.3.9", GitCommit:"e1f67d8ceb1d5b30ef967035f7a0d1b1ee088b37", GitTreeState:"clean", BuildDate:"2020-09-01T02:44:58Z", GoVersion:"go1.13.14", Compiler:"gc", Platform:"linux/amd64"}
$ clusterctl version | grep -o -P '(?<=GitVersion:).*?(?=,)'
"v0.3.9"

when it goes to
```
	elif [ "$(clusterctl version | grep -o -P '(?<=GitVersion:).*?(?=,)')" != "${CAPIRELEASE}" ]; then
```
logs are
```
+ '[' '"v0.3.9"' '!=' v0.3.9 ']'
```
we should add double quote around ${CAPIRELEASE}

Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>