### PR TITLE
Add action for verify script before pivoting in upgrade task.

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -92,6 +92,7 @@ verify_actions:
     - "ci_test_provision"
     - "feature_test_provisioning"
     - "pivoting"
+    - "upgrading"  
 pivot_actions:
     - "pivoting"    
     - "upgrading"


### PR DESCRIPTION
We are facing an issue with the calico during the pivoting in upgrade task. Because the calico.yaml file that we apply in our upgrade script needs additional configuration for metal3-dev-env. If we run the verify.yml file before pivoting, it applies the correct configuration for CNI. This PR will solve this issue with the CNI.