### PR TITLE
Bump sushy-tools to include a fix for potential race

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -2,6 +2,6 @@ FROM registry.hub.docker.com/library/python:3.8
 
 RUN apt update && \
     apt install -y libvirt-dev && \
-    pip3 install git+https://opendev.org/openstack/sushy-tools.git@b3bbb5b108216e39e5d6a98ae34e3ec38b568cf5 libvirt-python
+    pip3 install git+https://opendev.org/openstack/sushy-tools.git@5d1a1469558b0940d6351af29278c01598f8badf libvirt-python
 
 CMD sushy-emulator -i :: -p 8000 --config /root/sushy/conf.py


### PR DESCRIPTION
The fix handles race conditions when creating a directory for
PersistentDict, as two threads may be trying to create it
in parallel.