### PR TITLE
CI: Remove sourcing of common.sh script

### DIFF
--- a/lib/releases.sh
+++ b/lib/releases.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# shellcheck disable=SC1091
-source lib/common.sh
-
 function get_latest_release() {
   set +x
   if [ -z "${GITHUB_TOKEN:-}" ]; then


### PR DESCRIPTION
Master feature tests are [not passing](https://jenkins.nordix.org/view/Airship/job/airship_master_feature_tests_ubuntu/173/consoleFull) due to the unnecessary sourcing of `lib/common.sh` in `lib/releases.sh` script with logs:

`+ source /home/****/tested_repo/scripts/../lib/releases.sh
++ source lib/common.sh
/home/****/tested_repo/scripts/../lib/releases.sh: line 4: lib/common.sh: No such file or directory
make[1]: Leaving directory '/home/****/tested_repo/scripts/feature_tests/remediation'
make[1]: *** [Makefile:7: provision] Error 1
make: *** [Makefile:42: remediation_test] Error 2`

This PR removes sourcing of `lib/common.sh` script introduced in #498 . The reason for removal of `lib/common.sh` sourcing is because it is already sourced before running `lib/releases.sh` in all its execution places. 