### PR TITLE
Change erroneous Ubuntu Node Image

### DIFF
--- a/lib/images.sh
+++ b/lib/images.sh
@@ -3,7 +3,7 @@
 # Image url and checksum
 IMAGE_OS=${IMAGE_OS:-Centos}
 if [[ "${IMAGE_OS}" == "Ubuntu" ]]; then
-  export IMAGE_NAME=${IMAGE_NAME:-UBUNTU_20.04_NODE_IMAGE_K8S_v1.18.8.qcow2}
+  export IMAGE_NAME=${IMAGE_NAME:-UBUNTU_NODE_IMAGE_K8S_v1.18.8.qcow2}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://artifactory.nordix.org/artifactory/airship/images/k8s_v1.18.8/}
 elif [[ "${IMAGE_OS}" == "FCOS" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-fedora-coreos-32.20200923.2.0-openstack.x86_64.qcow2.xz}
@@ -15,6 +15,7 @@ else
   export IMAGE_NAME=${IMAGE_NAME:-cirros-0.5.1-x86_64-disk.img}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-http://download.cirros-cloud.net/0.5.1}
 fi
+
 export IMAGE_URL=http://$PROVISIONING_URL_HOST/images/${IMAGE_NAME}
 export IMAGE_CHECKSUM=http://$PROVISIONING_URL_HOST/images/${IMAGE_NAME}.md5sum
 

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -55,8 +55,8 @@ IRONIC_IMAGE_DIR: "{{ lookup('env', 'IRONIC_IMAGE_DIR') | default('/opt/metal3-d
 IRONIC_ENDPOINT_BRIDGE: "{{ lookup('env', 'CLUSTER_PROVISIONING_INTERFACE') | default('provisioning', true)}}"
 
 # Distibution specific environment variables
-IMAGE_NAME: "{{ lookup('env', 'IMAGE_NAME') | default('UBUNTU_20.04_NODE_IMAGE_K8S_v1.18.8.qcow2', true)}}"
-RAW_IMAGE_NAME: "{{ lookup('env', 'IMAGE_RAW_NAME') | default('UBUNTU_20.04_NODE_IMAGE_K8S_v1.18.8-raw.img', true)}}"
+IMAGE_NAME: "{{ lookup('env', 'IMAGE_NAME') | default('UBUNTU_NODE_IMAGE_K8S_v1.18.8.qcow2', true)}}"
+RAW_IMAGE_NAME: "{{ lookup('env', 'IMAGE_RAW_NAME') | default('UBUNTU_NODE_IMAGE_K8S_v1.18.8-raw.img', true)}}"
 IMAGE_LOCATION: "{{ lookup('env', 'IMAGE_LOCATION') | default('https://artifactory.nordix.org/artifactory/airship/images/k8s_v1.18.8/', true)}}"
 IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"
 IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.md5sum"


### PR DESCRIPTION
We are temporarily falling back to previous version of prebaked node image since the current version is showing the following error:

```
[  613.785649] EXT4-fs (sda1): Delayed block allocation failed for inode 520007 at logical offset 6144 with max blocks 2048 with error 117
[  613.809069] EXT4-fs (sda1): This should not happen!! Data will be lost
[  613.809069] 
[  614.759027] EXT4-fs (sda1): Delayed block allocation failed for inode 520061 at logical offset 6144 with max blocks 2048 with error 117
```