### PR TITLE
Add condition for moving BMO kustomization files in v1alpha4

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -436,15 +436,16 @@ function patch_clusterctl(){
     update_component_image BMO "${BAREMETAL_OPERATOR_IMAGE}"
     update_component_image IPAM "${IPAM_IMAGE}"
     update_capm3_imports
-
-    mv config/bmo/kustomization.yaml.orig config/bmo/kustomization.yaml
-    mv config/ipam/kustomization.yaml.orig config/ipam/kustomization.yaml
-
-    rm config/bmo/bmo-components.yaml
-    rm config/ipam/metal3-ipam-components.yaml
   fi
 
   make release-manifests
+
+  if [ "${CAPM3_VERSION}" != "v1alpha3" ]; then
+    mv config/bmo/kustomization.yaml.orig config/bmo/kustomization.yaml
+    mv config/ipam/kustomization.yaml.orig config/ipam/kustomization.yaml
+    rm config/bmo/bmo-components.yaml
+    rm config/ipam/metal3-ipam-components.yaml
+  fi
 
   rm -rf "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
   mkdir -p "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"


### PR DESCRIPTION
In case of v1alpha4 we are updating the images to use local ones and imports for the CAPM3 deployment files. Also we are putting moving of kustomize files for BMO and IPAM in the same condition and call make target to build the manifests to publish with a release. Instead, we have to take moving of kustomization files out and put in their own condition to properly patch clusterctl deployment files.