### PR TITLE
🐛 Add kubeconfig when installing BMO and Ironic and change Ironic container name 

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -8,7 +8,8 @@
       name: "{{ item }}"
       state: absent
     with_items:
-       - ironic
+       - ironic-api
+       - ironic-conductor
        - ironic-inspector
        - dnsmasq
        - httpd
@@ -47,6 +48,7 @@
     environment:
       IRONIC_HOST: "{{ IRONIC_HOST }}"
       IRONIC_HOST_IP: "{{ IRONIC_HOST_IP }}"
+      KUBECTL_ARGS: "{{ KUBECTL_ARGS }}"
     when: CAPM3_VERSION == "v1alpha3"
 
   # Install Ironic
@@ -55,6 +57,7 @@
     environment:
       IRONIC_HOST: "{{ IRONIC_HOST }}"
       IRONIC_HOST_IP: "{{ IRONIC_HOST_IP }}"
+      KUBECTL_ARGS: "{{ KUBECTL_ARGS }}"
 
   - name: Pivoting test
     delegate_to: "{{ CLUSTER_APIENDPOINT_IP }}"

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -33,6 +33,7 @@ EXTERNAL_SUBNET_V6_PREFIX: "{{ lookup('env', 'EXTERNAL_SUBNET_V6_PREFIX') | defa
 EXTERNAL_SUBNET_V6_HOST: "{{ lookup('env', 'EXTERNAL_SUBNET_V6_HOST') | default('fd55::1', true) }}"
 IRONIC_HOST: "{{ lookup('env', 'IRONIC_HOST') | default('172.22.0.2', true) }}"
 IRONIC_HOST_IP: "{{ lookup('env', 'IRONIC_HOST_IP') | default('172.22.0.2', true) }}"
+KUBECTL_ARGS: "--kubeconfig=/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
 DEPLOY_KERNEL_URL: "{{ lookup('env', 'DEPLOY_KERNEL_URL') }}"
 DEPLOY_RAMDISK_URL: "{{ lookup('env', 'DEPLOY_RAMDISK_URL') }}"
 IRONIC_URL: "{{ lookup('env', 'IRONIC_URL') }}"


### PR DESCRIPTION
#508 is missing kubeconfig so that Ironic and BMO is deployed in target cluster, also it fixes name for ironic container as ironic container now became ironic-api + ironic-conductor. 