### PR TITLE
Implementation for 3 control planes and 1 worker upgrade automated test after pivoting.

### DIFF
--- a/scripts/feature_tests/upgrade/controlplane_upgrade/3cp_1w_k8sVer_bootDiskImage_scaleInWorker_upgrade.sh
+++ b/scripts/feature_tests/upgrade/controlplane_upgrade/3cp_1w_k8sVer_bootDiskImage_scaleInWorker_upgrade.sh
@@ -14,28 +14,40 @@ start_logging "${1}"
 
 set_number_of_master_node_replicas 3
 set_number_of_worker_node_replicas 1
-
 provision_controlplane_node
 
-controlplane_is_provisioned
+set_kubeconfig_towards_target_cluster
 controlplane_has_correct_replicas 3
-
-# apply CNI
-apply_cni
+point_to_management_cluster
 
 provision_worker_node
+
+point_to_target_cluster
 worker_has_correct_replicas 1
+point_to_management_cluster
 
-deploy_workload_on_workers
+# Add maxSurge and maxUnvailable to 1 in the machinedeployment.
+kubectl get machinedeployment -n "${NAMESPACE}" test1 -o json |
+  jq '.spec.strategy.rollingUpdate.maxSurge=1|.spec.strategy.rollingUpdate.maxUnavailable=1' |
+  kubectl apply -f-
+sleep 30
 
-manage_node_taints "${CLUSTER_APIENDPOINT_IP}"
+## Start pivoting
+pushd "${METAL3_DEV_ENV_DIR}/scripts/feature_tests/pivoting" || exit
+make upgrading
+popd || exit
+sleep 120
+
+point_to_target_cluster
+# Untaint the masters
+manage_node_taints
 
 scale_workers_to 0
 worker_has_correct_replicas 0
 expected_free_nodes 1
 
 # k8s version upgrade
-CLUSTER_NAME=$(kubectl get clusters -n "${NAMESPACE}" | grep Provisioned | cut -f1 -d' ')
+CLUSTER_NAME=$(kubectl get clusters -n "${NAMESPACE}" | grep -i provisioned | cut -f1 -d' ')
 FROM_VERSION=$(kubectl get kcp -n "${NAMESPACE}" -oyaml |
   grep "version: v1" | cut -f2 -d':' | awk '{$1=$1;print}')
 
@@ -47,7 +59,7 @@ else
   exit 0
 fi
 
-# Node image version upgrade
+# Controlplane node image upgrade
 M3_MACHINE_TEMPLATE_NAME=$(kubectl get Metal3MachineTemplate -n "${NAMESPACE}" -oyaml |
   grep "name: " | grep -o "${CLUSTER_NAME}-controlplane" -m1)
 
@@ -62,20 +74,60 @@ kubectl apply -f "${Metal3MachineTemplate_OUTPUT_FILE}"
 
 echo "Upgrading a control plane node image and k8s version from ${FROM_VERSION}\
  to ${TO_VERSION} in cluster ${CLUSTER_NAME}"
-# Trigger the upgrade by replacing node image and k8s version in kcp yaml:
-kubectl get kcp -n "${NAMESPACE}" -oyaml |
-  sed "s/version: ${FROM_VERSION}/version: ${TO_VERSION}/" |
-  sed "s/name: ${M3_MACHINE_TEMPLATE_NAME}/name: new-controlplane-image/" | kubectl replace -f -
+
+# Trigger the upgrade by replacing node image and k8s version in KCP
+kubectl get kcp -n "${NAMESPACE}" -oyaml | 
+	sed "s/version: ${FROM_VERSION}/version: ${TO_VERSION}/" | 
+	sed "s/name: ${M3_MACHINE_TEMPLATE_NAME}/name: new-controlplane-image/" | 
+	kubectl replace -f -
 
 cp_nodes_using_new_bootDiskImage 3
 
+# Untaint the masters
+manage_node_taints
+
+controlplane_has_correct_replicas 3
+expected_free_nodes 1
 scale_workers_to 1
 worker_has_correct_replicas 1
+echo "Successfully upgrade 3 CP nodes"
 
-echo "Successfully upgrade 3 CP and 1 worker nodes"
+# Applying workload to the worker with node affinity
+WORKER_NAME=$(kubectl get nodes -n "${NAMESPACE}" | awk 'NR>1'| grep -v master | awk '{print $1}')
+kubectl label node "${WORKER_NAME}" type=worker
+
+# Deploy workload with node affinity
+deploy_workload_on_workers
+
+# Upgrade worker node image
+export new_wr_metal3MachineTemplate_name="${CLUSTER_NAME}-new-workers-image"
+echo "Create a new metal3MachineTemplate with new node image for worker nodes"
+wr_Metal3MachineTemplate_OUTPUT_FILE="/tmp/wr31_new_image.yaml"
+
+CLUSTER_UID=$(kubectl get clusters -n "${NAMESPACE}" "${CLUSTER_NAME}" -o json |
+    jq '.metadata.uid' | cut -f2 -d\")
+generate_metal3MachineTemplate "${new_wr_metal3MachineTemplate_name}" \
+        "${CLUSTER_UID}" "${wr_Metal3MachineTemplate_OUTPUT_FILE}" \
+        "${CAPM3_VERSION}" "${CAPI_VERSION}" \
+        "${CLUSTER_NAME}-workers-template"
+
+kubectl apply -f "${wr_Metal3MachineTemplate_OUTPUT_FILE}"
+
+kubectl get machinedeployment -n "${NAMESPACE}" "${CLUSTER_NAME}" -o json |
+        jq '.spec.template.spec.infrastructureRef.name="test1-new-workers-image"' |
+        kubectl apply -f-
+
+wr_nodes_using_new_bootDiskImage 1
+worker_has_correct_replicas 1
 log_test_result "3cp_1w_k8sVer_bootDiskImage_scaleInWorker_upgrade.sh" "pass"
+
+point_to_management_cluster
+
+# Pivot back
+pushd "${METAL3_DEV_ENV_DIR}/scripts/feature_tests/pivoting" || exit
+make repivoting
+popd || exit
 
 deprovision_cluster
 wait_for_cluster_deprovisioned
-
 set +x

--- a/scripts/feature_tests/upgrade/upgrade.sh
+++ b/scripts/feature_tests/upgrade/upgrade.sh
@@ -29,29 +29,10 @@ source "${METAL3_DEV_ENV_DIR}/lib/images.sh"
 # -----------------------------------------
 
 if [[ "${IMAGE_OS}" == "Ubuntu" ]]; then
-    # Run cluster level ugprade tests
-    pushd "${METAL3_DEV_ENV_DIR}/scripts/feature_tests/upgrade" || exit
-    # shellcheck disable=SC1091
-    source 1cp_1w_bootDiskImage_cluster_upgrade.sh
-    # shellcheck disable=SC1091
-    source clean_setup_env.sh
-    popd || exit
-
-    # Run worker upgrade cases
-    pushd "${METAL3_DEV_ENV_DIR}/scripts/feature_tests/upgrade/workers_upgrade" || exit
-    # shellcheck disable=SC1091
-    source 1cp_3w_bootDiskImage_scaleInWorkers_upgrade_both.sh
-    popd || exit
-
-    pushd "${METAL3_DEV_ENV_DIR}/scripts/feature_tests/upgrade" || exit
-    # shellcheck disable=SC1091
-    source clean_setup_env.sh
-    popd || exit
-
-    # Run controlplane upgrade tests
+    # Run controlplane and worker upgrade tests
     pushd "${METAL3_DEV_ENV_DIR}/scripts/feature_tests/upgrade/controlplane_upgrade" || exit
     # shellcheck disable=SC1091
-    source 3cp_1w_k8sVer_bootDiskImage_scaleInWorker_upgrade.sh
+   # source 3cp_1w_k8sVer_bootDiskImage_scaleInWorker_upgrade.sh
     popd || exit
 else
     # shellcheck disable=SC1091

--- a/scripts/feature_tests/upgrade/upgrade_common.sh
+++ b/scripts/feature_tests/upgrade/upgrade_common.sh
@@ -123,10 +123,18 @@ spec:
       labels:
         app: workload-1
     spec:
-      nodeName: "${WORKER_NAME}"
       containers:
       - name: nginx
         image: nginx
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: type
+                operator: In
+                values:
+                - worker
 EOF
 
     echo "Waiting for workloads to be ready"
@@ -144,7 +152,7 @@ EOF
             log_error " Workload failed to be deployed on the cluster"
             deprovision_cluster
             wait_for_cluster_deprovisioned
-            break
+            exit 1
         fi
     done
 }
@@ -200,7 +208,7 @@ function controlplane_is_provisioned() {
         sleep 10
         if [[ "${i}" -ge 1800 ]]; then
             log_error "Controlplane provisioning took longer than expected."
-            break
+            exit 1
         fi
     done
 }
@@ -221,7 +229,7 @@ function controlplane_has_correct_replicas() {
         sleep 10
         if [[ "${i}" -ge 1800 ]]; then
             log_error "Controlplane replicas not provisioned in expected time frame"
-            break
+            exit 1
         fi
     done
 }
@@ -262,7 +270,7 @@ function worker_has_correct_replicas() {
             else
                 log_error "Time out while waiting for workers to join the cluster"
             fi
-            break
+            exit 1
         fi
     done
 }
@@ -283,7 +291,7 @@ function cp_nodes_using_new_bootDiskImage() {
         if [[ "${i}" -ge 1800 ]]; then
             log_error "Time out while waiting for CP nodes to be provisioned \
             with a new boot disk image"
-            break
+            exit 1
         fi
     done
 
@@ -305,7 +313,7 @@ function wr_nodes_using_new_bootDiskImage() {
         if [[ "${i}" -ge 1800 ]]; then
             log_error "Time out while waiting for worker nodes to be provisioned\
              with a new boot disk image"
-            break
+            exit 1
         fi
     done
 
@@ -326,7 +334,7 @@ function expected_free_nodes() {
         sleep 10
         if [[ "${i}" -ge 1800 ]]; then
             log_error "Time out while waiting for original nodes to be released"
-            break
+            exit 1
         fi
     done
 
@@ -460,7 +468,7 @@ function verify_kubernetes_version_upgrade() {
         sleep 10
         if [[ "${i}" -ge 1800 ]]; then
             log_error "Time out while waiting for upgrade of kubernetes version of all nodes"
-            break
+            exit 1
         fi
     done
 }


### PR DESCRIPTION
This automation script will test three control plane and one worker upgrade use case. It will upgrade kubernetes version for control planes and node image upgrade for both  control plane and worker after pivoting. Also includes test for `nodeDrainTimeout` feature in worker node.  We limit the upgrade test run in the CI to one use case for better performance and less testing  time.

Co-author: anwar.hassen@est.tech
Git hub: Xenwar