### PR TITLE
Enable TLS between Ironic and Mariadb

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -214,7 +214,6 @@ EOF
     # Restore original files
     mv "${BMOPATH}/ironic-deployment/ironic/ironic.yaml.orig" "${BMOPATH}/ironic-deployment/ironic/ironic.yaml"
     mv "${BMOPATH}/ironic-deployment/keepalived/keepalived_patch.yaml.orig" "${BMOPATH}/ironic-deployment/keepalived/keepalived_patch.yaml"
-
   fi
   
   # Restore original files

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -22,6 +22,8 @@ fi
 source "$CONFIG"
 
 # Set variables
+export MARIADB_HOST="mariaDB"
+export MARIADB_HOST_IP="127.0.0.1"
 # Additional DNS
 ADDN_DNS=${ADDN_DNS:-}
 # External interface for routing traffic through the host

--- a/lib/ironic_tls_setup.sh
+++ b/lib/ironic_tls_setup.sh
@@ -18,12 +18,21 @@ if [ "${IRONIC_TLS_SETUP}" == "true" ]; then
     export IRONIC_INSPECTOR_CERT_FILE="${IRONIC_INSPECTOR_CERT_FILE:-"${WORKING_DIR}/certs/ironic-inspector.crt"}"
     export IRONIC_INSPECTOR_KEY_FILE="${IRONIC_INSPECTOR_KEY_FILE:-"${WORKING_DIR}/certs/ironic-inspector.key"}"
 
+    export MARIADB_CACERT_FILE="${MARIADB_CACERT_FILE:-"${WORKING_DIR}/certs/ironic-ca.pem"}"
+    export MARIADB_CAKEY_FILE="${IRONIC_CAKEY_FILE:-"${WORKING_DIR}/certs/ironic-ca.key"}"
+    export MARIADB_CERT_FILE="${MARIADB_CERT_FILE:-"${WORKING_DIR}/certs/mariadb.crt"}"
+    export MARIADB_KEY_FILE="${MARIADB_KEY_FILE:-"${WORKING_DIR}/certs/mariadb.key"}"
+
+
     # Generate CA Key files
     if [ ! -f "${IRONIC_CAKEY_FILE}" ]; then
         openssl genrsa -out "${IRONIC_CAKEY_FILE}" 2048
     fi
     if [ ! -f "${IRONIC_INSPECTOR_CAKEY_FILE}" ]; then
         openssl genrsa -out "${IRONIC_INSPECTOR_CAKEY_FILE}" 2048
+    fi
+    if [ ! -f "${MARIADB_CAKEY_FILE}" ]; then
+        openssl genrsa -out "${MARIADB_CAKEY_FILE}" 2048
     fi
 
     # Generate CA cert files
@@ -33,6 +42,9 @@ if [ "${IRONIC_TLS_SETUP}" == "true" ]; then
     if [ ! -f "${IRONIC_INSPECTOR_CACERT_FILE}" ]; then
         openssl req -x509 -new -nodes -key "${IRONIC_INSPECTOR_CAKEY_FILE}" -sha256 -days 1825 -out "${IRONIC_INSPECTOR_CACERT_FILE}" -subj /CN="ironic inspector CA"/
     fi
+    if [ ! -f "${MARIADB_CACERT_FILE}" ]; then
+        openssl req -x509 -new -nodes -key "${MARIADB_CAKEY_FILE}" -sha256 -days 1825 -out "${MARIADB_CACERT_FILE}" -subj /CN="mariadb CA"/
+    fi
 
     # Generate Key files
     if [ ! -f "${IRONIC_KEY_FILE}" ]; then
@@ -40,6 +52,9 @@ if [ "${IRONIC_TLS_SETUP}" == "true" ]; then
     fi
     if [ ! -f "${IRONIC_INSPECTOR_KEY_FILE}" ]; then
         openssl genrsa -out "${IRONIC_INSPECTOR_KEY_FILE}" 2048
+    fi
+    if [ ! -f "${MARIADB_KEY_FILE}" ]; then
+        openssl genrsa -out "${MARIADB_KEY_FILE}" 2048
     fi
 
     # Generate CSR and certificate files
@@ -52,7 +67,12 @@ if [ "${IRONIC_TLS_SETUP}" == "true" ]; then
         openssl x509 -req -in /tmp/ironic.csr -CA "${IRONIC_INSPECTOR_CACERT_FILE}" -CAkey "${IRONIC_INSPECTOR_CAKEY_FILE}" -CAcreateserial -out "${IRONIC_INSPECTOR_CERT_FILE}" -days 825 -sha256 -extfile <(printf "subjectAltName=IP:%s" "${IRONIC_HOST_IP}")
     fi
 
-    # Populate the CA certificate B64 variable
+    if [ ! -f "${MARIADB_CERT_FILE}" ]; then
+        openssl req -new -key "${MARIADB_KEY_FILE}" -out /tmp/mariadb.csr -subj /CN="${MARIADB_HOST}"/
+        openssl x509 -req -in /tmp/mariadb.csr -CA "${MARIADB_CACERT_FILE}" -CAkey "${MARIADB_CAKEY_FILE}" -CAcreateserial -out "${MARIADB_CERT_FILE}" -days 825 -sha256 -extfile <(printf "subjectAltName=IP:%s" "${MARIADB_HOST_IP}")
+    fi
+
+    #Populate the CA certificate B64 variable
     if [ "${IRONIC_CACERT_FILE}" == "${IRONIC_INSPECTOR_CACERT_FILE}" ]; then
         IRONIC_CA_CERT_B64="${IRONIC_CA_CERT_B64:-"$(base64 -w 0 < "${IRONIC_CACERT_FILE}")"}"
     else
@@ -75,4 +95,7 @@ else
     unset IRONIC_INSPECTOR_CACERT_FILE
     unset IRONIC_INSPECTOR_CERT_FILE
     unset IRONIC_INSPECTOR_KEY_FILE
+    unset MARIADB_CACERT_FILE
+    unset MARIADB_CERT_FILE
+    unset MARIADB_KEY_FILE
 fi

--- a/vars.md
+++ b/vars.md
@@ -63,3 +63,7 @@ assured that they are persisted.
 | IRONIC_INSPECTOR_PORT | Ironic Inspector port |  | 5050 |
 | IRONIC_API_PORT | Ironic Api port |  | 6385 |
 | NODE_DRAIN_TIMEOUT | Set the nodeDrainTimeout for controlplane and worker template |  | '0s' |
+| MARIADB_KEY_FILE | Path to the key of MariaDB | | /opt/metal3-dev-env/certs/mariadb.key |
+| MARIADB_CERT_FILE | Path to the cert of MariaDB | | /opt/metal3-dev-env/certs/mariadb.crt |
+| MARIADB_CAKEY_FILE | Path to the CA key of MariaDB | | /opt/metal3-dev-env/certs/ironic-ca.key |
+| MARIADB_CACERT_FILE | Path to the CA certificate of MariaDB | | /opt/metal3-dev-env/certs/ironic-ca.pem | 


### PR DESCRIPTION
This PR is related to:
https://github.com/metal3-io/ironic-image/pull/206 
https://github.com/metal3-io/baremetal-operator/pull/689
The two PRs above need to be merged before this PR can run the CI tests