### PR TITLE
✨ Add nodeDrainTimeout for controlplane and worker template in metal3-dev-env.

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -162,3 +162,7 @@
 
 # Secure Ironic deployment with TLS ("true" or "false")
 # export IRONIC_TLS_SETUP="true"
+
+# Set nodeDrainTimeout for controlplane and worker template, otherwise default value will be  '0s'. 
+#
+#export NODE_DRAIN_TIMEOUT=${NODE_DRAIN_TIMEOUT:-"0s"}

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -138,6 +138,7 @@ export NUM_NODES=${NUM_NODES:-"2"}
 export NUM_OF_MASTER_REPLICAS="${NUM_OF_MASTER_REPLICAS:-"1"}"
 export NUM_OF_WORKER_REPLICAS="${NUM_OF_WORKER_REPLICAS:-"1"}"
 export VM_EXTRADISKS=${VM_EXTRADISKS:-"false"}
+export NODE_DRAIN_TIMEOUT=${NODE_DRAIN_TIMEOUT:-"0s"}
 
 # Docker registry for local images
 export DOCKER_REGISTRY_IMAGE=${DOCKER_REGISTRY_IMAGE:-"docker.io/registry:latest"}

--- a/vars.md
+++ b/vars.md
@@ -58,3 +58,4 @@ assured that they are persisted.
 | IRONIC_INSPECTOR_USERNAME | Username for Ironic inspector basic auth |  |  |
 | IRONIC_PASSWORD | Password for Ironic basic auth |  |  |
 | IRONIC_INSPECTOR_PASSWORD | Password for Ironic inspector basic auth |  |  |
+| NODE_DRAIN_TIMEOUT | Set the nodeDrainTimeout for controlplane and worker template |  | '0s' |

--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ${ CLUSTER_NAME }
   namespace: ${ NAMESPACE }
 spec:
+  nodeDrainTimeout: ${ NODE_DRAIN_TIMEOUT }
   replicas: ${ CONTROL_PLANE_MACHINE_COUNT }
   version: ${ KUBERNETES_VERSION }
   infrastructureTemplate:

--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
@@ -19,6 +19,7 @@ spec:
         cluster.x-k8s.io/cluster-name: ${ CLUSTER_NAME }
         nodepool: nodepool-0
     spec:
+      nodeDrainTimeout: ${ NODE_DRAIN_TIMEOUT }             
       clusterName: ${ CLUSTER_NAME }
       version: ${ KUBERNETES_VERSION }
       bootstrap:

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -13,6 +13,7 @@ CLUSTER_NAME: "{{ lookup('env', 'CLUSTER_NAME') | default('test1', true) }}"
 NUM_OF_MASTER_REPLICAS: "{{ lookup('env', 'NUM_OF_MASTER_REPLICAS') | default(1, true) }}"
 NUM_OF_WORKER_REPLICAS: "{{ lookup('env', 'NUM_OF_WORKER_REPLICAS') | default(1, true) }}"
 NUM_NODES: "{{ lookup('env', 'NUM_NODES') | default(2, true) }}"
+NODE_DRAIN_TIMEOUT: "{{ lookup('env', 'NODE_DRAIN_TIMEOUT') | default('0s', true) }}"
 KUBECONFIG_PATH: "/home/ubuntu/.kube/config"
 KUBERNETES_VERSION: "{{ lookup('env', 'KUBERNETES_VERSION') | default('v1.18.8', true) }}"
 


### PR DESCRIPTION
This PR will add the `nodeDrainTimeout` configuration option in controlplane and worker template of metal3-dev-env. 
As to not affect existing deployments, made the default value to be `0s` and the user can override it with desired value.
