### PR TITLE
🌱 Use latest version of Ansible

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -26,6 +26,7 @@ source lib/images.sh
 
 # Install requirements
 ansible-galaxy install -r vm-setup/requirements.yml
+ansible-galaxy collection install ansible.netcommon
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "working_dir=$WORKING_DIR" \

--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -41,7 +41,7 @@ sudo dnf -y install \
   python3-pip \
   wget
 
-sudo pip3 install ansible==2.9.13
+sudo pip3 install ansible
 
 if [[ $DISTRO == "centos7" ]]; then
   # Install pip since it is used by the k8s Ansible module

--- a/ubuntu_install_requirements.sh
+++ b/ubuntu_install_requirements.sh
@@ -47,7 +47,7 @@ sudo apt -y update
 
 # Install python packages not included as rpms
 sudo pip3 install \
-  ansible==2.9.13 \
+  ansible \
   python-apt \
   openshift \
   pyYAML


### PR DESCRIPTION
Previously, **Ansible 2.9** and earlier had a single repo `ansible/ansible` and a single package called ansible. Starting from **2.10** and later, the `ansible/ansible` (ansible-base) repository only contains core Ansible programs, i.e `ansible-{playbook,galaxy,doc,test,etc}` and will be known as `ansible-base`. 
The rest of the modules and plugins have been moved into various "collections" so that they can be released independently of ansible-base and Ansible and will have their own repo (GitHub, GitLab, etc) with dedicated backlog, ie no more shared massive issue & PR backlog. 
So, this PR installs the collection called [`ansible.netcommon`](https://github.com/ansible-collections/ansible.netcommon) (latest as of now, version 1.4.1, which includes a bug fix for the issue we are facing) to be able to use latest ansible version (latest as of now, 2.10.2). 

Fixes #472 

