### PR TITLE
Update the local images if the *LOCAL_IMAGE* exported

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -156,15 +156,6 @@ for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
   IMAGE="${!IMAGE_VAR}"
   BRANCH="${!BRANCH_IMAGE_VAR:-master}"
 
-  case ${IMAGE_VAR%_LOCAL_IMAGE} in
-    'BAREMETAL_OPERATOR')
-      DOCKERFILE="./build/Dockerfile"
-    ;;
-    *)
-      DOCKERFILE="./Dockerfile"
-    ;;
-  esac
-
   # Is it a git repo?
   if [[ "$IMAGE" =~ "://" ]] ; then
     REPOPATH=~/${IMAGE##*/}
@@ -185,7 +176,7 @@ for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
   export $IMAGE_VAR="${IMAGE##*/}"
   #shellcheck disable=SC2086
   export $IMAGE_VAR="${REGISTRY}/localimages/${!IMAGE_VAR}"
-  sudo "${CONTAINER_RUNTIME}" build -t "${!IMAGE_VAR}" . -f "${DOCKERFILE}"
+  sudo "${CONTAINER_RUNTIME}" build -t "${!IMAGE_VAR}" . -f ./Dockerfile
   cd - || exit
   if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
     sudo "${CONTAINER_RUNTIME}" push --tls-verify=false "${!IMAGE_VAR}"

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -311,11 +311,25 @@ function patch_clusterctl(){
 
   # At this point the images variables have been updated with update_images
   # Reflect the change in components files
-  update_component_image CAPM3 "${CAPM3_IMAGE}"
+  if [ -n "${CAPM3_LOCAL_IMAGE}" ]; then
+    update_component_image CAPM3 "${CAPM3_LOCAL_IMAGE}"
+  else
+    update_component_image CAPM3 "${CAPM3_IMAGE}"
+  fi
 
   if [ "${CAPM3_VERSION}" != "v1alpha3" ]; then
-    update_component_image BMO "${BAREMETAL_OPERATOR_IMAGE}"
-    update_component_image IPAM "${IPAM_IMAGE}"
+    if [ -n "${BAREMETAL_OPERATOR_LOCAL_IMAGE}" ]; then
+      update_component_image BMO "${BAREMETAL_OPERATOR_LOCAL_IMAGE}"
+    else
+      update_component_image BMO "${BAREMETAL_OPERATOR_IMAGE}"
+    fi
+
+    if [ -n "${IPAM_LOCAL_IMAGE}" ]; then
+      update_component_image IPAM "${IPAM_LOCAL_IMAGE}"
+    else
+      update_component_image IPAM "${IPAM_IMAGE}"
+    fi
+
     update_capm3_imports
   fi
 


### PR DESCRIPTION
Currently we are ignoring update_component_image function when there is local image of e.g. CAPM3, BMO or IPAM,
This makes sure to update the images properly even for local images.