### PR TITLE
WIP: Revert 541

### DIFF
--- a/vm-setup/inventory.ini
+++ b/vm-setup/inventory.ini
@@ -1,2 +1,5 @@
 [virthost]
 localhost
+
+[ssh_connection]
+pipelining=True


### PR DESCRIPTION
Ubuntu & Centos v1alpha3 jobs are failing with

`"msg": "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user (rc: 1, err: chown: invalid user: 'metal3
`

We have seen it earlier when the new release of the Ansible came out. And recently it was fixed, and we moved to the latest Ansible in 541. However, we are seeing the similar issue again.

https://jenkins.nordix.org/view/Airship/job/airship_master_v1a3_integration_test_centos/375/console
https://jenkins.nordix.org/view/Airship/job/airship_master_v1a3_integration_test_ubuntu/386/console