### PR TITLE
Advance sushy-tools to 0.12.1

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -2,6 +2,6 @@ FROM registry.hub.docker.com/library/python:3.9
 
 RUN apt update && \
     apt install -y libvirt-dev && \
-    pip3 install git+https://opendev.org/openstack/sushy-tools.git@5d1a1469558b0940d6351af29278c01598f8badf libvirt-python
+    pip3 install sushy-tools==0.12.1 libvirt-python
 
 CMD sushy-emulator -i :: -p 8000 --config /root/sushy/conf.py


### PR DESCRIPTION
This version has better support of vmedia with q35 machines.