### PR TITLE
CI: count workers in target cluster that are 'Ready'

### DIFF
--- a/scripts/feature_tests/upgrade/upgrade_common.sh
+++ b/scripts/feature_tests/upgrade/upgrade_common.sh
@@ -236,7 +236,7 @@ function worker_has_correct_replicas() {
     fi
 
     for i in {1..1800}; do
-        wr_replicas=$(kubectl get nodes | awk 'NR>1' | grep -vc master)
+        wr_replicas=$(kubectl get nodes | awk 'NR>1' | grep -v master | grep -wc Ready)
         if [[ "${replicas}" -eq 0 ]]; then
             if [[ "${wr_replicas}" -eq "${replicas}" ]]; then
                 echo "Expected worker replicas have left the cluster"


### PR DESCRIPTION
It is occasionally possible that during an upgrade, an
old worker node is not deleted in the target cluster
and it is left as garbage in 'NotReady' state.
This PR fixes that not all workers are counted but only
the 'Ready' ones.

Merge this PR after https://github.com/metal3-io/metal3-dev-env/pull/524