### PR TITLE
Fix ironic configmap for TLS

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -51,6 +51,12 @@
       KUBECTL_ARGS: "{{ KUBECTL_ARGS }}"
     when: CAPM3_VERSION == "v1alpha3"
 
+  # Configure Ironic configmap
+  - name: Configure Ironic Configmap
+    shell: |
+      cp {{ BMOPATH }}/ironic-deployment/keepalived/ironic_bmo_configmap.env {{ BMOPATH }}/ironic-deployment/keepalived/ironic_bmo_configmap.env.orig
+      cp {{ IRONIC_DATA_DIR }}/ironic_bmo_configmap.env  {{ BMOPATH }}/ironic-deployment/keepalived/ironic_bmo_configmap.env
+
   # Install Ironic
   - name: Install Ironic
     shell: "{{ BMOPATH }}/tools/deploy.sh false true {{ IRONIC_TLS_SETUP }} {{ IRONIC_BASIC_AUTH }} true"
@@ -58,6 +64,9 @@
       IRONIC_HOST: "{{ IRONIC_HOST }}"
       IRONIC_HOST_IP: "{{ IRONIC_HOST_IP }}"
       KUBECTL_ARGS: "{{ KUBECTL_ARGS }}"
+ 
+  - name: Reinstate Ironic Configmap
+    shell: "mv {{ BMOPATH }}/ironic-deployment/keepalived/ironic_bmo_configmap.env.orig {{ BMOPATH }}/ironic-deployment/keepalived/ironic_bmo_configmap.env"
 
   - name: Label BMO CRDs in target cluster.
     shell: 'kubectl --kubeconfig /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml label crds baremetalhosts.metal3.io {{ item }} --overwrite '

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -15,6 +15,7 @@ NUM_OF_WORKER_REPLICAS: "{{ lookup('env', 'NUM_OF_WORKER_REPLICAS') | default(1,
 NUM_NODES: "{{ lookup('env', 'NUM_NODES') | default(2, true) }}"
 NODE_DRAIN_TIMEOUT: "{{ lookup('env', 'NODE_DRAIN_TIMEOUT') | default('0s', true) }}"
 BMOPATH: "{{ lookup('env', 'BMOPATH') }}"
+IRONIC_DATA_DIR: "{{ lookup('env', 'IRONIC_DATA_DIR') }}"
 KUBECONFIG_PATH: "/home/ubuntu/.kube/config"
 KUBERNETES_VERSION: "{{ lookup('env', 'KUBERNETES_VERSION') | default('v1.18.8', true) }}"
 


### PR DESCRIPTION
This PR fixes a bug for ironic bmo configmap specially for TLS setup. Since in 03 we modify the ironic configmap to reflect TLS changes , we also need the same setup post pivot. However, we were overriding those values once we were done with the source cluster setup. This PR keeps a copy of the configuration and uses that for target cluster. 