### PR TITLE
Fix serial log deletion

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -66,6 +66,6 @@ if [[ $OS == "centos" || $OS == "rhel" ]]; then
 fi
 
 # Clean up any serial logs
-sudo rm -rf /var/log/libvirt/qemu/\*serial0.log
+sudo rm -rf /var/log/libvirt/qemu/*serial0.log*
 
 rm -rf  "${HOME}"/.cluster-api


### PR DESCRIPTION
Serial logs were not getting deleted. This creates havoc in m3-dev-env iterative testing. This PR fixes the deletion. 