### PR TITLE
Remove ironic-log and inspector-log in move

### DIFF
--- a/scripts/feature_tests/cleanup_env.sh
+++ b/scripts/feature_tests/cleanup_env.sh
@@ -18,7 +18,7 @@ source lib/ironic_basic_auth.sh
 ssh-keygen -f /home/"${USER}"/.ssh/known_hosts -R "${CLUSTER_APIENDPOINT_IP}"
 
 # Kill and remove the running ironic containers
-for name in ironic ironic-inspector ironic-endpoint-keepalived dnsmasq httpd mariadb; do
+for name in ironic ironic-inspector ironic-endpoint-keepalived dnsmasq httpd mariadb ironic-log-watch ironic-inspector-log-watch; do
   sudo "${CONTAINER_RUNTIME}" ps | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" kill $name
   sudo "${CONTAINER_RUNTIME}" ps --all | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" rm $name -f
 done

--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -15,6 +15,8 @@
        - httpd
        - mariadb
        - ironic-endpoint-keepalived
+       - ironic-log-watch
+       - ironic-inspector-log-watch
     when: EPHEMERAL_CLUSTER == "kind"
 
   - name: Remove Ironic from from source cluster (Ephemeral Cluster is minikube)


### PR DESCRIPTION
Remove newly created ironic-log and inspector-log containers from source cluster during pivoting. 