### PR TITLE
Deactivate combined upgrade test use case for Centos.

### DIFF
--- a/scripts/feature_tests/upgrade/upgrade.sh
+++ b/scripts/feature_tests/upgrade/upgrade.sh
@@ -44,7 +44,7 @@ else
     # Run controlplane components upgrade tests
     pushd "${METAL3_DEV_ENV_DIR}/scripts/feature_tests/upgrade/combined_tests" || exit
     # shellcheck disable=SC1091
-    source 1cp_1w_bootDiskImageANDK8sControllers_clusterLevel_upgrade.sh
+    #source 1cp_1w_bootDiskImageANDK8sControllers_clusterLevel_upgrade.sh
     popd || exit
 fi
 


### PR DESCRIPTION
We are facing issues with combined upgrade test in Centos. At this moment, we are debugging the issue and trying to find a solution.  The combined test will be activated once we solve the issue.