### PR TITLE
WIP: Apache webserver handles TLS on Ironic and Ironic-inspector sides

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -178,7 +178,8 @@ function update_images(){
 #
 function launch_ironic() {
   pushd "${BMOPATH}"
-
+  # Only enabling the inspector reverse proxy if and only if the ironic TLS is enabled
+  INSPECTOR_REVERSE_PROXY_SETUP="$IRONIC_TLS_SETUP" 
     # Update Configmap parameters with correct urls
     cp "${BMOPATH}/ironic-deployment/keepalived/ironic_bmo_configmap.env" "${BMOPATH}/ironic-deployment/keepalived/ironic_bmo_configmap.env.orig"
     cat << EOF | sudo tee "$IRONIC_DATA_DIR/ironic_bmo_configmap.env"
@@ -193,6 +194,7 @@ IRONIC_ENDPOINT=${IRONIC_URL}
 IRONIC_INSPECTOR_ENDPOINT=${IRONIC_INSPECTOR_URL}
 CACHEURL=http://${PROVISIONING_URL_HOST}/images
 IRONIC_FAST_TRACK=true
+INSPECTOR_REVERSE_PROXY_SETUP=${INSPECTOR_REVERSE_PROXY_SETUP}
 EOF
 
   if [ "$NODES_PLATFORM" == "libvirt" ] ; then

--- a/04_verify.sh
+++ b/04_verify.sh
@@ -224,6 +224,7 @@ EXPTD_V1ALPHA4_RS="cluster.x-k8s.io/provider:infrastructure-metal3:capm3-system:
   cluster.x-k8s.io/provider:control-plane-kubeadm:capi-webhook-system:1"
 BRIDGES="provisioning baremetal"
 EXPTD_CONTAINERS="httpd-infra registry vbmc sushy-tools"
+[[ $IRONIC_TLS_SETUP == "true" ]] && EXPTD_CONTAINERS="${EXPTD_CONTAINERS} httpd-reverse-proxy"
 
 FAILS=0
 BMO_RUN_LOCAL="${BMO_RUN_LOCAL:-false}"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -413,7 +413,7 @@ function init_minikube() {
 #
 function remove_ironic_containers() {
   #shellcheck disable=SC2015
-  for name in ipa-downloader vbmc sushy-tools httpd-infra; do
+  for name in ipa-downloader vbmc sushy-tools httpd-infra httpd-reverse-proxy; do
     sudo "${CONTAINER_RUNTIME}" ps | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" kill $name || true
     sudo "${CONTAINER_RUNTIME}" ps --all | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" rm $name -f || true
   done

--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -13,6 +13,7 @@
        - ironic-inspector
        - dnsmasq
        - httpd
+       - httpd-reverse-proxy
        - mariadb
        - ironic-endpoint-keepalived
        - ironic-log-watch


### PR DESCRIPTION
This PR adds an option to let Apache web server handle TLS on Ironic and Ironic-inspector side.
Related PRs: 
https://github.com/metal3-io/ironic-image/pull/230
https://github.com/metal3-io/baremetal-operator/pull/728
metal3-io/ironic-inspector-image#70