### PR TITLE
Fix indentation for the podman installation

### DIFF
--- a/vm-setup/roles/packages_installation/tasks/ubuntu_required_packages.yml
+++ b/vm-setup/roles/packages_installation/tasks/ubuntu_required_packages.yml
@@ -60,12 +60,12 @@
             name: podman
             state: present
 
-    - name: Registries configuration for podman
-      blockinfile:
-        path: /etc/containers/registries.conf
-        block: |
-            [registries.insecure]
-            registries = ['{{ REGISTRY }}']
+        - name: Registries configuration for podman
+          blockinfile:
+            path: /etc/containers/registries.conf
+            block: |
+                [registries.insecure]
+                registries = ['{{ REGISTRY }}']
       become: yes
       when: CONTAINER_RUNTIME == "podman"
 


### PR DESCRIPTION
Fix the indentation for `Registries configuration for podman` task in Ansible script.