### PR TITLE
Use remove_local_ironic script from BMO 

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -449,6 +449,10 @@ function start_management_cluster () {
 # -----------------------------
 
 clone_repos
+
+# Kill and remove the running ironic containers
+"$BMOPATH"/tools/remove_local_ironic.sh
+
 create_clouds_yaml
 if [ "${EPHEMERAL_CLUSTER}" != "tilt" ]; then
   start_management_cluster

--- a/cluster_cleanup.sh
+++ b/cluster_cleanup.sh
@@ -7,6 +7,10 @@ source lib/common.sh
 # Delete cluster
 if [ "${EPHEMERAL_CLUSTER}" == "kind" ]; then
   sudo su -l -c "kind delete cluster  || true" "${USER}"
+  # Kill and remove the running ironic containers
+  if [ -f "$BMOPATH/tools/remove_local_ironic.sh" ]; then
+    "$BMOPATH"/tools/remove_local_ironic.sh
+  fi
 fi
 
 if [ "${EPHEMERAL_CLUSTER}" == "minikube" ]; then

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -421,11 +421,11 @@ function init_minikube() {
 }
 
 #
-# Kill and remove the running ironic containers
+# Kill and remove the infra containers
 #
 function remove_ironic_containers() {
   #shellcheck disable=SC2015
-  for name in ipa-downloader ironic ironic-api ironic-conductor ironic-inspector ironic-endpoint-keepalived dnsmasq httpd mariadb vbmc sushy-tools httpd-infra ironic-log-watch ironic-inspector-log-watch; do
+  for name in ipa-downloader vbmc sushy-tools httpd-infra; do
     sudo "${CONTAINER_RUNTIME}" ps | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" kill $name || true
     sudo "${CONTAINER_RUNTIME}" ps --all | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" rm $name -f || true
   done

--- a/scripts/feature_tests/cleanup_env.sh
+++ b/scripts/feature_tests/cleanup_env.sh
@@ -18,10 +18,7 @@ source lib/ironic_basic_auth.sh
 ssh-keygen -f /home/"${USER}"/.ssh/known_hosts -R "${CLUSTER_APIENDPOINT_IP}"
 
 # Kill and remove the running ironic containers
-for name in ironic ironic-inspector ironic-endpoint-keepalived dnsmasq httpd mariadb ironic-log-watch ironic-inspector-log-watch; do
-  sudo "${CONTAINER_RUNTIME}" ps | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" kill $name
-  sudo "${CONTAINER_RUNTIME}" ps --all | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" rm $name -f
-done
+"$BMOPATH"/tools/remove_local_ironic.sh
 
 clusterctl delete --all -v5
 


### PR DESCRIPTION
Keeping the list of containers to be removed in BMO makes it simpler to maintain. 
This PR should go in after BMO PR# [729](https://github.com/metal3-io/baremetal-operator/pull/729) 