### PR TITLE
Add console=ttyS0 to kernel params

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -193,6 +193,10 @@ CACHEURL=http://$IRONIC_HOST/images
 IRONIC_FAST_TRACK=true
 EOF
 
+  if [ "$NODES_PLATFORM" == "libvirt" ] ; then
+    echo "IRONIC_KERNEL_PARAMS=console=ttyS0" | sudo tee -a "$IRONIC_DATA_DIR/ironic_bmo_configmap.env"
+  fi
+
   if [ "${EPHEMERAL_CLUSTER}" != "minikube" ]; then
     update_images
     ${RUN_LOCAL_IRONIC_SCRIPT}


### PR DESCRIPTION
In a virtual environment set console=ttyS0 so that the IPA
console can be logged for debugging.

To be used along with
https://github.com/metal3-io/ironic-image/pull/226