### PR TITLE
Fix centos minikube networking

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -418,6 +418,9 @@ function init_minikube() {
           --model virtio --source baremetal \
           --type network --config
     fi
+
+    # Restart libvirtd
+    sudo systemctl restart libvirtd
 }
 
 #


### PR DESCRIPTION
Not restarting libvirt is messing up minikube network. This PR makes sure minikube network is synced with libvirtd. 