### PR TITLE
Fix ownership/filenames for basic_auth

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -125,11 +125,13 @@ EOF
     fi
     if [ "${IRONIC_BASIC_AUTH}" == "true" ]; then
       sudo mkdir -p /opt/metal3/auth/ironic
+      sudo chown "$USER":"$USER" /opt/metal3/auth/ironic
       cp "${IRONIC_AUTH_DIR}ironic-username" /opt/metal3/auth/ironic/username
       cp "${IRONIC_AUTH_DIR}ironic-password" /opt/metal3/auth/ironic/password
       sudo mkdir -p /opt/metal3/auth/ironic-inspector
-      cp "${IRONIC_AUTH_DIR}ironic-inspector-username" /opt/metal3/auth/ironic-inspector/username
-      cp "${IRONIC_AUTH_DIR}ironic-inspector-password" /opt/metal3/auth/ironic-inspector/password
+      sudo chown "$USER":"$USER" /opt/metal3/auth/ironic-inspector
+      cp "${IRONIC_AUTH_DIR}ironic-username" /opt/metal3/auth/ironic-inspector/username
+      cp "${IRONIC_AUTH_DIR}ironic-password" /opt/metal3/auth/ironic-inspector/password
     fi
 
     export IRONIC_ENDPOINT=${IRONIC_URL}


### PR DESCRIPTION
The mkdir is done as root, but then we try to copy as $USER,
and also lib/ironic_basic_auth.sh doesn't create separate
files for inspector