### PR TITLE
Optimize selinux configuration

### DIFF
--- a/centos_install_requirements.sh
+++ b/centos_install_requirements.sh
@@ -7,7 +7,7 @@ source lib/logging.sh
 source lib/common.sh
 
 sudo dnf install -y libselinux-utils
-if selinuxenabled ; then
+if getenforce | grep Enforcing; then
     sudo setenforce permissive
     sudo sed -i "s/=enforcing/=permissive/g" /etc/selinux/config
 fi


### PR DESCRIPTION
selinuxenabled exits with 0 when selinux is in permissive or enforcing status.
when selinux is already in permissive status, we don't need to configure selinux

Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>