### PR TITLE
Fix bare variable evaluation deprecation issue

### DIFF
--- a/vm-setup/roles/libvirt/tasks/network_setup_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/network_setup_tasks.yml
@@ -22,7 +22,7 @@
     nodes: "{{ vm_nodes }}"
     networks: "{{ networks }}"
   register: node_mac_map
-  when: vm_nodes
+  when: vm_nodes | length > 0
 
 # Create the global, root-managed libvirt networks to which we will
 # attach the undercoud and vm virtual machines.

--- a/vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml
@@ -53,7 +53,7 @@
     autostart: "yes"
     uri: "{{ libvirt_uri }}"
 
-- when: vm_nodes
+- when: vm_nodes | length > 0
   environment:
     LIBVIRT_DEFAULT_URI: "{{ libvirt_uri }}"
   block:

--- a/vm-setup/roles/libvirt/tasks/vm_teardown_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/vm_teardown_tasks.yml
@@ -17,7 +17,7 @@
     LIBVIRT_DEFAULT_URI: "{{ libvirt_uri }}"
   block:
 
-    - when: vm_nodes
+    - when: vm_nodes | length > 0
       block:
 
         # Check if the vm nodes exist.


### PR DESCRIPTION
Fix the following warning:
  evaluating 'vm_nodes' as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS

Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>