### PR TITLE
Fix basic_aut credentials vars of inspector

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -130,8 +130,8 @@ EOF
       cp "${IRONIC_AUTH_DIR}ironic-password" /opt/metal3/auth/ironic/password
       sudo mkdir -p /opt/metal3/auth/ironic-inspector
       sudo chown "$USER":"$USER" /opt/metal3/auth/ironic-inspector
-      cp "${IRONIC_AUTH_DIR}ironic-username" /opt/metal3/auth/ironic-inspector/username
-      cp "${IRONIC_AUTH_DIR}ironic-password" /opt/metal3/auth/ironic-inspector/password
+      cp "${IRONIC_AUTH_DIR}${IRONIC_INSPECTOR_USERNAME}" /opt/metal3/auth/ironic-inspector/username
+      cp "${IRONIC_AUTH_DIR}${IRONIC_INSPECTOR_PASSWORD}" /opt/metal3/auth/ironic-inspector/password
     fi
 
     export IRONIC_ENDPOINT=${IRONIC_URL}


### PR DESCRIPTION
Currently we are moving `ironic-username` & `ironic-password` to /opt/metal3/auth/ironic-inspector directory. This is okay as long as user doesn't provide custom username/password for inspector. However, if `IRONIC_INSPECTOR_USERNAME` & `IRONIC_INSPECTOR_PASSWORD` are given by the user, then we will ignore the actual provided username/password and instead move `ironic-username` & `ironic-password`.
This PR adds `IRONIC_INSPECTOR_USERNAME` & `IRONIC_INSPECTOR_PASSWORD` in the mv command to make sure that we don't ignore user provided credentials.