### PR TITLE
Fix interface ironicendpoint is missing in centos

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_centos.rc
+++ b/vm-setup/roles/v1aX_integration_test/templates/clusterctl_env_template_centos.rc
@@ -30,6 +30,8 @@ export CTLPLANE_KUBEADM_EXTRA_CONFIG="
       sshAuthorizedKeys:
       - {{ SSH_PUB_KEY_CONTENT }}
     preKubeadmCommands:
+      - systemctl restart NetworkManager.service
+      - ifup eth0
 {% if CAPM3_VERSION == "v1alpha3" %}
       - ifup eth1
 {% endif %}
@@ -173,6 +175,8 @@ export WORKERS_KUBEADM_EXTRA_CONFIG="
         sshAuthorizedKeys:
         - {{ SSH_PUB_KEY_CONTENT }}
       preKubeadmCommands:
+        - systemctl restart NetworkManager.service
+        - ifup eth0
 {% if CAPM3_VERSION == "v1alpha3" %}
         - ifup eth1
 {% endif %}


### PR DESCRIPTION
This commit is to fix an issue that interface 'ironicendpoint' is missing in centos. With the fix, interface 'ironicendpoint' will appear and be UP automatically.