### PR TITLE
Prepull container images hosted in docker hub

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -100,7 +100,7 @@ else
       curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/"${KIND_VERSION}"/kind-"$(uname)"-amd64
       chmod +x ./kind
       sudo mv kind /usr/local/bin/.
-      sudo "${CONTAINER_RUNTIME}" pull kindest/node:"${KUBERNETES_VERSION}"
+      sudo "${CONTAINER_RUNTIME}" pull "${KIND_NODE_IMAGE}"
   fi
   if [ "${EPHEMERAL_CLUSTER}" == "tilt" ]; then
     curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
@@ -208,3 +208,12 @@ if [ "${EPHEMERAL_CLUSTER}" == "minikube" ]; then
   configure_minikube
   init_minikube
 fi
+
+# Download Calico images and other container images
+for container in $(env | grep "CALICO_*" | cut -f2 -d'='); do
+  sudo "${CONTAINER_RUNTIME}" pull "${container}"
+done
+
+for container in "${DOCKER_REGISTRY_IMAGE}" "${GOLANG_IMG}" "${CENTOS_IMG}"; do
+  sudo "${CONTAINER_RUNTIME}" pull "${container}"
+done

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -176,6 +176,27 @@ fi
 # IPAM controller image
 export IPAM_IMAGE=${IPAM_IMAGE:-"quay.io/metal3-io/ip-address-manager:master"}
 
+# fmuyassarov:(NOTE)
+# We are prepulling Kind node image while creating Jenkins CI image,
+# to avoid Docker hub pull rate limit issue. When CI runs
+# Kind cluster, the Kind image will be available to be used.
+export KIND_NODE_IMAGE=${KIND_NODE_IMAGE:-"kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab"}
+
+# fmuyassarov:(NOTE)
+# We need these variables in order to prepull
+# container images while building Jenkins CI image.
+export CALICO_CNI_IMG="${CALICO_CNI_IMG:-"docker.io/calico/cni:v3.17.1"}"
+export CALICO_POD2DAEMON_IMG="${CALICO_POD2DAEMON_IMG:-"docker.io/calico/pod2daemon-flexvol:v3.17.1"}"
+export CALICO_NODE_IMG="${CALICO_NODE_IMG:-"docker.io/calico/node:v3.17.1"}"
+export CALICO_KUBE_CONTROLLERS_IMG="${CALICO_NODE_IMG:-"docker.io/calico/kube-controllers:v3.17.1"}"
+# We need golang container image when runing CI jobs from BMO, CAPM3, IPAM, repositories,
+# while building container image
+export GOLANG_IMG="${GOLANG_IMG:-"registry.hub.docker.com/library/golang:1.15.3"}"
+# We need centos container image when runing CI jobs from
+# ironic-image and ironic-inspector-image repositories,
+# while building ironic container images.
+export CENTOS_IMG="${CENTOS_IMG:-"docker.io/centos:centos8"}"
+
 # Default hosts memory
 export DEFAULT_HOSTS_MEMORY=${DEFAULT_HOSTS_MEMORY:-4096}
 


### PR DESCRIPTION
In Nordix we are building Jenkins CI images on a daily bases. As part building those images we are running 01* script. This patch ensures that we download all the container images (hosted in Docker hub) needed during integration test in dev-env.
Fixes: https://github.com/metal3-io/project-infra/issues/166