### PR TITLE
Allow setting the lease expiry for DHCP

### DIFF
--- a/vm-setup/roles/common/defaults/main.yml
+++ b/vm-setup/roles/common/defaults/main.yml
@@ -64,6 +64,8 @@ networks:
     dhcp_range_v6:
       - "{{ virsh_dhcp_v6_start }}"
       - "{{ virsh_dhcp_v6_end }}"
+    # libvirt defaults to minutes as the unit
+    lease_expiry: 60
     nat_port_range:
       - 1024
       - 65535

--- a/vm-setup/roles/libvirt/templates/network.xml.j2
+++ b/vm-setup/roles/libvirt/templates/network.xml.j2
@@ -41,7 +41,9 @@
         {% set ironic_name = ironic_prefix + flavor + "_" + num|string %}
         {% set hostname_format = lookup('vars', flavor + '_hostname_format', default=flavor + '-%d') %}
         {% set hostname = hostname_format % num %}
-      <host mac='{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}' ip='{{item.dhcp_range_v4[0]|ipmath(ns.index|int)}}'/>
+      <host mac='{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}' ip='{{item.dhcp_range_v4[0]|ipmath(ns.index|int)}}'>
+        <lease expiry='{{ item.lease_expiry }}'/>
+      </host>
         {% set ns.index = ns.index + 1 %}
       {% endfor %}
     {% endfor %}
@@ -88,7 +90,9 @@
         {% set ironic_name = ironic_prefix + flavor + "_" + num|string %}
         {% set hostname_format = lookup('vars', flavor + '_hostname_format', default=flavor + '-%d') %}
         {% set hostname = hostname_format % num %}
-        <host id='00:03:00:01:{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}' ip='{{item.dhcp_range_v6[0]|ipmath(ns.index|int)}}'/>
+        <host id='00:03:00:01:{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}' ip='{{item.dhcp_range_v6[0]|ipmath(ns.index|int)}}'>
+          <lease expiry='{{ item.lease_expiry }}'/>
+        </host>
         {% set ns.index = ns.index + 1 %}
       {% endfor %}
     {% endfor %}


### PR DESCRIPTION
Newer versions of libvirt (6.3.0 and up) allow the lease expiry to
be set for hosts. We have some functionality that depends on using
infinite leases, so we would like to be able to set this through
metal3-dev-env.