### PR TITLE
Add verify action during post pivot action

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -102,7 +102,8 @@ verify_actions:
     - "ci_test_provision"
     - "feature_test_provisioning"
     - "pivoting"
-    - "upgrading"  
+    - "upgrading"
+    - "post_pivot"
 pivot_actions:
     - "ci_test_provision"
     - "pivoting"    


### PR DESCRIPTION
Post_Pivot action is not calling verify actions. As a result, CNI is not
getting installed if post_pivot is called outside CI workflow. This PR
fixes this bug.