### PR TITLE
Modify default_vcpu and use minimum resources in metal3-dev-env

### DIFF
--- a/vm-setup/roles/common/defaults/main.yml
+++ b/vm-setup/roles/common/defaults/main.yml
@@ -10,7 +10,7 @@ libvirt_nic_model: virtio
 # overrides configured.
 default_disk: 50
 default_memory: 8192
-default_vcpu: 4
+default_vcpu: 2
 num_nodes: 2
 extradisks: false
 virtualbmc_base_port: 6230


### PR DESCRIPTION
We are using` default_vcpu= 4` for each BMH(control plane and worker) in metal3-dev-env. This PR will edit the `default_vcpu=2` to limit the use of the resources.