### PR TITLE
Fix openshift python package to 0.11.2

### DIFF
--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -43,7 +43,7 @@ packages:
         - libssl-dev
     pip3:
      - python-apt
-     - openshift
+     - openshift==0.11.2
      - pyYAML
      - virtualbmc
      - lxml

--- a/vm-setup/roles/v1aX_integration_test/tasks/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Install openshift client in CentOS 8 using pip3
   pip:
     executable: "pip3"
-    name: openshift
+    name: openshift==0.11.2
     state: present
   become: yes
   become_user: root


### PR DESCRIPTION
With the lastes openshift python package to 0.12.0 the tests are
failing. This is a temporary fix.

One such failure is reported here: https://jenkins.nordix.org/view/Airship/job/airship_master_v1a4_integration_test_ubuntu/461/consoleFull 

```
Failed to get client due to 404\nReason: Not Found\nHTTP response headers: HTTPHeaderDict({'Date': 'Mon, 01 Mar 2021 02:02:16 GMT', 'Server': 'Apache', 'Content-Length': '196', 'Content-Type': 'text/html; charset=iso-8859-1'})\nHTTP response body: b'<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\\n<html><head>\\n<title>404 Not Found</title>\\n</head><body>\\n<h1>Not Found</h1>\\n<p>The requested URL was not found on this server.</p>\\n</body></html>\\n'\nOriginal traceback: \n  File \"/usr/local/lib/python3.8/dist-packages/openshift/dynamic/client.py\", line 42, in inner\n    resp = func(self, *args, **kwargs)\n\n  File \"/usr/local/lib/python3.8/dist-packages/openshift/dynamic/client.py\", line 235, in request\n    return self.client.call_api(\n\n  File \"/usr/local/lib/python3.8/dist-packages/kubernetes/client/api_client.py\", line 348, in call_api\n    return self.__call_api(resource_path, method,\n\n  File \"/usr/local/lib/python3.8/dist-packages/kubernetes/client/api_client.py\", line 180, in __call_api\n    response_data = self.request(\n\n  File \"/usr/local/lib/python3.8/dist-packages/kubernetes/client/api_client.py\", line 373, in request\n    return self.rest_client.GET(url,\n\n  File \"/usr/local/lib/python3.8/dist-packages/kubernetes/client/rest.py\", line 239, in GET\n    return self.request(\"GET\", url,\n\n  File \"/usr/local/lib/python3.8/dist-packages/kubernetes/client/rest.py\", line 233, in request\n    raise ApiException(http_resp=r)\n"[0m
[0;31m}[0m
```