### PR TITLE
Bump sushy-tools and allow to ignore boot device

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -2,6 +2,6 @@ FROM registry.hub.docker.com/library/python:3.9
 
 RUN apt update && \
     apt install -y libvirt-dev && \
-    pip3 install sushy-tools==0.14.0 libvirt-python
+    pip3 install sushy-tools==0.15.0 libvirt-python
 
 CMD sushy-emulator -i :: -p 8000 --config /root/sushy/conf.py

--- a/vm-setup/roles/virtbmc/defaults/main.yml
+++ b/vm-setup/roles/virtbmc/defaults/main.yml
@@ -1,2 +1,3 @@
 # Can be set to "teardown" to destroy a previous configuration
 virtbmc_action: setup
+sushy_ignore_boot_device: False

--- a/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
+++ b/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
@@ -96,4 +96,5 @@
     dest: "{{ working_dir }}/virtualbmc/sushy-tools/conf.py"
     content: |
       SUSHY_EMULATOR_LIBVIRT_URI = "{{ vbmc_libvirt_uri }}"
+      SUSHY_EMULATOR_IGNORE_BOOT_DEVICE = "{{ sushy_ignore_boot_device }}"
   become: true


### PR DESCRIPTION
The latest release adds a variable that allows us to test setting
the boot device via efibootmgr, when combined with the live-iso
disk format this can be used to install e.g using the Fedora
CoreOS iso.

https://review.opendev.org/c/openstack/releases/+/778023
https://review.opendev.org/c/openstack/sushy-tools/+/776660