### PR TITLE
Using a better lower-bound version for jinja2 to make sure behavior is right

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -27,7 +27,7 @@ else
   sudo alternatives --set python /usr/bin/python3
 fi
 
-sudo pip3 install ansible
+sudo pip3 install ansible "jinja2>=2.10"
 
 # NOTE(fmuyassarov) Make sure to source before runnig install-package-playbook.yml
 # because there are some vars exported in network.sh and used by


### PR DESCRIPTION
Jinja2 namespaces were introduced in 2.10, hence not available on older versions.