### PR TITLE
Revert Bump sushy-tools and allow to ignore boot device to fix CI

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -2,6 +2,6 @@ FROM registry.hub.docker.com/library/python:3.9
 
 RUN apt update && \
     apt install -y libvirt-dev && \
-    pip3 install sushy-tools==0.15.0 libvirt-python
+    pip3 install sushy-tools==0.14.0 libvirt-python
 
 CMD sushy-emulator -i :: -p 8000 --config /root/sushy/conf.py

--- a/vm-setup/roles/virtbmc/defaults/main.yml
+++ b/vm-setup/roles/virtbmc/defaults/main.yml
@@ -1,3 +1,2 @@
 # Can be set to "teardown" to destroy a previous configuration
 virtbmc_action: setup
-sushy_ignore_boot_device: False

--- a/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
+++ b/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
@@ -96,5 +96,4 @@
     dest: "{{ working_dir }}/virtualbmc/sushy-tools/conf.py"
     content: |
       SUSHY_EMULATOR_LIBVIRT_URI = "{{ vbmc_libvirt_uri }}"
-      SUSHY_EMULATOR_IGNORE_BOOT_DEVICE = "{{ sushy_ignore_boot_device }}"
   become: true


### PR DESCRIPTION
This is a revert of #606 

We are struggling deprovision the BMH with redfish as follows:
```
`NAMESPACE   NAME     STATUS   STATE            CONSUMER                   BMC
                                                    HARDWARE_PROFILE   ONLINE   ERROR
metal3      node-0   OK       ready                                       ipmi://192.168.111.1:6230
                                                    unknown            true
metal3      node-1   OK       deprovisioning   test1-controlplane-22rcl   redfish+http://192.168.111.1:8000/redfis
h/v1/Systems/2cd7ddb7-956c-4664-b8cc-b19b37952fb6   unknown            false
`
```

Ironic always hangs in `clean_wait `state for node-1:
```
`baremetal node list
+--------------------------------------+--------+---------------+-------------+--------------------+-------------+
| UUID                                 | Name   | Instance UUID | Power State | Provisioning State | Maintenance |
+--------------------------------------+--------+---------------+-------------+--------------------+-------------+
| 217f36ed-3d37-4e23-8bea-8f2da8e5ab22 | node-0 | None          | power on    | manageable         | False       |
| 29e8e3a9-bc1f-4472-a668-e83a06e28c43 | node-1 | None          | power on    | clean wait         | False       |
+--------------------------------------+--------+---------------+-------------+--------------------+-------------+
`
```