### PR TITLE
Support NUM_NODES=0 metal3 deployments

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -252,7 +252,7 @@ function make_bm_hosts() {
 function apply_bm_hosts() {
   pushd "${BMOPATH}"
   list_nodes | make_bm_hosts > "${WORKING_DIR}/bmhosts_crs.yaml"
-  if [ "${EPHEMERAL_CLUSTER}" != "tilt" ]; then
+  if [[ -n "$(list_nodes)" ]]; then
     kubectl apply -f "${WORKING_DIR}/bmhosts_crs.yaml" -n metal3
   fi
   popd

--- a/04_verify.sh
+++ b/04_verify.sh
@@ -281,11 +281,13 @@ process_status $?
 echo ""
 
 ## Verify
-while read -r name address user password mac; do
-  iterate check_bm_hosts "${name}" "${address}" "${user}" \
-    "${password}" "${mac}"
-  echo ""
-done <<< "$(list_nodes)"
+if [[ -n "$(list_nodes)" ]]; then
+  while read -r name address user password mac; do
+    iterate check_bm_hosts "${name}" "${address}" "${user}" \
+      "${password}" "${mac}"
+    echo ""
+  done <<< "$(list_nodes)"
+fi
 
 # Verify that the operator are running locally
 if [[ "${BMO_RUN_LOCAL}" == true ]]; then

--- a/vm-setup/roles/common/tasks/main.yml
+++ b/vm-setup/roles/common/tasks/main.yml
@@ -3,7 +3,12 @@
 - set_fact:
     generate_vm_nodes: "{{vm_nodes is not defined}}"
 
-- name: Define vm_nodes if not already defined
+- name: Set an empty default for vm_nodes if not already defined
+  set_fact:
+    vm_nodes: []
+  when: generate_vm_nodes
+
+- name: Populate vm_nodes if not already defined
   when: generate_vm_nodes
   include_tasks: vm_nodes_tasks.yml
   loop: "{{flavors|dict2items}}"

--- a/vm-setup/roles/common/tasks/vm_nodes_tasks.yml
+++ b/vm-setup/roles/common/tasks/vm_nodes_tasks.yml
@@ -5,7 +5,7 @@
 - set_fact:
     vm_nodes_index: "{{vm_nodes_index|default(0)|int}}"
 - set_fact:
-    vm_nodes: "{{vm_nodes|default([]) + [
+    vm_nodes: "{{vm_nodes + [
                  {'name': ironic_prefix + '%s_%s'|format(flavor.key, item),
                   'flavor': flavor.key,
                   'virtualbmc_port': virtualbmc_base_port|int+vm_nodes_index|int+item} ]}}"


### PR DESCRIPTION
This change allows NUM_NODES=0 to deploy Metal3 with no virtual machines acting as bare metal hosts. 

Prior to this change, NUM_NODES=0 would error during the 02 script while doing vm-setup (vm_nodes undefined).