### PR TITLE
Parameterize CAPI maxSurge field

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -31,6 +31,14 @@
 #
 #export SSH_PUB_KEY=~/.ssh/id_rsa.pub
 
+# Set the controlplane replica count
+#export NUM_OF_MASTER_REPLICAS=1
+
+# This variable defines if controlplane should scale-in or scale-out during upgrade
+# The field values can be 0 or 1. Default is 1. When set to 1 controlplane scale-out
+# When set to 0 controlplane scale-in. In case of scale-in NUM_OF_MASTER_REPLICAS must be >=3. 
+# export MAX_SURGE_VALUE=1
+
 #
 # Select the Container Runtime, can be "podman" or "docker"
 # Defaults to "podman"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -141,6 +141,7 @@ export NUM_OF_MASTER_REPLICAS="${NUM_OF_MASTER_REPLICAS:-"1"}"
 export NUM_OF_WORKER_REPLICAS="${NUM_OF_WORKER_REPLICAS:-"1"}"
 export VM_EXTRADISKS=${VM_EXTRADISKS:-"false"}
 export NODE_DRAIN_TIMEOUT=${NODE_DRAIN_TIMEOUT:-"0s"}
+export MAX_SURGE_VALUE="${MAX_SURGE_VALUE:-"1"}"
 
 # Docker registry for local images
 export DOCKER_REGISTRY_IMAGE=${DOCKER_REGISTRY_IMAGE:-"docker.io/registry:latest"}

--- a/vars.md
+++ b/vars.md
@@ -9,6 +9,8 @@ assured that they are persisted.
 
 | Name | Option | Allowed values | Default |
 | :------ | :------- | :--------------- | :-------- |
+| NUM_OF_MASTER_REPLICAS | Set the controlplane replica count. ||1| 
+| MAX_SURGE_VALUE | This variable defines if controlplane should scale-in or scale-out during upgrade. | 0 (scale-in) or 1 (scale-out) |1| 
 | EPHEMERAL_CLUSTER | Tool for running management/ephemeral cluster. | minikube, kind, tilt | Ubuntu default is kind. Only minikube is supported on CentOS |
 | EXTERNAL_SUBNET                | This is the subnet used on the "baremetal" libvirt network, created as the primary network interface for the virtual bare metalhosts.                                                                                                                    | CIDR                               | 192.168.111.0/24                                             |
 | SSH_PUB_KEY                    | This SSH key will be automatically injected into the provisioned host by the clusterctl environment template files.                                                                                                                                                   |                           | ~/.ssh/id_rsa.pub                                            |

--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
@@ -4,8 +4,11 @@ metadata:
   name: ${ CLUSTER_NAME }
   namespace: ${ NAMESPACE }
 spec:
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: ${ MAX_SURGE_VALUE }
   nodeDrainTimeout: ${ NODE_DRAIN_TIMEOUT }
-  replicas: ${ CONTROL_PLANE_MACHINE_COUNT }
+  replicas: ${ NUM_OF_MASTER_REPLICAS }
   version: ${ KUBERNETES_VERSION }
   infrastructureTemplate:
     kind: Metal3MachineTemplate

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -18,6 +18,7 @@ BMOPATH: "{{ lookup('env', 'BMOPATH') }}"
 IRONIC_DATA_DIR: "{{ lookup('env', 'IRONIC_DATA_DIR') }}"
 KUBECONFIG_PATH: "/home/ubuntu/.kube/config"
 KUBERNETES_VERSION: "{{ lookup('env', 'KUBERNETES_VERSION') | default('v1.20.4', true) }}"
+MAX_SURGE_VALUE: "{{ lookup('env', 'MAX_SURGE_VALUE') | default('1', true) }}"
 
 KUBERNETES_BINARIES_VERSION: "{{ lookup('env', 'KUBERNETES_BINARIES_VERSION') | default(lookup('env', 'KUBERNETES_VERSION') | default('v1.18.0', true), true) }}"
 KUBERNETES_BINARIES_CONFIG_VERSION: "{{ lookup('env', 'KUBERNETES_BINARIES_CONFIG_VERSION') | default('v0.2.7', true) }}"


### PR DESCRIPTION
The Cluster API control plane now allows for scaling in [4293](https://github.com/kubernetes-sigs/cluster-api/pull/4293#event-4525955116). Documentation can be found [rolling-update-strategy](https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/proposals/20191017-kubeadm-based-control-plane.md#rolling-update-strategy)
This PR parameterizes the required metal3_dev_env fields and adds a new environment variable MAX_SURGE_VALUE.