### PR TITLE
Remove undeclared WORKER_MACHINE_COUNT variable

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
@@ -8,7 +8,7 @@ metadata:
     nodepool: nodepool-0
 spec:
   clusterName: ${ CLUSTER_NAME }
-  replicas: ${ WORKER_MACHINE_COUNT }
+  replicas: ${ NUM_OF_WORKER_REPLICAS }
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: ${ CLUSTER_NAME }


### PR DESCRIPTION
Metal3 dev-env uses undeclared WORKER_MACHINE_COUNT variable in cluster-template-workers.yaml This PR replaces WORKER_MACHINE_COUNT with defined and defaulted NUM_OF_WORKER_REPLICAS.