### PR TITLE
replace curl with wget to download images.

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -151,7 +151,7 @@ mkdir -p "$IRONIC_IMAGE_DIR"
 pushd "$IRONIC_IMAGE_DIR"
 
 if [ ! -f "${IMAGE_NAME}" ] ; then
-    curl -f --insecure --compressed -O -L "${IMAGE_LOCATION}/${IMAGE_NAME}"
+    wget --no-verbose --no-check-certificate "${IMAGE_LOCATION}/${IMAGE_NAME}"
     IMAGE_SUFFIX="${IMAGE_NAME##*.}"
     if [ "${IMAGE_SUFFIX}" == "xz" ] ; then
       unxz -v "${IMAGE_NAME}"


### PR DESCRIPTION
There is at least one artifact (https://artifactory.nordix.org/artifactory/airship/images/k8s_v1.20.4/CENTOS_8.2_NODE_IMAGE_K8S_v1.20.4.qcow2) that failed to download completely with curl due to artifactory.nordix.org closes the connection after downloading approx. 1GB. wget retries in this case and resumes the download.

Fixes #624 