### PR TITLE
Add python3 jmespath package installation

### DIFF
--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -85,7 +85,8 @@ packages:
          - python3-six
          - httpd-tools
         pip3:
-          - jmespath
+         - jmespath
+
 DAEMON_JSON_PATH: "{{ metal3_dir }}/vm-setup/roles/packages_installation/files"
 CONTAINER_RUNTIME: "{{ lookup('env', 'CONTAINER_RUNTIME') }}"
 OS_VERSION_ID: "{{ lookup('env', 'OS_VERSION_ID') }}"

--- a/vm-setup/roles/packages_installation/tasks/main.yml
+++ b/vm-setup/roles/packages_installation/tasks/main.yml
@@ -37,6 +37,11 @@
       package:
           name: "{{ packages.centos.rhel8.packages }}"
           state: present
+    - name: Install packages on CentOS/RHEL8 using pip3
+      pip:
+          executable: "pip3"
+          name: "{{ packages.centos.rhel8.pip3 }}"
+          state: present
     - name: Perform CentOS/RHEL8 required configurations
       include: centos_required_packages.yml
     - name: Install packages using pip3


### PR DESCRIPTION
This PR install python3 jmespath package. This Package installation is in progress in [623](https://github.com/metal3-io/metal3-dev-env/pull/623) but we should install package to be able to create new integration tests without waiting to 623 to be merged first. 