### PR TITLE
Remove libvirtd restart in init_minikube

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -403,9 +403,6 @@ function init_minikube() {
           --model virtio --source baremetal \
           --type network --config
     fi
-
-    # Restart libvirtd
-    sudo systemctl restart libvirtd
 }
 
 #


### PR DESCRIPTION
This libvirtd restart shouldn't be needed after minikube network configuration. Removing the libvirtd restart will also avoid a timeout issue in minikube itself.