### PR TITLE
🐛 Fix the issue that tripleo-repo requires a stream version of OS to run properly. 

### DIFF
--- a/resources/vbmc/Dockerfile
+++ b/resources/vbmc/Dockerfile
@@ -1,11 +1,11 @@
 FROM docker.io/centos:centos8
 
 RUN dnf install -y python3 python3-requests python3-pip && \
-    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current && \
-    dnf update -y && \
-    dnf install -y python3-virtualbmc && \
-    dnf clean all && \
-    rm -rf /var/cache/{yum,dnf}/*
+     curl https://raw.githubusercontent.com/openstack/tripleo-repos/0543f7664a6d2b2a24b21164a9256e75b886becb/tripleo_repos/main.py | python3 - -b master current && \
+     dnf update -y && \
+     dnf install -y python3-virtualbmc && \
+     dnf clean all && \
+     rm -rf /var/cache/{yum,dnf}/*
 
 # NOTE(dtantsur): work around old pyghmi in RDO; this operation will become
 # no-op once RDO is updated.


### PR DESCRIPTION
This temporary fix the issue `__main__.InvalidArguments: --stream provided, but OS is not the Stream version. Please ensure the host is Stream.` in Dockerfile of vbmc