### PR TITLE
🐛 A proper fix for the Centos stream issue that tripleo-repo requires a stream version of OS to run properly

### DIFF
--- a/resources/vbmc/Dockerfile
+++ b/resources/vbmc/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/centos:centos8
 
 RUN dnf install -y python3 python3-requests python3-pip && \
-     curl https://raw.githubusercontent.com/openstack/tripleo-repos/0543f7664a6d2b2a24b21164a9256e75b886becb/tripleo_repos/main.py | python3 - -b master current && \
+     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current-tripleo --no-stream && \
      dnf update -y && \
      dnf install -y python3-virtualbmc && \
      dnf clean all && \


### PR DESCRIPTION
This fix is a replacement for the temporary fix in https://github.com/metal3-io/metal3-dev-env/pull/636


