### PR TITLE
Pin Minikube version to v1.18.1

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -72,13 +72,13 @@ fi
 
 if [ "${EPHEMERAL_CLUSTER}" == "minikube" ]; then
   if ! command -v minikube 2>/dev/null ; then
-      curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+      curl -Lo minikube https://storage.googleapis.com/minikube/releases/"${MINIKUBE_VERSION}"/minikube-linux-amd64
       chmod +x minikube
       sudo mv minikube /usr/local/bin/.
   fi
 
   if ! command -v docker-machine-driver-kvm2 2>/dev/null ; then
-      curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2
+      curl -LO https://storage.googleapis.com/minikube/releases/"${MINIKUBE_VERSION}"/docker-machine-driver-kvm2
       chmod +x docker-machine-driver-kvm2
       sudo mv docker-machine-driver-kvm2 /usr/local/bin/.
   fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -198,9 +198,12 @@ fi
 # Kustomize version
 export KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-"v3.8.5"}
 
-# Kind version
+# Kind version (if EPHEMERAL_CLUSTER=kind)
 export KIND_VERSION=${KIND_VERSION:-"v0.10.0"}
 export KIND_NODE_IMAGE_VERSION=${KIND_NODE_IMAGE_VERSION:-"v1.20.2"}
+
+# Minikube version (if EPHEMERAL_CLUSTER=minikube)
+export MINIKUBE_VERSION=${MINIKUBE_VERSION:-"v1.18.1"}
 
 # Test and verification related variables
 SKIP_RETRIES="${SKIP_RETRIES:-false}"


### PR DESCRIPTION
There's a flaky issue with getting an IP address in v1.19.0 which is still under investigation. By pinning the minikube version (like we pin the kind version), we'll make the master CentOS builds more reliable until the root cause of the issue can be found.