### PR TITLE
Make ipv4 hostname the fqdn

### DIFF
--- a/vm-setup/roles/libvirt/templates/network.xml.j2
+++ b/vm-setup/roles/libvirt/templates/network.xml.j2
@@ -41,7 +41,11 @@
         {% set ironic_name = ironic_prefix + flavor + "_" + num|string %}
         {% set hostname_format = lookup('vars', flavor + '_hostname_format', default=flavor + '-%d') %}
         {% set hostname = hostname_format % num %}
+  {% if item.domain is defined %}
+      <host mac='{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}.{{item.domain}}' ip='{{item.dhcp_range_v4[0]|ipmath(ns.index|int)}}'/>
+  {% else %}
       <host mac='{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}' ip='{{item.dhcp_range_v4[0]|ipmath(ns.index|int)}}'/>
+  {% endif %}
         {% set ns.index = ns.index + 1 %}
       {% endfor %}
     {% endfor %}


### PR DESCRIPTION
Otherwise we end up with inconsistent inspection results from IPA in
dual-stack environments, initially the hostname is the shortname
provided via the ipv4 lease, then later it's updated to the FQDN
provided via ipv6.

To ensure consistent behavior, append the domain so the ipv4 host_name
option contains the FQDN.