### PR TITLE
Update docs and comments to accurately describe defaults

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -12,7 +12,7 @@
 # v6   -- IPv6
 # v4v6 -- dual-stack IPv4+IPv6
 #
-#export IP_STACK=v6
+#export IP_STACK=v4
 
 #
 # This is the subnet used on the "baremetal" libvirt network, created as the
@@ -37,11 +37,11 @@
 # This variable defines if controlplane should scale-in or scale-out during upgrade
 # The field values can be 0 or 1. Default is 1. When set to 1 controlplane scale-out
 # When set to 0 controlplane scale-in. In case of scale-in NUM_OF_MASTER_REPLICAS must be >=3. 
-# export MAX_SURGE_VALUE=1
+#export MAX_SURGE_VALUE=1
 
 #
 # Select the Container Runtime, can be "podman" or "docker"
-# Defaults to "podman"
+# Defaults to "docker" on ubuntu and "podman" otherwise
 #
 #export CONTAINER_RUNTIME="podman"
 
@@ -117,19 +117,19 @@
 #export KUBERNETES_BINARIES_CONFIG_VERSION="v0.2.7"
 
 # Configure provisioning network for single-stack ipv6
-#PROVISIONING_IPV6=false
+#export PROVISIONING_IPV6=false
 
 # Image OS (can be "Cirros", "Ubuntu", "Centos", overriden by IMAGE_* if set)
-#
-#export IMAGE_OS="Cirros"
+# Default: Centos
+#export IMAGE_OS="Centos"
 
 # Image for target hosts deployment
 #
-#export IMAGE_NAME="cirros-0.5.1-x86_64-disk.img"
+#export IMAGE_NAME="CENTOS_8.2_NODE_IMAGE_K8S_v1.20.4.qcow2"
 
 # Location of the image to download
 #
-#export IMAGE_LOCATION="http://download.cirros-cloud.net/0.5.1"
+#export IMAGE_LOCATION="https://artifactory.nordix.org/artifactory/airship/images/k8s_v1.20.4"
 
 # Image username for ssh
 #
@@ -137,7 +137,7 @@
 
 # Container image for ironic pod
 #
-# export IRONIC_IMAGE="quay.io/metal3-io/ironic"
+#export IRONIC_IMAGE="quay.io/metal3-io/ironic"
 
 # Container image for vbmc container
 #
@@ -154,22 +154,23 @@
 #export CLUSTER_PROVISIONING_INTERFACE="ironicendpoint"
 
 # POD CIDR
-# export POD_CIDR=${POD_CIDR:-"192.168.0.0/18"
+#export POD_CIDR=${POD_CIDR:-"192.168.0.0/18"}
 
 # Node hostname format. This is a format string that must contain exactly one
 # %d format field that will be replaced with an integer representing the number
 # of the node.
-# export NODE_HOSTNAME_FORMAT="node-%d"
+#export NODE_HOSTNAME_FORMAT="node-%d"
 
 # Ephemeral cluster used as management cluster for cluster API
 # (can be "kind", "minikube" or "tilt"). Only "minikube" is supported with
 # CentOS
 # Selecting "tilt" does not deploy a management cluster, it is left up to the
 # user
-# export EPHEMERAL_CLUSTER=minikube
+# Default is "kind" when CONTAINER_RUNTIME="docker", otherwise it is "minikube"
+#export EPHEMERAL_CLUSTER=minikube
 
 # Secure Ironic deployment with TLS ("true" or "false")
-# export IRONIC_TLS_SETUP="true"
+#export IRONIC_TLS_SETUP="true"
 
 # Set nodeDrainTimeout for controlplane and worker template, otherwise default value will be  '0s'. 
 #

--- a/vars.md
+++ b/vars.md
@@ -12,59 +12,59 @@ assured that they are persisted.
 | NUM_OF_MASTER_REPLICAS | Set the controlplane replica count. ||1| 
 | MAX_SURGE_VALUE | This variable defines if controlplane should scale-in or scale-out during upgrade. | 0 (scale-in) or 1 (scale-out) |1| 
 | EPHEMERAL_CLUSTER | Tool for running management/ephemeral cluster. | minikube, kind, tilt | Ubuntu default is kind. Only minikube is supported on CentOS |
-| EXTERNAL_SUBNET                | This is the subnet used on the "baremetal" libvirt network, created as the primary network interface for the virtual bare metalhosts.                                                                                                                    | CIDR                               | 192.168.111.0/24                                             |
-| SSH_PUB_KEY                    | This SSH key will be automatically injected into the provisioned host by the clusterctl environment template files.                                                                                                                                                   |                           | ~/.ssh/id_rsa.pub                                            |
-| CONTAINER_RUNTIME              | Select the Container Runtime                                                                                                                                                                                                                             | "docker", "podman"                   | "podman"                                                     |
-| BMOREPO                        | Set the Baremetal Operator repository to clone                                                                                                                                                                                                           |                                 | https://github.com/metal3-io/baremetal-operator.git          |
-| BMOBRANCH                      | Set the Baremetal Operator branch to checkout                                                                                                                                                                                                            |                                      | master                                                       |
-| CAPM3REPO                      | Set the Cluster Api Metal3 provider repository to clone                                                                                                                                                                                                  |                                | https://github.com/metal3-io/cluster-api-provider-metal3.git |
-| CAPM3BRANCH                    | Set the Cluster Api Metal3 provider branch to checkout                                                                                                                                                                                                   |                                      | master                                                       |
-| FORCE_REPO_UPDATE              | Force deletion of the BMO and CAPM3 repositories before cloning them again                                                                                                                                                                               | "true", "false"                      | "false"                                                      |
-| BMO_RUN_LOCAL                  | Run a local baremetal operator instead of deploying in Kubernetes                                                                                                                                                                                        | "true", "false"                      | "false"                                                      |
-| CAPM3_RUN_LOCAL                | Run a local CAPM3 operator instead of deploying in Kubernetes                                                                                                                                                                                             | "true", "false"                      | "false"                                                      |
-| SKIP_RETRIES                   | Do not retry on failure during verifications or tests of the environment. This should be false. It could only be set to false for verifications of a dev env deployment that fully completed. Otherwise failures will appear as resources are not ready. | "true", "false"                      | "false"                                                      |
-| TEST_TIME_INTERVAL             | Interval between retries after verification or test failure (seconds)                                                                                                                                                                                    |                                 | 10                                                           |
-| TEST_MAX_TIME                  | Number of maximum verification or test retries                                                                                                                                                                                                           |                                 | 120                                                          |
-| BMC_DRIVER                     | Set the BMC driver                                                                                                                                                                                                                                       | "ipmi", "redfish"                    | "mixed"                                                       |
-| IMAGE_OS                       | OS of the image to boot the nodes from, overriden by IMAGE\_\* if set                                                                                                                                                                                    | "Centos", "Cirros", "FCOS", "Ubuntu" | "Centos"                                                     |
-| IMAGE_NAME                     | Image for target hosts deployment                                                                                                                                                                                                                        |                                      | "CENTOS_8.2_NODE_IMAGE_K8S_v1.19.3.qcow2"                    |
-| IMAGE_LOCATION                 | Location of the image to download                                                                                                                                                                                                                        |                                 | https://artifactory.nordix.org/artifactory/airship/images/k8s_v1.19.3/                     |
-| IMAGE_USERNAME                 | Image username for ssh                                                                                                                                                                                                                                   |                                      | "metal3"                                                     |
-| IRONIC_IMAGE                   | Container image for local ironic services                                                                                                                                                                                                                |                                      | "quay.io/metal3-io/ironic"                                   |
-| VBMC_IMAGE                     | Container image for vbmc container                                                                                                                                                                                                                       |                                      | "quay.io/metal3-io/vbmc"                                     |
-| SUSHY_TOOLS_IMAGE              | Container image for sushy-tools container                                                                                                                                                                                                                |                                      | "quay.io/metal3-io/sushy-tools"                              |
-| CAPM3_VERSION                   | Version of Cluster API provider Metal3                                                                                                                                                                                                                                | "v1alpha3", "v1alpha4"   | "v1alpha4"                                                   |
-| CAPI_VERSION                   | Version of Cluster API                                                                                                                                                                                                                                | "v1alpha3" | "v1alpha3"                                                   |
-| CLUSTER_APIENDPOINT_IP         | API endpoint IP for target cluster                                                                                                                                                                                                                        | "x.x.x.x/x"                          | "192.168.111.249"                                            |
-| CLUSTER_PROVISIONING_INTERFACE | Cluster provisioning Interface                                                                                                                                                                                                                           | "ironicendpoint"                     | "ironicendpoint"                                             |
-| POD_CIDR                       | Pod CIDR                                                                                                                                                                                                                                                 | "x.x.x.x/x"                          | "192.168.0.0/18"                                             |
-| KUBERNETES_VERSION                       | Kubernetes version                                                                                                                                                                                                                                                 | "x.x.x"                          | "1.20.4"                                             |
-| KUBERNETES_BINARIES_VERSION                       | Version of kubelet, kubeadm and kubectl                                                                                                                                                                                                                                                 | "x.x.x-xx" or "x.x.x"                          | same as KUBERNETES_VERSION                                             |
-| KUBERNETES_BINARIES_CONFIG_VERSION                       | Version of kubelet.service and 10-kubeadm.conf files                                                                                                                                                                                                                                                 | "vx.x.x"                          | "v0.2.7"                                             |
-| NUM_NODES                | Set the number of virtual machines to be provisioned. This VMs will be further configured as control-plane or worker Nodes      |   | 2 |
-| VM_EXTRADISKS            | Add extra disks to the virtual machines provisioned. By default the size of the extra disk is set in the libvirt Ansible role to 8 GB        | "true", "false" | "false" |
-| DEFAULT_HOSTS_MEMORY     | Set the default memory size in MB for the virtual machines provisioned.        |  | 4096 |
-| CLUSTER_NAME             | Set the name of the target cluster |  | test1 |
+| EXTERNAL_SUBNET | This is the subnet used on the "baremetal" libvirt network, created as the primary network interface for the virtual bare metalhosts. | CIDR | 192.168.111.0/24 |
+| SSH_PUB_KEY | This SSH key will be automatically injected into the provisioned host by the clusterctl environment template files. | | ~/.ssh/id_rsa.pub |
+| CONTAINER_RUNTIME | Select the Container Runtime | "docker", "podman" | "podman" |
+| BMOREPO | Set the Baremetal Operator repository to clone | | https://github.com/metal3-io/baremetal-operator.git |
+| BMOBRANCH | Set the Baremetal Operator branch to checkout | | master |
+| CAPM3REPO | Set the Cluster Api Metal3 provider repository to clone | | https://github.com/metal3-io/cluster-api-provider-metal3.git |
+| CAPM3BRANCH | Set the Cluster Api Metal3 provider branch to checkout | | master |
+| FORCE_REPO_UPDATE | Force deletion of the BMO and CAPM3 repositories before cloning them again | "true", "false" | "false" |
+| BMO_RUN_LOCAL | Run a local baremetal operator instead of deploying in Kubernetes | "true", "false" | "false" |
+| CAPM3_RUN_LOCAL | Run a local CAPM3 operator instead of deploying in Kubernetes | "true", "false" | "false" |
+| SKIP_RETRIES | Do not retry on failure during verifications or tests of the environment. This should be false. It could only be set to false for verifications of a dev env deployment that fully completed. Otherwise failures will appear as resources are not ready. | "true", "false" | "false" |
+| TEST_TIME_INTERVAL | Interval between retries after verification or test failure (seconds) | | 10 |
+| TEST_MAX_TIME | Number of maximum verification or test retries | | 120 |
+| BMC_DRIVER | Set the BMC driver | "ipmi", "redfish" | "mixed" |
+| IMAGE_OS | OS of the image to boot the nodes from, overriden by IMAGE\_\* if set | "Centos", "Cirros", "FCOS", "Ubuntu" | "Centos" |
+| IMAGE_NAME | Image for target hosts deployment | | "CENTOS_8.2_NODE_IMAGE_K8S_v1.19.3.qcow2" |
+| IMAGE_LOCATION | Location of the image to download | | https://artifactory.nordix.org/artifactory/airship/images/k8s_v1.19.3/ |
+| IMAGE_USERNAME | Image username for ssh | | "metal3" |
+| IRONIC_IMAGE | Container image for local ironic services | | "quay.io/metal3-io/ironic" |
+| VBMC_IMAGE | Container image for vbmc container | | "quay.io/metal3-io/vbmc" |
+| SUSHY_TOOLS_IMAGE | Container image for sushy-tools container | | "quay.io/metal3-io/sushy-tools" |
+| CAPM3_VERSION | Version of Cluster API provider Metal3 | "v1alpha3", "v1alpha4" | "v1alpha4" |
+| CAPI_VERSION | Version of Cluster API | "v1alpha3" | "v1alpha3" |
+| CLUSTER_APIENDPOINT_IP | API endpoint IP for target cluster | "x.x.x.x/x" | "192.168.111.249" |
+| CLUSTER_PROVISIONING_INTERFACE | Cluster provisioning Interface | "ironicendpoint" | "ironicendpoint" |
+| POD_CIDR | Pod CIDR | "x.x.x.x/x" | "192.168.0.0/18" |
+| KUBERNETES_VERSION | Kubernetes version | "x.x.x" | "1.20.4" |
+| KUBERNETES_BINARIES_VERSION | Version of kubelet, kubeadm and kubectl | "x.x.x-xx" or "x.x.x" | same as KUBERNETES_VERSION |
+| KUBERNETES_BINARIES_CONFIG_VERSION | Version of kubelet.service and 10-kubeadm.conf files | "vx.x.x" | "v0.2.7" |
+| NUM_NODES | Set the number of virtual machines to be provisioned. This VMs will be further configured as control-plane or worker Nodes | | 2 |
+| VM_EXTRADISKS | Add extra disks to the virtual machines provisioned. By default the size of the extra disk is set in the libvirt Ansible role to 8 GB | "true", "false" | "false" |
+| DEFAULT_HOSTS_MEMORY | Set the default memory size in MB for the virtual machines provisioned. | | 4096 |
+| CLUSTER_NAME | Set the name of the target cluster | | test1 |
 | IRONIC_TLS_SETUP | Enable TLS for Ironic and inspector | "true", "false" | "true" |
 | IRONIC_BASIC_AUTH | Enable HTTP basic authentication for Ironic and inspector | "true", "false" | "true" |
-| IRONIC_CA_CERT_B64 | Base 64 encoded CA certificate of Ironic |  |   |
-| IRONIC_CACERT_FILE | Path to the CA certificate of Ironic |  | /opt/metal3-dev-env/certs/ironic-ca.pem |
-| IRONIC_INSPECTOR_CACERT_FILE | Path to the CA certificate of Ironic inspector |  | /opt/metal3-dev-env/certs/ironic-ca.pem |
-| IRONIC_CAKEY_FILE | Path to the CA key of Ironic |  | /opt/metal3-dev-env/certs/ironic-ca.key |
-| IRONIC_INSPECTOR_CAKEY_FILE | Path to the CA key of Ironic inspector |  | /opt/metal3-dev-env/certs/ironic-ca.key |
-| IRONIC_CERT_FILE | Path to the certificate of Ironic |  | /opt/metal3-dev-env/certs/ironic.crt |
-| IRONIC_INSPECTOR_CERT_FILE | Path to the CA certificate of Ironic inspector |  | /opt/metal3-dev-env/certs/ironic-inspector.crt |
-| IRONIC_KEY_FILE | Path to the certificate key of Ironic |  | /opt/metal3-dev-env/certs/ironic.key |
-| IRONIC_INSPECTOR_KEY_FILE | Path to the certificate key of Ironic inspector |  | /opt/metal3-dev-env/certs/ironic-inspector.key |
-| IRONIC_USERNAME | Username for Ironic basic auth |  |  |
-| IRONIC_INSPECTOR_USERNAME | Username for Ironic inspector basic auth |  |  |
-| IRONIC_PASSWORD | Password for Ironic basic auth |  |  |
-| IRONIC_INSPECTOR_PASSWORD | Password for Ironic inspector basic auth |  |  |
-| REGISTRY_PORT | Container image registry port |  | 5000 |
-| HTTP_PORT | Httpd server port |  | 6180 |
-| IRONIC_INSPECTOR_PORT | Ironic Inspector port |  | 5050 |
-| IRONIC_API_PORT | Ironic Api port |  | 6385 |
-| NODE_DRAIN_TIMEOUT | Set the nodeDrainTimeout for controlplane and worker template |  | '0s' |
+| IRONIC_CA_CERT_B64 | Base 64 encoded CA certificate of Ironic | | |
+| IRONIC_CACERT_FILE | Path to the CA certificate of Ironic | | /opt/metal3-dev-env/certs/ironic-ca.pem |
+| IRONIC_INSPECTOR_CACERT_FILE | Path to the CA certificate of Ironic inspector | | /opt/metal3-dev-env/certs/ironic-ca.pem |
+| IRONIC_CAKEY_FILE | Path to the CA key of Ironic | | /opt/metal3-dev-env/certs/ironic-ca.key |
+| IRONIC_INSPECTOR_CAKEY_FILE | Path to the CA key of Ironic inspector | | /opt/metal3-dev-env/certs/ironic-ca.key |
+| IRONIC_CERT_FILE | Path to the certificate of Ironic | | /opt/metal3-dev-env/certs/ironic.crt |
+| IRONIC_INSPECTOR_CERT_FILE | Path to the CA certificate of Ironic inspector | | /opt/metal3-dev-env/certs/ironic-inspector.crt |
+| IRONIC_KEY_FILE | Path to the certificate key of Ironic | | /opt/metal3-dev-env/certs/ironic.key |
+| IRONIC_INSPECTOR_KEY_FILE | Path to the certificate key of Ironic inspector | | /opt/metal3-dev-env/certs/ironic-inspector.key |
+| IRONIC_USERNAME | Username for Ironic basic auth | | |
+| IRONIC_INSPECTOR_USERNAME | Username for Ironic inspector basic auth | | |
+| IRONIC_PASSWORD | Password for Ironic basic auth | | |
+| IRONIC_INSPECTOR_PASSWORD | Password for Ironic inspector basic auth | | |
+| REGISTRY_PORT | Container image registry port | | 5000 |
+| HTTP_PORT | Httpd server port | | 6180 |
+| IRONIC_INSPECTOR_PORT | Ironic Inspector port | | 5050 |
+| IRONIC_API_PORT | Ironic Api port | | 6385 |
+| NODE_DRAIN_TIMEOUT | Set the nodeDrainTimeout for controlplane and worker template | | '0s' |
 | MARIADB_KEY_FILE | Path to the key of MariaDB | | /opt/metal3-dev-env/certs/mariadb.key |
 | MARIADB_CERT_FILE | Path to the cert of MariaDB | | /opt/metal3-dev-env/certs/mariadb.crt |
 | MARIADB_CAKEY_FILE | Path to the CA key of MariaDB | | /opt/metal3-dev-env/certs/ironic-ca.key |

--- a/vars.md
+++ b/vars.md
@@ -11,10 +11,13 @@ assured that they are persisted.
 | :------ | :------- | :--------------- | :-------- |
 | NUM_OF_MASTER_REPLICAS | Set the controlplane replica count. ||1| 
 | MAX_SURGE_VALUE | This variable defines if controlplane should scale-in or scale-out during upgrade. | 0 (scale-in) or 1 (scale-out) |1| 
-| EPHEMERAL_CLUSTER | Tool for running management/ephemeral cluster. | minikube, kind, tilt | Ubuntu default is kind. Only minikube is supported on CentOS |
-| EXTERNAL_SUBNET | This is the subnet used on the "baremetal" libvirt network, created as the primary network interface for the virtual bare metalhosts. | CIDR | 192.168.111.0/24 |
+| EPHEMERAL_CLUSTER | Tool for running management/ephemeral cluster. | minikube, kind, tilt | "kind" when using docker as the container runtime (the default on Ubuntu), "minikube" otherwise |
+| IP_STACK | Choose whether the "baremetal" libvirt network will use IPv4, IPv6, or IPv4+IPv6. This network is the primary network interface for the virtual bare metal hosts. <br/> Note that this only sets up the underlying network, and fully provisioning IPv6 kubernetes clusters is not yet automated. If IPv6 is enabled, DHCPv6 will be available to the virtual bare metal hosts. | "v4", "v6", "v4v6" (dual-stack)) | v4 |
+| EXTERNAL_SUBNET_V4 | When using IPv4 stack, this is the subnet used on the "baremetal" libvirt network, created as the primary network interface for the virtual bare metalhosts. | IPv4 CIDR | 192.168.111.0/24 |
+| EXTERNAL_SUBNET_V6 | When using IPv6 stack, this is the subnet used on the "baremetal" libvirt network, created as the primary network interface for the virtual bare metalhosts. | IPv6 CIDR | 192.168.111.0/24 |
+| PROVISIONING_IPV6 | Configure provisioning network for single-stack ipv6 | "true", "false" | false |
 | SSH_PUB_KEY | This SSH key will be automatically injected into the provisioned host by the clusterctl environment template files. | | ~/.ssh/id_rsa.pub |
-| CONTAINER_RUNTIME | Select the Container Runtime | "docker", "podman" | "podman" |
+| CONTAINER_RUNTIME | Select the Container Runtime | "docker", "podman" | "docker" on ubuntu, "podman" otherwise |
 | BMOREPO | Set the Baremetal Operator repository to clone | | https://github.com/metal3-io/baremetal-operator.git |
 | BMOBRANCH | Set the Baremetal Operator branch to checkout | | master |
 | CAPM3REPO | Set the Cluster Api Metal3 provider repository to clone | | https://github.com/metal3-io/cluster-api-provider-metal3.git |
@@ -38,6 +41,7 @@ assured that they are persisted.
 | CLUSTER_APIENDPOINT_IP | API endpoint IP for target cluster | "x.x.x.x/x" | "192.168.111.249" |
 | CLUSTER_PROVISIONING_INTERFACE | Cluster provisioning Interface | "ironicendpoint" | "ironicendpoint" |
 | POD_CIDR | Pod CIDR | "x.x.x.x/x" | "192.168.0.0/18" |
+| NODE_HOSTNAME_FORMAT | Node hostname format. This is a format string that must contain exactly one %d format field that will be replaced with an integer representing the number of the node. | "node-%d" |
 | KUBERNETES_VERSION | Kubernetes version | "x.x.x" | "1.20.4" |
 | KUBERNETES_BINARIES_VERSION | Version of kubelet, kubeadm and kubectl | "x.x.x-xx" or "x.x.x" | same as KUBERNETES_VERSION |
 | KUBERNETES_BINARIES_CONFIG_VERSION | Version of kubelet.service and 10-kubeadm.conf files | "vx.x.x" | "v0.2.7" |


### PR DESCRIPTION
This PR updates the `vars.md` doc and comments in `config_example.sh` to more accurately describe default values which are assumed by other scripts.

Note that I have decided to remove spacing which made the `vars.md` columns aligned in markdown. It was not kept up to date anyway, and with some rows being very wide it decreased readability in my opinion. But naturally I'm open to doing it another way.

The non-whitespace changes in `vars.md` are as follows:
```diff
$ diff <(git show origin/master:vars.md | sed 's/\s\s*/ /g') <(git show origin/update/docs-about-variable-defaults-wgslr:vars.md)
14,15c14,18
< | EPHEMERAL_CLUSTER | Tool for running management/ephemeral cluster. | minikube, kind, tilt | Ubuntu default is kind. Only minikube is supported on CentOS |
< | EXTERNAL_SUBNET | This is the subnet used on the "baremetal" libvirt network, created as the primary network interface for the virtual bare metalhosts. | CIDR | 192.168.111.0/24 |
---
> | EPHEMERAL_CLUSTER | Tool for running management/ephemeral cluster. | minikube, kind, tilt | "kind" when using docker as container (the default on Ubuntu), "minikube" otherwise |
> | IP_STACK | Choose whether the "baremetal" libvirt network will use IPv4, IPv6, or IPv4+IPv6. This network is the primary network interface for the virtual bare metal hosts. <br/> Note that this only sets up the underlying network, and fully provisioning IPv6 kubernetes clusters is not yet automated. If IPv6 is enabled, DHCPv6 will be available to the virtual bare metal hosts. | "v4", "v6", "v4v6" (dual-stack)) | v4 |
> | EXTERNAL_SUBNET_V4 | When using IPv4 stack, this is the subnet used on the "baremetal" libvirt network, created as the primary network interface for the virtual bare metalhosts. | IPv4 CIDR | 192.168.111.0/24 |
> | EXTERNAL_SUBNET_V6 | When using IPv6 stack, this is the subnet used on the "baremetal" libvirt network, created as the primary network interface for the virtual bare metalhosts. | IPv6 CIDR | 192.168.111.0/24 |
> | PROVISIONING_IPV6 | Configure provisioning network for single-stack ipv6 | "true", "false" | false |
17c20
< | CONTAINER_RUNTIME | Select the Container Runtime | "docker", "podman" | "podman" |
---
> | CONTAINER_RUNTIME | Select the Container Runtime | "docker", "podman" | "docker" on ubuntu, "podman" otherwise |
40a44
> | NODE_HOSTNAME_FORMAT | Node hostname format. This is a format string that must contain exactly one %d format field that will be replaced with an integer representing the number of the node. | "node-%d" |
```

I will squash the commits after the review.