### PR TITLE
Tidy Calico config in integration test verify

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
@@ -62,7 +62,7 @@
                       - name: IP_AUTODETECTION_METHOD
                         value: "interface=enp2s0"
     when:
-      ansible_distribution == "Ubuntu"
+      IMAGE_OS == "Ubuntu"
 
   - name: Add IP_AUTODETECTION_METHOD in calico config Centos
     blockinfile:
@@ -73,7 +73,7 @@
                       - name: IP_AUTODETECTION_METHOD
                         value: "interface=eth1"
     when:
-      ansible_distribution == "CentOS"
+      IMAGE_OS == "Centos"
 
   - name: Apply Calico manifest
     k8s:

--- a/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
@@ -72,8 +72,6 @@
           # for indentation
                       - name: IP_AUTODETECTION_METHOD
                         value: "interface=eth1"
-                      - name: FELIX_IPTABLESBACKEND
-                        value: "NFT"
     when:
       ansible_distribution == "CentOS"
 


### PR DESCRIPTION
Two minor fixes:
1. Use `IMAGE_OS` instead of `ansible_distribution` to determine the OS. The Calico config is applied on the target node, so we want the OS of the node, not the host where Ansible is running.
2. As of Calico v3.18.1, `FELIX_IPTABLESBACKEND` defaults to 'auto', which automatically determines if a host is using netfilter.