### PR TITLE
Deprecate network-scripts package in Centos/RHEL

### DIFF
--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -80,7 +80,6 @@ packages:
          - polkit-pkla-compat
          - python3-netaddr
          - virt-install
-         - network-scripts
          - firewalld
          - python3-six
          - httpd-tools


### PR DESCRIPTION
The `network-scripts` package will be removed in future Centos/RHEL releases. NetworkManager should have support for ifup/ifdown scripts.