### PR TITLE
Add kashifest as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,9 +7,9 @@ approvers:
  - russellb
  - stbenjam
  - fmuyassarov
+ - kashifest
 
 reviewers:
- - kashifest
  - jan-est
  - xenwar
  - Jaakko-Os


### PR DESCRIPTION
Following our email discussion, adding @kashifest as approver in metal3-dev-env.
/cc @dhellmann @hardys @russellb @stbenjam @maelk 