### PR TITLE
Modify ironic deployment name and namespace from pivoting and upgrading.

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -160,6 +160,7 @@ export IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironi
 export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
 export IRONIC_IMAGE_DIR="$IRONIC_DATA_DIR/html/images"
 export IRONIC_KEEPALIVED_IMAGE=${IRONIC_KEEPALIVED_IMAGE:-"quay.io/metal3-io/keepalived"}
+export IRONIC_NAMESPACE=${IRONIC_NAMESPACE:-"capm3-system"}
 # Enable ironic restart feature when the TLS certificate is updated
 export RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-${IRONIC_TLS_SETUP}}
 

--- a/scripts/feature_tests/cleanup_env.sh
+++ b/scripts/feature_tests/cleanup_env.sh
@@ -22,7 +22,7 @@ if [ "${EPHEMERAL_CLUSTER}" == "kind" ]; then
   "$BMOPATH"/tools/remove_local_ironic.sh
 else 
   # Scale down ironic
-  kubectl scale deploy -n "${NAMESPACE}" metal3-ironic --replicas=0
+  kubectl scale deploy -n "${IRONIC_NAMESPACE}" capm3-ironic --replicas=0
 fi
 
 clusterctl delete --all -v5
@@ -67,7 +67,7 @@ if [ "${EPHEMERAL_CLUSTER}" == "kind" ]; then
   popd || exit
 else 
   # Scale up ironic
-  kubectl scale deploy -n "${NAMESPACE}" metal3-ironic --replicas=1
+  kubectl scale deploy -n "${IRONIC_NAMESPACE}" capm3-ironic --replicas=1
 fi
 
 

--- a/scripts/feature_tests/upgrade/upgrade_vars.sh
+++ b/scripts/feature_tests/upgrade/upgrade_vars.sh
@@ -9,8 +9,8 @@ export CAPIRELEASE_HARDCODED="v0.3.8"
 export CAPM3RELEASE="v0.4.0"
 export CAPM3_REL_TO_VERSION="v0.4.1"
 
-export CAPIRELEASE="v0.3.12"
-export CAPI_REL_TO_VERSION="v0.3.14"
+export CAPIRELEASE="v0.3.15"
+export CAPI_REL_TO_VERSION="v0.3.16"
 
 export CAPI_API_VERSION="v1alpha3"
 export CAPM3_API_VERSION="v1alpha4"

--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -21,12 +21,12 @@
     become_user: root
     when: EPHEMERAL_CLUSTER == "kind"
 
-  - name: Remove Ironic from from source cluster (Ephemeral Cluster is minikube)
+  - name: Remove Ironic from source cluster (Ephemeral Cluster is minikube)
     k8s:
-      name: metal3-ironic
+      name: capm3-ironic
       kind: Deployment
       state: absent
-      namespace: "{{ NAMESPACE }}"
+      namespace: "{{ IRONIC_NAMESPACE }}"
     when: EPHEMERAL_CLUSTER == "minikube"
 
   - name: Label BMO CRDs.
@@ -69,7 +69,7 @@
     shell: "kubectl get pods -n cert-manager -o json | jq -r '.items[].status.phase' | grep -cv Running"
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    retries: 150 
+    retries: 20 
     delay: 20
     register: target_running_pods
     until: target_running_pods.stdout|int == 0

--- a/vm-setup/roles/v1aX_integration_test/tasks/move_back.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move_back.yml
@@ -3,10 +3,10 @@
   # Remove Ironic from target cluster
   - name: Remove Ironic from target cluster
     k8s:
-      name: metal3-ironic
+      name: capm3-ironic
       kind: Deployment
       state: absent
-      namespace: "{{ NAMESPACE }}"
+      namespace: "{{ IRONIC_NAMESPACE }}"
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
 
   - name: Install Ironic in Source cluster (Ephemeral Cluster is kind)

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -214,16 +214,16 @@
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
 #                       Upgrade Ironic                                                  |
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
-  - name: Scale down metal3-ironic deployment
+  - name: Scale down capm3-ironic deployment
     shell: |
-            kubectl scale deploy metal3-ironic -n {{NAMESPACE}} --replicas 0
+            kubectl scale deploy capm3-ironic -n {{IRONIC_NAMESPACE}} --replicas 0
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
     ignore_errors: yes
 
   - name: Count running ironic pods
     shell: |
-            kubectl get pods -n {{NAMESPACE}} | grep -c metal3-ironic 
+            kubectl get pods -n {{IRONIC_NAMESPACE}} | grep -c capm3-ironic
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
     retries: 200
@@ -234,7 +234,7 @@
 
   - name: Upgrade ironic image based containers 
     shell: |
-            kubectl set image deployments metal3-ironic {{item}}=quay.io/metal3-io/ironic:{{IRONIC_IMAGE_TAG}} -n {{NAMESPACE}}
+            kubectl set image deployments capm3-ironic {{item}}=quay.io/metal3-io/ironic:{{IRONIC_IMAGE_TAG}} -n {{IRONIC_NAMESPACE}}
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
     loop:
@@ -246,7 +246,7 @@
 
   - name: Upgrade ironic-inspector image based containers 
     shell: |
-            kubectl set image deployments metal3-ironic {{item}}=quay.io/metal3-io/ironic-inspector:{{IRONIC_IMAGE_TAG}} -n {{NAMESPACE}}
+            kubectl set image deployments capm3-ironic {{item}}=quay.io/metal3-io/ironic-inspector:{{IRONIC_IMAGE_TAG}} -n {{IRONIC_NAMESPACE}}
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
     loop:
@@ -254,15 +254,15 @@
       - httpd-reverse-proxy
       - ironic-inspector-log-watch
         
-  - name: Scale up metal3-ironic deployment
+  - name: Scale up capm3-ironic deployment
     shell: |
-            kubectl scale deploy metal3-ironic -n {{NAMESPACE}} --replicas 1
+            kubectl scale deploy capm3-ironic -n {{IRONIC_NAMESPACE}} --replicas 1
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"        
 
   - name: Count running ironic pods, only upgraded pod should exist
     shell: |
-            kubectl get pods -n {{NAMESPACE}} | grep -c metal3-ironic
+            kubectl get pods -n {{IRONIC_NAMESPACE}} | grep -c capm3-ironic
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
     retries: 100
@@ -273,7 +273,7 @@
 
   - name: Count number of upgraded ironic containers
     shell: |
-            kubectl get deployments metal3-ironic -n {{NAMESPACE}} -o json |
+            kubectl get deployments capm3-ironic -n {{IRONIC_NAMESPACE}} -o json |
             jq '.spec.template.spec.containers[].image' |
             grep -c "{{IRONIC_IMAGE_TAG}}"
     environment:
@@ -283,8 +283,8 @@
 
   - name: Count running upgraded ironic containers
     shell: |
-            ironic_pod_name=$(kubectl get pods -n {{NAMESPACE}} -o name| grep metal3-ironic | cut -f2 -d/)
-            kubectl get pods -n {{NAMESPACE}} ${ironic_pod_name}  -o json |
+            ironic_pod_name=$(kubectl get pods -n {{IRONIC_NAMESPACE}} -o name| grep capm3-ironic | cut -f2 -d/)
+            kubectl get pods -n {{IRONIC_NAMESPACE}} ${ironic_pod_name}  -o json |
             jq '.status.containerStatuses[]| select(.ready==true)|.name' | wc -l
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -2,6 +2,7 @@
 # Ansible playbook related variables
 HOME: "{{ lookup('env', 'HOME') }}"
 NAMESPACE: "{{ lookup('env', 'NAMESPACE') | default('metal3', true) }}"
+IRONIC_NAMESPACE: "{{ lookup('env', 'IRONIC_NAMESPACE') | default('capm3-system', true) }}"
 CRS_PATH: "{{ metal3_dir }}/vm-setup/roles/v1aX_integration_test/templates"
 TEMP_GEN_DIR: "{{ metal3_dir }}/vm-setup/roles/v1aX_integration_test/files/manifests"
 MANIFESTS_DIR: "{{ metal3_dir }}/vm-setup/roles/v1aX_integration_test/files"


### PR DESCRIPTION
This PR will change the ironic deployment name and namespace.  [Ironic-deployment PR](https://github.com/metal3-io/baremetal-operator/pull/859) is introducing cert-manager setup for ironic deployment where namespace is changed from `metal3` to `capm3-system` and deployment name is also changed from `metal3-ironic` to `capm3-ironic`. So this PR needs to go in first and after that we will be able to run [Ironic-deployment PR](https://github.com/metal3-io/baremetal-operator/pull/859). 

Also [capm3 PR](https://github.com/metal3-io/cluster-api-provider-metal3/pull/199) needs to go in with this PR.