### PR TITLE
Allow non-verified HTTPS sources for virtualmedia

### DIFF
--- a/vm-setup/roles/virtbmc/defaults/main.yml
+++ b/vm-setup/roles/virtbmc/defaults/main.yml
@@ -1,3 +1,4 @@
 # Can be set to "teardown" to destroy a previous configuration
 virtbmc_action: setup
 sushy_ignore_boot_device: False
+sushy_vmedia_verify_ssl: True

--- a/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
+++ b/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
@@ -97,4 +97,5 @@
     content: |
       SUSHY_EMULATOR_LIBVIRT_URI = "{{ vbmc_libvirt_uri }}"
       SUSHY_EMULATOR_IGNORE_BOOT_DEVICE = {{ sushy_ignore_boot_device }}
+      SUSHY_EMULATOR_VMEDIA_VERIFY_SSL = {{ sushy_vmedia_verify_ssl }}
   become: true


### PR DESCRIPTION
A new sushy-tools configuration option has been
added to enable the emulator to insert media served
over HTTPS without verification.

https://github.com/openstack/sushy-tools/commit/b6542f6e8ef805773c63db974ce51b5be588903f

This PR allows the configuration option

SUSHY_EMULATOR_VMEDIA_VERIFY_SSL

to be set in the virtbmc role.

Signed-off-by: Richard Su <rwsu@redhat.com>