### PR TITLE
Fetch the manifests even when the verification fails

### DIFF
--- a/04_verify.sh
+++ b/04_verify.sh
@@ -311,4 +311,5 @@ done
 
 
 echo -e "\nNumber of failures : $FAILS"
+. "$(dirname "$(readlink -f "${0}")")"/scripts/fetch_manifests.sh
 exit "${FAILS}"


### PR DESCRIPTION
Currently, the manifests of objects can be fetched only when the CI passes the verification step in script 04_verify.sh. This PR aims to take the manifests even if the CI cannot pass that step.