### PR TITLE
Refactor some usage of shell into native kubernetes modules + small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _clouds_yaml
 
 *.swp
 ipv6-*/
+vm-setup/roles/v1aX_integration_test/files/manifests

--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -118,8 +118,6 @@ function install_clusterctl() {
   curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/"${CAPIRELEASE}"/clusterctl-linux-amd64 -o clusterctl
   chmod +x ./clusterctl
   sudo mv ./clusterctl /usr/local/bin/clusterctl
-  mkdir -p home/"${USER}"/.cluster-api
-  touch home/"${USER}"/.cluster-api/version.yaml
 }
 
 if ! [ -x "$(command -v clusterctl)" ]; then

--- a/vm-setup/roles/firewall/tasks/main.yml
+++ b/vm-setup/roles/firewall/tasks/main.yml
@@ -1,10 +1,13 @@
 - name: "firewalld"
-  include: firewalld.yaml
-  become: true
+  include_tasks: firewalld.yaml
+  args:
+    apply:
+      become: true
   when: use_firewalld
 
 - name: "iptables"
-  include: iptables.yaml
-  become: true
+  include_tasks: iptables.yaml
+  args:
+    apply:
+      become: true
   when: not use_firewalld
-

--- a/vm-setup/roles/libvirt/tasks/network_teardown_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/network_teardown_tasks.yml
@@ -14,14 +14,15 @@
   with_items: "{{ networks }}"
   become: true
 
+# TODO: Replace with ansible community.general.nmcli?
 - name: Delete bridges and veth interfaces on Ubuntu
   shell: |
      sudo ip link set baremetal down
      sudo ip link set provisioning down
      sudo ip link set ironicendpoint down
-     brctl delbr baremetal | true
-     brctl delbr provisioning | true
-     sudo ip link del ironicendpoint | true
+     brctl delbr baremetal || true
+     brctl delbr provisioning || true
+     sudo ip link del ironicendpoint || true
 
   when:
     - ansible_distribution == 'Ubuntu'

--- a/vm-setup/roles/packages_installation/tasks/main.yml
+++ b/vm-setup/roles/packages_installation/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Install packages on Ubuntu
   block:
     - name: Install required packages for Ubuntu
-      include: ubuntu_required_packages.yml
+      include_tasks: ubuntu_required_packages.yml
     - name: Install common packages using standard package manager for Ubuntu
       package:
         name: "{{ packages.ubuntu.common.packages}}"
@@ -38,7 +38,7 @@
           name: "{{ packages.centos.rhel8.packages }}"
           state: present
     - name: Perform CentOS/RHEL8 required configurations
-      include: centos_required_packages.yml
+      include_tasks: centos_required_packages.yml
     - name: Install packages using pip3
       pip:
         executable: "pip3"

--- a/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
@@ -23,52 +23,74 @@
           (IMAGE_OS == "")
 
   - name: Check if cluster deprovisioning started.
-    shell: "kubectl get cluster -n {{ NAMESPACE }} -o json | jq -r '.items[] | .status.phase'"
+    k8s_info:
+      # TODO: This should be set based on CAPI_VERSION when v1alpha4 is working.
+      api_version: cluster.x-k8s.io/v1alpha3
+      kind: Cluster
+      namespace: "{{ NAMESPACE }}"
     register: deprovision_cluster
     retries: 2
     delay: 20
-    until: (deprovision_cluster.stdout == "deleting") or
-           (deprovision_cluster.stdout == "Deleting") or
-           (deprovision_cluster.stdout == "")
+    until: (deprovision_cluster is succeeded) and (
+             (deprovision_cluster.resources | length == 0) or
+             (deprovision_cluster.resources[0].status.phase | lower == "deleting"))
 
   - name: Wait until "{{ NUM_NODES }}" bmhs become ready again.
-    shell: |
-        kubectl get bmh -n {{ NAMESPACE }} -o json | jq -r '[ .items[]
-        | select (.status.provisioning.state == "ready")
-        | .metadata.name ] | length'
+    k8s_info:
+      api_version: metal3.io/v1alpha1
+      kind: BareMetalHost
+      namespace: "{{ NAMESPACE }}"
     register: deprovisioned_nodes
     retries: 150
     delay: 10
-    until: deprovisioned_nodes.stdout ==  NUM_NODES
+    vars:
+      query: "[? status.provisioning.state=='ready'].status.provisioning.state"
+    until: (deprovisioned_nodes is succeeded) and
+           (deprovisioned_nodes.resources | length > 0) and
+           (deprovisioned_nodes.resources | json_query(query) | length == (NUM_NODES | int))
 
   - name: Wait until no metal3machines are remaining
-    shell: |
-        kubectl get metal3machine -n {{ NAMESPACE }} -o json | jq -r '[ .items[] ] | length'
+    k8s_info:
+      api_version: infrastructure.cluster.x-k8s.io/{{ CAPM3_VERSION }}
+      kind: Metal3Machine
+      namespace: "{{ NAMESPACE }}"
     register: deprovisioned_m3m
     retries: 150
     delay: 3
-    until: deprovisioned_m3m.stdout ==  "0"
+    until: (deprovisioned_m3m is succeeded) and
+           (deprovisioned_m3m.resources | length == 0)
 
   - name: Wait until no machines are remaining
-    shell: |
-        kubectl get machine -n {{ NAMESPACE }} -o json | jq -r '[ .items[] ] | length'
+    k8s_info:
+      # TODO: This should be set based on CAPI_VERSION when v1alpha4 is working.
+      api_version: cluster.x-k8s.io/v1alpha3
+      kind: Machine
+      namespace: "{{ NAMESPACE }}"
     register: deprovisioned_machines
     retries: 150
     delay: 3
-    until: deprovisioned_machines.stdout ==  "0"
+    until: (deprovisioned_machines is succeeded) and
+           (deprovisioned_machines.resources | length == 0)
 
   - name: Wait until no metal3cluster is remaining
-    shell: |
-        kubectl get metal3cluster -n {{ NAMESPACE }} -o json | jq -r '[ .items[] ] | length'
+    k8s_info:
+      api_version: infrastructure.cluster.x-k8s.io/{{ CAPM3_VERSION }}
+      kind: Metal3Cluster
+      namespace: "{{ NAMESPACE }}"
     register: deprovisioned_metal3cluster
     retries: 150
     delay: 3
-    until: deprovisioned_metal3cluster.stdout ==  "0"
+    until: (deprovisioned_metal3cluster is succeeded) and
+           (deprovisioned_metal3cluster.resources | length ==  0)
 
   - name: Wait until no cluster is remaining
-    shell: |
-        kubectl get cluster -n {{ NAMESPACE }} -o json | jq -r '[ .items[] ] | length'
+    k8s_info:
+      # TODO: This should be set based on CAPI_VERSION when v1alpha4 is working.
+      api_version: cluster.x-k8s.io/v1alpha3
+      kind: Cluster
+      namespace: "{{ NAMESPACE }}"
     register: deprovisioned_cluster
     retries: 150
     delay: 3
-    until: deprovisioned_cluster.stdout ==  "0"
+    until: (deprovisioned_cluster is succeeded) and
+           (deprovisioned_cluster.resources | length ==  0)

--- a/vm-setup/roles/v1aX_integration_test/tasks/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/main.yml
@@ -9,14 +9,14 @@
   when: ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == '8'
 
 - name: Generate templates
-  include: generate_templates.yml
+  include_tasks: generate_templates.yml
 
 - name: Download image for deployment
-  include: download_image.yml
+  include_tasks: download_image.yml
   when: v1aX_integration_test_action in image_download_actions
 
 - name: Test inspection API
-  include: inspection.yml
+  include_tasks: inspection.yml
   when: v1aX_integration_test_action in inspection_action
 
 - name: Provision cluster
@@ -41,23 +41,23 @@
   when: v1aX_integration_test_action in provision_workers_actions
 
 - name: verify deployment
-  include: verify.yml
+  include_tasks: verify.yml
   when: v1aX_integration_test_action in verify_actions
 
 - name: pivot
-  include: move.yml
+  include_tasks: move.yml
   when: v1aX_integration_test_action in pivot_actions
 
 - name: Upgrade cluster
-  include: upgrade.yml
+  include_tasks: upgrade.yml
   when: v1aX_integration_test_action == "upgrading"
 
 - name: post pivot operations
-  include: post_pivot.yml
+  include_tasks: post_pivot.yml
   when: v1aX_integration_test_action == "post_pivot"
 
 - name: repivot
-  include: move_back.yml
+  include_tasks: move_back.yml
   when: v1aX_integration_test_action in repivot_actions
 
 - name: Deprovision worker nodes
@@ -85,13 +85,13 @@
   when: v1aX_integration_test_action in deprovision_cluster_actions
 
 - name: Cleanup deployment
-  include: cleanup.yml
+  include_tasks: cleanup.yml
   when: v1aX_integration_test_action in cleanup_actions
 
 - name: Node remediation
-  include: remediation.yml
+  include_tasks: remediation.yml
   when: v1aX_integration_test_action == "remediation"
 
 - name: Node reuse
-  include: node_reuse.yml
+  include_tasks: node_reuse.yml
   when: v1aX_integration_test_action == "node_reuse"

--- a/vm-setup/roles/v1aX_integration_test/tasks/remediation.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/remediation.yml
@@ -74,7 +74,7 @@
 
   # Power cycle a single worker node
   - name: Power cycle a single worker node
-    include: power_cycle.yml
+    include_tasks: power_cycle.yml
     vars:
       BMH_NODE: "{{ WORKER_BMH }}"
       LIBVIRT_VM: "{{ WORKER_VM }}"
@@ -82,8 +82,8 @@
 
   # Power cycle a single master node
   - name: Power cycle a single master node
-    include: power_cycle.yml
-    vars: 
+    include_tasks: power_cycle.yml
+    vars:
       BMH_NODE: "{{ MASTER_BMH_0 }}"
       LIBVIRT_VM: "{{ MASTER_VM_0 }}"
       K8S_NODE: "{{ MASTER_NODE_0 }}"
@@ -127,7 +127,7 @@
     until:
       - MASTER_NODE_1 in ready_master.stdout_lines
       - MASTER_NODE_2 in ready_master.stdout_lines
-    
+
   - name: List only running VMs
     virt:
       command: list_vms
@@ -156,7 +156,7 @@
   - name: Mark "{{ WORKER_BMH }}" as unhealthy
     shell: |
       kubectl annotate bmh "{{ WORKER_BMH }}" -n "{{ NAMESPACE }}" capi.metal3.io/unhealthy=
- 
+
   - name: Delete worker Machine object "{{ WORKER_NODE }}"
     shell: |
       kubectl delete machine "{{ WORKER_NODE }}" -n "{{ NAMESPACE }}"
@@ -177,7 +177,7 @@
 
   - name: Scale up the machinedeployment
     shell: kubectl scale machinedeployment "{{ CLUSTER_NAME }}" -n "{{ NAMESPACE }}" --replicas=2
-  
+
   - pause:
      minutes: 1
 
@@ -220,30 +220,30 @@
     delay: 20
     register: ready_hosts
     until: ready_hosts.stdout == "1"
-    
-    ## Start Metal3DataTemplate reference test
-  - name: Get the Metal3DataTemplate, Edit name , Add templateReference and apply it 
-    shell: kubectl get m3dt -n "{{ NAMESPACE }}" "{{ CLUSTER_NAME }}"-workers-template  -ojson | 
-              jq '.metadata.name="test-new-m3dt"' |  
-              jq '.|del(.metadata|.managedFields,.uid,.resourceVersion,.ownerReferences,.finalizers)' |
-              jq '.|del(.status)' | 
-              jq '.spec.templateReference="{{ CLUSTER_NAME }}-workers-template"' |
-              kubectl apply -f- 
 
-  - name: Get the Metal3MachineTemplate, Edit name, Refer to new Metal3DataTemplate and apply it 
-    shell: kubectl get m3mt -n "{{ NAMESPACE }}" "{{ CLUSTER_NAME }}"-workers -ojson |
-              jq '.spec.template.spec.dataTemplate.name="test-new-m3dt"' | 
-              jq '.metadata.name="test-new-m3mt"' |  
+    ## Start Metal3DataTemplate reference test
+  - name: Get the Metal3DataTemplate, Edit name , Add templateReference and apply it
+    shell: kubectl get m3dt -n "{{ NAMESPACE }}" "{{ CLUSTER_NAME }}"-workers-template  -ojson |
+              jq '.metadata.name="test-new-m3dt"' |
               jq '.|del(.metadata|.managedFields,.uid,.resourceVersion,.ownerReferences,.finalizers)' |
-              jq '.|del(.status)' | 
+              jq '.|del(.status)' |
+              jq '.spec.templateReference="{{ CLUSTER_NAME }}-workers-template"' |
+              kubectl apply -f-
+
+  - name: Get the Metal3MachineTemplate, Edit name, Refer to new Metal3DataTemplate and apply it
+    shell: kubectl get m3mt -n "{{ NAMESPACE }}" "{{ CLUSTER_NAME }}"-workers -ojson |
+              jq '.spec.template.spec.dataTemplate.name="test-new-m3dt"' |
+              jq '.metadata.name="test-new-m3mt"' |
+              jq '.|del(.metadata|.managedFields,.uid,.resourceVersion,.ownerReferences,.finalizers)' |
+              jq '.|del(.status)' |
               kubectl apply -f-
 
   - name: Edit MachineDeployment to point to the new m3mt
-    shell: kubectl get md -n "{{ NAMESPACE }}" "{{ CLUSTER_NAME }}" -ojson | 
-              jq '.spec.template.spec.infrastructureRef.name="test-new-m3mt"' | 
+    shell: kubectl get md -n "{{ NAMESPACE }}" "{{ CLUSTER_NAME }}" -ojson |
+              jq '.spec.template.spec.infrastructureRef.name="test-new-m3mt"' |
               jq '.spec.strategy.rollingUpdate.maxUnavailable=1' |
               kubectl apply -f-
-    
+
   - pause:
      minutes: 1
 
@@ -255,7 +255,7 @@
     until: ready_hosts.stdout == "1"
 
   - name: Check if one Metal3Data refers to the old template
-    shell: kubectl get m3d -n "{{ NAMESPACE }}" -ojson | 
+    shell: kubectl get m3d -n "{{ NAMESPACE }}" -ojson |
               jq -r '[ .items[] | select (.spec.templateReference=="{{ CLUSTER_NAME }}-workers-template")|
               .metadata.name ] | length'
     retries: 5
@@ -267,7 +267,7 @@
   - name: Scale KCP back to three replicas
     shell: |
       kubectl scale kcp "{{ CLUSTER_NAME }}" -n "{{ NAMESPACE }}" --replicas=3
-  
+
   - name: Wait until "{{ NUMBER_OF_BMH }}"" BMH are provisioned
     shell: kubectl get bmh -n "{{ NAMESPACE }}" | grep -w provisioned | wc -l
     retries: 200

--- a/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
@@ -4,39 +4,60 @@
       NUMBER_OF_BMH: "{{ NUM_OF_MASTER_REPLICAS|int +  NUM_OF_WORKER_REPLICAS|int }}"
 
   - name: Wait until cluster becomes provisioned.
-    shell: "kubectl get cluster -n {{ NAMESPACE }} -o json | jq -r '.items[] | .status.phase'"
+    k8s_info:
+      # TODO: This should be set based on CAPI_VERSION when v1alpha4 is working.
+      api_version: cluster.x-k8s.io/v1alpha3
+      kind: Cluster
+      namespace: "{{ NAMESPACE }}"
     register: provisioned_cluster
     retries: 100
     delay: 20
-    until: (provisioned_cluster.stdout == "provisioned") or
-           (provisioned_cluster.stdout == "Provisioned")
+    until: (provisioned_cluster is succeeded) and
+           (provisioned_cluster.resources | length > 0) and
+           (provisioned_cluster.resources[0].status.phase | lower == "provisioned")
 
   - name: Wait until "{{ NUMBER_OF_BMH }}" BMHs become provisioned.
-    shell: |
-        kubectl get bmh -n {{ NAMESPACE }} -o json | jq -r '[ .items[]
-        | select (.status.provisioning.state == "provisioned")
-        | .metadata.name ] | length'
+    k8s_info:
+      api_version: metal3.io/v1alpha1
+      kind: BareMetalHost
+      namespace: "{{ NAMESPACE }}"
     register: provisioned_bmh
     retries: 200
     delay: 30
-    until: provisioned_bmh.stdout == NUMBER_OF_BMH
+    vars:
+      query: "[? status.provisioning.state=='provisioned']"
+    until: (provisioned_bmh is succeeded) and
+           (provisioned_bmh.resources | length > 0) and
+           (provisioned_bmh.resources | json_query(query) | length ==  (NUMBER_OF_BMH | int))
 
   - name: Wait until "{{ NUMBER_OF_BMH }}" machines become running.
-    shell: |
-        kubectl get machines -n {{ NAMESPACE }} -o json | jq -r '[ .items[]
-        | select (.status.phase == "Running" or .status.phase == "running")
-        | .metadata.name ] | length'
+    k8s_info:
+      # TODO: This should be set based on CAPI_VERSION when v1alpha4 is working.
+      api_version: cluster.x-k8s.io/v1alpha3
+      kind: Machine
+      namespace: "{{ NAMESPACE }}"
     register: provisioned_machines
     retries: 150
     delay: 20
-    until: provisioned_machines.stdout == NUMBER_OF_BMH
-
-  - name: Define username variable as "{{ IMAGE_USERNAME }}" for target node
-    set_fact:
-      username: "{{ IMAGE_USERNAME }}"
+    vars:
+      query: "[? status.phase=='running' || status.phase=='Running']"
+    until: (provisioned_machines is succeeded) and
+           (provisioned_machines.resources | length > 0) and
+           (provisioned_machines.resources | json_query(query) | length == (NUMBER_OF_BMH | int))
 
   - name: Fetch target cluster kubeconfig
-    shell: "kubectl get secrets {{ CLUSTER_NAME }}-kubeconfig -n {{ NAMESPACE }} -o json | jq -r '.data.value'| base64 -d > /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
+    k8s_info:
+      api_version: v1
+      kind: Secret
+      name: "{{ CLUSTER_NAME }}-kubeconfig"
+      namespace: "{{ NAMESPACE }}"
+    register: kubeconfig_secret
+
+  - name: Store target cluster kubeconfig
+    blockinfile:
+      path: /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml
+      create: yes
+      block: "{{ kubeconfig_secret.resources[0].data.value | b64decode }}"
 
   # Install Calico
   - name: Download Calico manifest
@@ -83,24 +104,31 @@
     register: install_cni
 
   # Check for pods & nodes on the target cluster
-  - name: Check if pods in running state
-    shell: "kubectl get pods --kubeconfig /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml -A -o json | jq -r '.items[].status.phase' | grep -v Running"
+  - name: Wait for all pods to be in running state
+    k8s_info:
+      api_version: v1
+      kind: Pod
+      namespace: "{{ NAMESPACE }}"
+      kubeconfig: /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml
+      field_selectors:
+        - status.phase!=Running
     retries: 150
     delay: 20
-    register: running_pods
-    failed_when: >
-      (running_pods.stderr != "") or
-      (running_pods.rc > 1) or
-      (running_pods.stdout != "")
-    until: running_pods.stdout == ""
+    register: not_running_pods
+    until: (not_running_pods is succeeded) and
+           (not_running_pods.resources | length == 0)
 
-  - name: Check if nodes in ready state
-    shell: "kubectl get nodes --kubeconfig /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml | grep -w Ready | wc -l"
+  - name: Wait for nodes to be in ready state
+    k8s_info:
+      api_version: v1
+      kind: Node
+      kubeconfig: /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml
     retries: 150
     delay: 3
-    register: ready_nodes
-    failed_when: >
-      (ready_nodes.stderr != "") or
-      (ready_nodes.rc != 0) or
-      (ready_nodes.stdout != NUMBER_OF_BMH)
-    until: ready_nodes.stdout == NUMBER_OF_BMH
+    register: nodes
+    vars:
+      # For all Nodes, select those that have the Ready condition set to True
+      query: "[*].status.conditions[? type=='Ready' && status=='True']"
+    until: (nodes is succeeded) and
+           (nodes.resources | length > 0) and
+           (nodes.resources | json_query(query) | length == (NUMBER_OF_BMH | int))


### PR DESCRIPTION
The major part of this PR is converting use of the Ansible `shell` module into `k8s_info`. In addition to this it changes all `include`s to `include_tasks` to make the behavior more predictable and avoid problems later when it is deprecated. (See [the documentation](https://docs.ansible.com/ansible/2.9/modules/include_module.html#include-module).)