### PR TITLE
Move from CentOS8.3 to CentOS Stream

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -179,7 +179,7 @@ for IMAGE_VAR in $(env | grep -v "_LOCAL_IMAGE=" | grep "_IMAGE=" | grep -o "^[^
 
 # Start image downloader container
 #shellcheck disable=SC2086
-sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name ipa-downloader ${POD_NAME} \
+sudo "${CONTAINER_RUNTIME}" run -d --net host --name ipa-downloader ${POD_NAME} \
      -e IPA_BASEURI="$IPA_BASEURI" \
      -v "$IRONIC_DATA_DIR":/shared "${IPA_DOWNLOADER_IMAGE}" /usr/local/bin/get-resource.sh
 

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -197,19 +197,19 @@ if [[ $OS == ubuntu ]]; then
       --env "PROVISIONING_INTERFACE=ironicendpoint" "${IRONIC_IMAGE}"
 else
   #shellcheck disable=SC2086
-  sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name httpd-infra ${POD_NAME_INFRA} \
+  sudo "${CONTAINER_RUNTIME}" run -d --net host --name httpd-infra ${POD_NAME_INFRA} \
       -v "$IRONIC_DATA_DIR":/shared --entrypoint /bin/runhttpd \
       "${IRONIC_IMAGE}"
 fi
 
 # Start vbmc and sushy containers
 #shellcheck disable=SC2086
-sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name vbmc ${POD_NAME_INFRA} \
+sudo "${CONTAINER_RUNTIME}" run -d --net host --name vbmc ${POD_NAME_INFRA} \
      -v "$WORKING_DIR/virtualbmc/vbmc":/root/.vbmc -v "/root/.ssh":/root/ssh \
      "${VBMC_IMAGE}"
 
 #shellcheck disable=SC2086
-sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name sushy-tools ${POD_NAME_INFRA} \
+sudo "${CONTAINER_RUNTIME}" run -d --net host --name sushy-tools ${POD_NAME_INFRA} \
      -v "$WORKING_DIR/virtualbmc/sushy-tools":/root/sushy -v "/root/.ssh":/root/ssh \
      "${SUSHY_TOOLS_IMAGE}"
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Instructions can be found here: <https://metal3.io/try-it.html>
 
 Versions v1alpha3 or v1alpha4 are later referred as **v1alphaX**.
 
-The v1alphaX deployment can be done with Ubuntu 18.04, 20.04 or Centos 8 target host
-images. By default, for Ubuntu based target hosts we are using Ubuntu 20.04
+The v1alphaX deployment can be done with Ubuntu 18.04, 20.04 or Centos Stream 8 target
+host images. By default, for Ubuntu based target hosts we are using Ubuntu 20.04
 
 ### Requirements
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -50,7 +50,7 @@ export OS_VERSION_ID=$VERSION_ID
 export SUPPORTED_DISTROS=(centos8 rhel8 ubuntu18 ubuntu20)
 
 if [[ ! "${SUPPORTED_DISTROS[*]}" =~ $DISTRO ]]; then
-   echo "Supported OS distros for the host are: CentOS8 or RHEL8 or Ubuntu20.04"
+   echo "Supported OS distros for the host are: CentOS Stream 8 or RHEL8 or Ubuntu20.04"
    exit 1
 fi
 


### PR DESCRIPTION
While running integration tests in centos without removing `--privileged` flag, podman will be failing with following error:
 
```
 + sudo podman run -d --net host --privileged --name ipa-downloader --pod ironic-pod -e IPA_BASEURI= -v /opt/metal3-dev-env/ironic:/shared quay.io/metal3-io/ironic-ipa-downloader /usr/local/bin/get-resource.sh
Error: OCI runtime error: container_linux.go:370: starting container process caused: unknown capability "CAP_PERFMON"
make: *** [Makefile:4: install_requirements] Error 126
```

There are two workaround to fix it, as per suggested in [bugzilla-bug-report](https://bugzilla.redhat.com/show_bug.cgi?id=1946982):
- remove `--privileged` flag
- downgrade podman to 3.0.1 version.

`--privileged` flag means to allow the container to access all the capabilities provided by the kernel, but as seems we do not need all of the capabilities and removing it can also satisfy our needs rather than downgrading podman to lower version. Please feel free to let me know if you think otherwise.  

Fixes #671 
