### PR TITLE
🐛 Fix kubectl apply issue in nodereuse

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/node_reuse.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/node_reuse.yml
@@ -28,7 +28,7 @@
 
   - name: Update maxSurge field in KubeadmControlPlane to 0 to start testing KCP scale-in feature. 
     shell: |
-        kubectl get kubeadmcontrolplane "{{ CLUSTER_NAME }}" -n "{{ NAMESPACE }}" -o json | jq '.spec.rolloutStrategy.rollingUpdate.maxSurge=0' | kubectl apply -f-
+        kubectl patch -n "{{ NAMESPACE }}" kubeadmcontrolplane "{{ CLUSTER_NAME }}" --type=merge -p '{"spec": {"rolloutStrategy": {"rollingUpdate": {"maxSurge": 0}}}}'
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
 
@@ -161,7 +161,7 @@
 
   - name: Put maxSurge field in KubeadmControlPlane back to default value(1).
     shell: |
-        kubectl get kubeadmcontrolplane "{{ CLUSTER_NAME }}" -n "{{ NAMESPACE }}" -o json | jq '.spec.rolloutStrategy.rollingUpdate.maxSurge=1' | kubectl apply -f-
+        kubectl patch -n "{{ NAMESPACE }}" kubeadmcontrolplane "{{ CLUSTER_NAME }}" --type=merge -p '{"spec": {"rolloutStrategy": {"rollingUpdate": {"maxSurge": 1}}}}'
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
 
@@ -224,7 +224,7 @@
 
   - name: Update maxSurge and maxUnavailable fields in MachineDeployment.
     shell: |
-        kubectl get machinedeployment "{{ CLUSTER_NAME }}" -n "{{ NAMESPACE }}" -o json | jq '.spec.strategy.rollingUpdate.maxSurge=0|.spec.strategy.rollingUpdate.maxUnavailable=1' | kubectl apply -f-
+        kubectl patch -n "{{ NAMESPACE }}" machinedeployment "{{ CLUSTER_NAME }}" --type=merge -p '{"spec": {"strategy": {"rollingUpdate": {"maxSurge": 0,"maxUnavailable": 1}}}}'
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
 


### PR DESCRIPTION
Feature test CI sometimes failing with:

```
`TASK [v1aX_integration_test : Put maxSurge field in KubeadmControlPlane back to default value(1).] ***
...
[0;31m        "Resource: \"controlplane.cluster.x-k8s.io/v1alpha3, Resource=kubeadmcontrolplanes\", GroupVersionKind: \"controlplane.cluster.x-k8s.io/v1alpha3, Kind=KubeadmControlPlane\"",[0m
[0;31m        "Name: \"test1\", Namespace: \"metal3\"",[0m
[0;31m        "for: \"STDIN\": Operation cannot be fulfilled on kubeadmcontrolplanes.controlplane.cluster.x-k8s.io \"test1\": the object has been modified; please apply your changes to the latest version and try again"[0m`
```

It seems, since we already changed maxSurge field once before also and by that time `resoruceVersion` gets incremented and once we try to change the field again, it uses old cached `resoruceVersion` number to apply the object and fails. For that, we might need to drop some of the fields before reapplying them in KCP. 