### PR TITLE
🐛 Fix upgrade tests

### DIFF
--- a/scripts/feature_tests/upgrade/upgrade_vars.sh
+++ b/scripts/feature_tests/upgrade/upgrade_vars.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eux
 
 # Folder created for specific capi release when running
 # ${CLUSTER_API_REPO}/cmd/clusterctl/hack/create-local-repository.py
@@ -6,8 +7,13 @@
 
 export CAPIRELEASE_HARDCODED="v0.3.8"
 
+function get_capm3_latest() {
+    clusterctl upgrade plan | grep infrastructure-metal3 | awk 'NR == 1 {print $5}'
+}
+
 export CAPM3RELEASE="v0.4.0"
-export CAPM3_REL_TO_VERSION="v0.4.1"
+CAPM3_REL_TO_VERSION="$(get_capm3_latest)" || true
+export CAPM3_REL_TO_VERSION
 
 export CAPIRELEASE="v0.3.15"
 export CAPI_REL_TO_VERSION="v0.3.16"


### PR DESCRIPTION
Upgrade master builds in jenkins are failing during one of the checks in upgrade task due to the mismatch in `CAPM3_REL_TO_VERSION` var which is currently hardcoded `v0.4.1` version but latest version of CAPM3 as of now is `v0.4.2`. This PR tries to dynamically fetch CAPM3 varsion from the output of `clusterctl upgrade plan ` and set it to the `CAPM3_REL_TO_VERSION`  var. 

**Note:** we are ignoring output of `clusterctl upgrade plan ` first time, since `upgrade_vars.sh` sourced before running `make` and there is no cluster, but value will be fetched once we source file second time after `make` completed. 
