### PR TITLE
Set NUM_NODES for feature tests

### DIFF
--- a/scripts/feature_tests/node_reuse/Makefile
+++ b/scripts/feature_tests/node_reuse/Makefile
@@ -1,5 +1,6 @@
 export NUM_OF_MASTER_REPLICAS := 3
 export NUM_OF_WORKER_REPLICAS := 1
+export NUM_NODES := 4
 
 all: node_reuse
 

--- a/scripts/feature_tests/pivoting/Makefile
+++ b/scripts/feature_tests/pivoting/Makefile
@@ -1,6 +1,7 @@
 M3PATH := "$(dirname "$(readlink -f "${0}")")../../../"
 export NUM_OF_MASTER_REPLICAS := 3
 export NUM_OF_WORKER_REPLICAS := 1
+export NUM_NODES := 4
 
 all: provision fetch_manifests pivoting
 

--- a/scripts/feature_tests/remediation/Makefile
+++ b/scripts/feature_tests/remediation/Makefile
@@ -1,5 +1,6 @@
 export NUM_OF_MASTER_REPLICAS := 3
 export NUM_OF_WORKER_REPLICAS := 1
+export NUM_NODES := 4
 
 all: provision remediation deprovision
 

--- a/scripts/feature_tests/upgrade/Makefile
+++ b/scripts/feature_tests/upgrade/Makefile
@@ -1,10 +1,10 @@
 M3PATH := "$(dirname "$(readlink -f "${0}")")../../../"
 export NUM_OF_MASTER_REPLICAS := 3
 export NUM_OF_WORKER_REPLICAS := 1
+export NUM_NODES := 4
 
 all: fetch_manifests upgrade
 fetch_manifests:
 	./../../fetch_manifests.sh
 upgrade:
 	./upgrade.sh
-

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -89,9 +89,6 @@ CAPI_REL_TO_VERSION: "{{ lookup('env', 'CAPI_REL_TO_VERSION') }}"
 CAPM3_API_VERSION: "{{ lookup('env', 'CAPM3_API_VERSION') }}"
 CAPI_API_VERSION: "{{ lookup('env', 'CAPI_API_VERSION') }}"
 
-CAPM3RELEASE: "{{ lookup('env', 'CAPM3RELEASE') }}"
-CAPIRELEASE: "{{ lookup('env', 'CAPIRELEASE') }}"
-
 provision_cluster_actions:
     - "ci_test_provision"
     - "provision_cluster"
@@ -130,7 +127,7 @@ verify_actions:
     - "post_pivot"
 pivot_actions:
     - "ci_test_provision"
-    - "pivoting"    
+    - "pivoting"
     - "post_pivot"
     - "upgrading"
 repivot_actions:


### PR DESCRIPTION
NUM_NODES defaults to 2, which doesn't work with the feature tests since they set `NUM_OF_MASTER_REPLICAS=3` and `NUM_OF_WORKER_REPLICAS=1`. In the CI jobs we override NUM_NODES to make things work.

Now NUM_NODES is set to 4 for these tests (without having to override it).

Why I think we need this: When I want to manually test something by running for example `make feature_tests_upgrade`, I must first remember to do `export NUM_NODES=4` or the test will fail since there are not enough nodes. Since are already setting values for the number of masters/workers we might as well do it for the total number of nodes also.

Delete duplicate variable declarations for CAPM3RELEASE and CAPIRELEASE.