### PR TITLE
Cleanup variables for CAPI and CAPM3

### DIFF
--- a/scripts/feature_tests/upgrade/upgrade_vars.sh
+++ b/scripts/feature_tests/upgrade/upgrade_vars.sh
@@ -18,9 +18,6 @@ export CAPM3_REL_TO_VERSION
 export CAPIRELEASE="v0.3.15"
 export CAPI_REL_TO_VERSION="v0.3.16"
 
-export CAPI_API_VERSION="v1alpha3"
-export CAPM3_API_VERSION="v1alpha4"
-
 export KUBERNETES_VERSION="v1.21.1"
 export UPGRADED_K8S_VERSION="v1.21.2"
 

--- a/vm-setup/roles/v1aX_integration_test/templates/Metal3MachineTemplate.yml
+++ b/vm-setup/roles/v1aX_integration_test/templates/Metal3MachineTemplate.yml
@@ -1,10 +1,10 @@
-apiVersion: infrastructure.cluster.x-k8s.io/{{CAPM3_API_VERSION}}
+apiVersion: infrastructure.cluster.x-k8s.io/{{CAPM3_VERSION}}
 kind: Metal3MachineTemplate
 metadata:
   name: {{ M3MT_NAME }}
   namespace: metal3
   ownerReferences:
-  - apiVersion: cluster.x-k8s.io/{{CAPI_API_VERSION}}
+  - apiVersion: cluster.x-k8s.io/{{CAPI_VERSION}}
     kind: Cluster
     name: {{ CLUSTER_NAME }}
     uid: {{ CLUSTER_UID }}

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -91,11 +91,6 @@ CAPM3PATH: "{{M3PATH}}/cluster-api-provider-metal3"
 
 CAPM3_REL_TO_VERSION: "{{ lookup('env', 'CAPM3_REL_TO_VERSION') }}"
 CAPI_REL_TO_VERSION: "{{ lookup('env', 'CAPI_REL_TO_VERSION') }}"
-CAPM3_API_VERSION: "{{ lookup('env', 'CAPM3_API_VERSION') }}"
-CAPI_API_VERSION: "{{ lookup('env', 'CAPI_API_VERSION') }}"
-
-CAPM3RELEASE: "{{ lookup('env', 'CAPM3RELEASE') }}"
-CAPIRELEASE: "{{ lookup('env', 'CAPIRELEASE') }}"
 
 provision_cluster_actions:
     - "ci_test_provision"
@@ -135,7 +130,7 @@ verify_actions:
     - "post_pivot"
 pivot_actions:
     - "ci_test_provision"
-    - "pivoting"    
+    - "pivoting"
     - "post_pivot"
     - "upgrading"
 repivot_actions:


### PR DESCRIPTION
- Remove duplicate keys for CAPI_VERSION and CAPM3_VERSION
- Remove variables CAPI_API_VERSION and CAPM3_API_VERSION that were only
used for upgrade tests, and replace them with CAPI_VERSION and
CAPM3_VERSION.

Note that CAPI_VERSION is already set to `v1alpha4` in the CI, whereas CAPI_API_VERSION was set to `v1alpha3`, so to keep the current behavior the version is now hard-coded. There is [an issue](https://github.com/metal3-io/metal3-dev-env/issues/688) for parameterizing this later when support is in place for `v1alpha4`.