### PR TITLE
Add renovate config with Minikube updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,27 @@
 {
-  "extends": [
-    "config:base"
-  ]
+ "extends": ["config:base"],
+ "baseBranches": ["master"],
+ "bumpVersion": null,
+ "packageRules": [
+   {
+     "depTypeList": ["devDependencies"],
+     "updateTypes": ["minor"],
+     "automerge": false
+   }
+ ],
+ "prHourlyLimit": 5,
+ "prConcurrentLimit": 5,
+ "rangeStrategy": "bump",
+ "renovateFork": true,
+ "includeForks": true,
+ "regexManagers": [
+    {
+      "fileMatch": ["^lib/common.sh$"],
+      "matchStrings": ["MINIKUBE_VERSION:-\"(?<currentValue>.*?)\"}"],
+      "depNameTemplate": "kubernetes/minikube",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
+  "assignees": ["kashifest", "fmuyassarov","furkatgofurov7", "Xenwar", "smoshiur1237", "jan-est"],
+  "assigneesSampleSize": 2
 }


### PR DESCRIPTION
Add a renovate configuration which will automatically raise pull
requests for minikube updates.

Renovate pull requests will be automatically assigned to two of the
members of the OWNERS file who support the CI for this project. We could
automate the assignees list by using a CODEOWNERS file in future.

If this change is successful, we should see Renovate try to bump
minikube to version v1.21.0.