### PR TITLE
Add a script to run a command with environment variables

### DIFF
--- a/lib/images.sh
+++ b/lib/images.sh
@@ -32,3 +32,7 @@ export IMAGE_USERNAME=${IMAGE_USERNAME:-metal3}
 # Image basename and rawname
 IMAGE_BASE_NAME="${IMAGE_NAME%.*}"
 export IMAGE_RAW_NAME="${IMAGE_BASE_NAME}-raw.img"
+
+# variables used for template parametrization in CAPM3
+export IMAGE_RAW_URL=http://$PROVISIONING_URL_HOST/images/${IMAGE_RAW_NAME}
+export IMAGE_RAW_CHECKSUM=http://$PROVISIONING_URL_HOST/images/${IMAGE_RAW_NAME}.md5sum

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -74,6 +74,7 @@ if [[ "$CLUSTER_APIENDPOINT_IP" == *":"* ]]; then
 else
   export CLUSTER_APIENDPOINT_HOST="$CLUSTER_APIENDPOINT_IP"
 fi
+export CLUSTER_APIENDPOINT_PORT=${CLUSTER_APIENDPOINT_PORT:-"6443"}
 
 # Calculate DHCP range
 network_address dhcp_range_start "$PROVISIONING_NETWORK" 10

--- a/scripts/run_command.sh
+++ b/scripts/run_command.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Runs arbitrary command with environment variables used by the metal3-dev-env
+# setup scripts.
+
+set -xe
+
+METAL3_DIR="$(dirname "$(readlink -f "${0}")")/.."
+
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
+source "${METAL3_DIR}/lib/logging.sh"
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
+source "${METAL3_DIR}/lib/common.sh"
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
+source "${METAL3_DIR}/lib/releases.sh"
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
+source "${METAL3_DIR}/lib/network.sh"
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
+source "${METAL3_DIR}/lib/images.sh"
+
+exec "$@"

--- a/vars.md
+++ b/vars.md
@@ -38,7 +38,9 @@ assured that they are persisted.
 | SUSHY_TOOLS_IMAGE | Container image for sushy-tools container | | "quay.io/metal3-io/sushy-tools" |
 | CAPM3_VERSION | Version of Cluster API provider Metal3 | "v1alpha4", "v1alpha5" | "v1alpha5" |
 | CAPI_VERSION | Version of Cluster API | "v1alpha3" | "v1alpha3" |
-| CLUSTER_APIENDPOINT_IP | API endpoint IP for target cluster | "x.x.x.x/x" | "192.168.111.249" |
+| CLUSTER_APIENDPOINT_IP | API endpoint IP for target cluster | "x.x.x.x" | "192.168.111.249" |
+| CLUSTER_APIENDPOINT_HOST | API endpoint host for target cluster | | $CLUSTER_APIENDPOINT_IP |
+| CLUSTER_APIENDPOINT_PORT | API endpoint port for target cluster | | "6443" |
 | CLUSTER_PROVISIONING_INTERFACE | Cluster provisioning Interface | "ironicendpoint" | "ironicendpoint" |
 | POD_CIDR | Pod CIDR | "x.x.x.x/x" | "192.168.0.0/18" |
 | NODE_HOSTNAME_FORMAT | Node hostname format. This is a format string that must contain exactly one %d format field that will be replaced with an integer representing the number of the node. | "node-%d" |


### PR DESCRIPTION
This allows executing a script within the environment resolved by metal3-dev-env, i.e., with variables set to their default values if missing and image URLs derived from IMAGE_OS variable. Currently this will be used for running e2e tests in CAPM3. (see [CAPM3#218](https://github.com/metal3-io/cluster-api-provider-metal3/pull/218)). Additionally, exports a few variables used in the CAPM3 PR.

