### PR TITLE
Update notes from CentOS 8 Stream to CentOS 8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Instructions can be found here: <https://metal3.io/try-it.html>
 
 Versions v1alpha4 or v1alpha5 are later referred as **v1alphaX**.
 
-The v1alphaX deployment can be done with Ubuntu 18.04, 20.04 or Centos 8 target
+The v1alphaX deployment can be done with Ubuntu 18.04, 20.04 or Centos 8.3 target
 host images. By default, for Ubuntu based target hosts we are using Ubuntu 20.04
 
 ### Requirements


### PR DESCRIPTION
This PR fix the CentOS version in the README from 8 to 8.3