### PR TITLE
Add option to enable the reverse proxy for Ironic-inspector

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -169,6 +169,10 @@ export IRONIC_KEEPALIVED_IMAGE=${IRONIC_KEEPALIVED_IMAGE:-"quay.io/metal3-io/kee
 export IRONIC_NAMESPACE=${IRONIC_NAMESPACE:-"capm3-system"}
 # Enable ironic restart feature when the TLS certificate is updated
 export RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-${IRONIC_TLS_SETUP}}
+export INSPECTOR_REVERSE_PROXY_SETUP=${INSPECTOR_REVERSE_PROXY_SETUP:-"true"}
+if [[ "$IRONIC_TLS_SETUP" == "false" ]]; then
+  export INSPECTOR_REVERSE_PROXY_SETUP="false" # No Revese proxy for Ironic inspector if TLS is not used
+fi
 
 # Baremetal operator image
 export BAREMETAL_OPERATOR_IMAGE=${BAREMETAL_OPERATOR_IMAGE:-"quay.io/metal3-io/baremetal-operator"}

--- a/vars.md
+++ b/vars.md
@@ -72,6 +72,7 @@ assured that they are persisted.
 | IRONIC_INSPECTOR_PORT | Ironic Inspector port | | 5050 |
 | IRONIC_API_PORT | Ironic Api port | | 6385 |
 | RESTART_CONTAINER_CERTIFICATE_UPDATED | Enable the ironic restart feature when TLS certificates are updated | "true", "false" | "true" |
+| INSPECTOR_REVERSE_PROXY_SETUP | Enable the reverse proxy to handle TLS for Ironic-inspector | "true", "false" | "true" |
 | NODE_DRAIN_TIMEOUT | Set the nodeDrainTimeout for controlplane and worker template | | '0s' |
 | MARIADB_KEY_FILE | Path to the key of MariaDB | | /opt/metal3-dev-env/certs/mariadb.key |
 | MARIADB_CERT_FILE | Path to the cert of MariaDB | | /opt/metal3-dev-env/certs/mariadb.crt |


### PR DESCRIPTION
When TLS is used, add option to enable the reverse proxy for Ironic-inspector