### PR TITLE
Update DockerHub registry path

### DIFF
--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -14,6 +14,6 @@ else
     --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \
     --workdir /workdir \
-    registry.hub.docker.com/pipelinecomponents/markdownlint:latest \
+    docker.io/pipelinecomponents/markdownlint:latest \
     /workdir/hack/markdownlint.sh "${@}"
 fi;

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -15,6 +15,6 @@ else
     --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \
     --workdir /workdir \
-    registry.hub.docker.com/koalaman/shellcheck-alpine:stable \
+    docker.io/koalaman/shellcheck-alpine:stable \
     /workdir/hack/shellcheck.sh "${@}"
 fi;

--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/python:3.9
+FROM docker.io/python:3.9
 
 RUN apt update && \
     apt install -y libvirt-dev && \


### PR DESCRIPTION
The registry path for DockerHub https://registry.hub.docker.com/v2/ returns a 404. Docker/Podman make a GET request to this path before pulling the image, and they're failing at this step. Whether DockerHub have deprecated or changed the behaviour of their registry is unclear.

Updating the paths to docker.io resolves this issue and allows Docker image pulling once more.