### PR TITLE
Switch to DIY callback plugin for Ansible

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -44,7 +44,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "metal3_dir=$SCRIPTDIR" \
   -e "virthost=$HOSTNAME" \
   -i vm-setup/inventory.ini \
-  -b -vvv vm-setup/install-package-playbook.yml
+  -b vm-setup/install-package-playbook.yml
 
 # shellcheck disable=SC1091
 source lib/network.sh

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -28,7 +28,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "nodes_file=$NODES_FILE" \
     -e "node_hostname_format=$NODE_HOSTNAME_FORMAT" \
     -i vm-setup/inventory.ini \
-    -b -vvv vm-setup/setup-playbook.yml
+    -b vm-setup/setup-playbook.yml
 
 # Usually virt-manager/virt-install creates this: https://www.redhat.com/archives/libvir-list/2008-August/msg00179.html
 if ! sudo virsh pool-uuid default > /dev/null 2>&1 ; then
@@ -108,7 +108,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "{use_firewalld: $USE_FIREWALLD}" \
     -e "external_subnet_v4: ${EXTERNAL_SUBNET_V4}" \
     -i vm-setup/inventory.ini \
-    -b -vvv vm-setup/firewall.yml
+    -b vm-setup/firewall.yml
 
 # FIXME(stbenjam): ansbile firewalld module doesn't seem to be doing the right thing
 if [ "$USE_FIREWALLD" == "True" ]; then

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,22 @@
+[defaults]
+stdout_callback=community.general.diy
+
+[callback_diy]
+; Note that the action can be both k8s_info and community.kubernetes.k8s_info
+runner_retry_msg='
+  FAILED: {{ ansible_callback_diy.task.name }}
+  {{ ("FAILED: " + ansible_callback_diy.task.name) | length * "-" }}
+  {% if ansible_callback_diy.task.action is search("k8s_info") %}
+  {% for r in ansible_callback_diy.result.output.resources %}
+    kind: {{ r.kind }}
+    name: {{ r.metadata.name }}
+    {% if r.kind == "BareMetalHost" %}
+    status.provisioning:
+      {{ r.status.provisioning | to_nice_yaml | indent(2, first=True) }}
+    {% else %}
+    status:
+      {{ r.status | to_nice_yaml | indent(2, first=True) }}
+    {% endif %}
+  {% endfor %}
+  {% endif %}
+  RETRYING: {{ ansible_callback_diy.task.name }} {{ ansible_callback_diy.result.output.attempts }}/{{ ansible_callback_diy.task.retries }}'

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -40,7 +40,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
     -e "nodes_file=$NODES_FILE" \
     -i vm-setup/inventory.ini \
-    -b -vvv vm-setup/teardown-playbook.yml
+    -b vm-setup/teardown-playbook.yml
 
 if [ "$USE_FIREWALLD" == "False" ]; then
  ANSIBLE_FORCE_COLOR=true ansible-playbook \
@@ -48,7 +48,7 @@ if [ "$USE_FIREWALLD" == "False" ]; then
     -e "external_subnet_v4: ${EXTERNAL_SUBNET_V4}" \
     -e "firewall_rule_state=absent" \
     -i vm-setup/inventory.ini \
-    -b -vvv vm-setup/firewall.yml
+    -b vm-setup/firewall.yml
 fi
 
 # There was a bug in this file, it may need to be recreated.

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -35,4 +35,4 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
    -e "metal3_dir=$SCRIPTDIR" \
    -e "v1aX_integration_test_action=${ACTION}" \
    -i "${METAL3_DIR}/vm-setup/inventory.ini" \
-   -b -vvv "${METAL3_DIR}/vm-setup/v1aX_integration_test.yml"
+   -b "${METAL3_DIR}/vm-setup/v1aX_integration_test.yml"


### PR DESCRIPTION
The DIY callback plugin is configured to print only the status of k8s resources instead of everything (but otherwise work as before). Ansible verbosity is also turned down to default.

The goal is to reduce the amount of useless logs produced by the CI but still show relevant/interesting parts.

My reasoning is as follows. Note that all of this is very much open for discussion. This is just my point of view.

1. We get a lot of output that is not very useful because we run ansible with `-vvv`. If a task fails, it will usually anyway print extra information about the error, so we skip `-vvv` and should still get the most important information.
2. The `k8s_info` module that we are now using a bit more prints everything (including all the managed fields and what not) when running with `-vvv`. This is too much. Without `-vvv` it doesn't print anything though, and that is too little. It becomes hard to tell what is going on for example when a task is using `until` to wait for some node/machine/bmh.
  Solution: use the DIY callback and configure it to print only the `status` field of all resources (+ name and kind). This gives us the most valuable information while still reducing the amount of logs quite a lot. (Note that we will still get the full output if a task fails.)
3. (This could be left as a follow up.) Ansible [blocks can be used for error handling](https://docs.ansible.com/ansible/latest/user_guide/playbooks_blocks.html#handling-errors-with-blocks). We could benefit from this by gathering extra information about the environment in case a task fails. This works well in cases where it is known already what to look for. For example, we may choose to gather information about all Machines, BareMetalHosts, Pods and Nodes if a task fails and then print all of it. Note that this is in addition to the above. We still get the full output from the failed task, but after it we can add more.
4. (Extra) We could also consider disabling the echo of some/all bash commands. They are quite repetitive and in case of failure we would still get the line where it failed. The main drawback that I see with this is that it may be less obvious what value some environment variables have.