### PR TITLE
Uplift kustomize to v4.1.3

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -206,7 +206,7 @@ else
 fi
 
 # Kustomize version
-export KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-"v3.8.5"}
+export KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-"v4.1.3"}
 
 # Kind version (if EPHEMERAL_CLUSTER=kind)
 export KIND_VERSION=${KIND_VERSION:-"v0.11.1"}


### PR DESCRIPTION
This is needed because only the newer kustomize versions ignore patches for missing targets. This is important for example in CAPM3, where a recent PR [#223](https://github.com/metal3-io/cluster-api-provider-metal3/pull/223) broke e2e tests when using the old kustomize version.