### PR TITLE
🐛 Remove duplicate manifest fetching for KCP

### DIFF
--- a/scripts/fetch_manifests.sh
+++ b/scripts/fetch_manifests.sh
@@ -14,7 +14,6 @@ manifests=(
   m3cluster
   m3machine
   metal3machinetemplate
-  kcp
   kubeadmconfig
   kubeadmconfigtemplates
   kubeadmcontrolplane


### PR DESCRIPTION
Remove `kcp` from the list of objects to fetch its manifest since there is already `kubeadmcontrolplane`