### PR TITLE
Improve/tidy up feature test related scripts and notes

### DIFF
--- a/scripts/feature_tests/README.md
+++ b/scripts/feature_tests/README.md
@@ -159,7 +159,6 @@ Depending on where from the job is triggered, **\*** can be:
 - metal3io_bmo
 - metal3io_project_infra
 - metal3io_ironic_ipa_downloader
-- metal3io_ironic_inspector
 - metal3io_ironic_image
 - nordix_capi_m3
 - nordix_metal3_dev_env

--- a/scripts/feature_tests/cleanup_env.sh
+++ b/scripts/feature_tests/cleanup_env.sh
@@ -6,17 +6,17 @@ ROOTPATH="$(dirname "$(readlink -f "${0}")")/../.."
 # shellcheck disable=SC1091
 source "${ROOTPATH}/scripts/feature_tests/feature_test_vars.sh"
 # shellcheck disable=SC1091
-source lib/logging.sh
+source "${ROOTPATH}/lib/logging.sh"
 # shellcheck disable=SC1091
-source lib/common.sh
+source "${ROOTPATH}/lib/common.sh"
 # shellcheck disable=SC1091
-source lib/releases.sh
+source "${ROOTPATH}/lib/releases.sh"
 # shellcheck disable=SC1091
-source lib/network.sh
+source "${ROOTPATH}/lib/network.sh"
 # shellcheck disable=SC1091
-source lib/ironic_tls_setup.sh
+source "${ROOTPATH}/lib/ironic_tls_setup.sh"
 # shellcheck disable=SC1091
-source lib/ironic_basic_auth.sh
+source "${ROOTPATH}/lib/ironic_basic_auth.sh"
 
 # Remove old SSH keys
 ssh-keygen -f /home/"${USER}"/.ssh/known_hosts -R "${CLUSTER_APIENDPOINT_IP}"
@@ -73,8 +73,6 @@ else
   # Scale up ironic
   kubectl scale deploy -n "${IRONIC_NAMESPACE}" capm3-ironic --replicas=1
 fi
-
-
 
 # shellcheck disable=SC2153
 clusterctl init --core cluster-api:"${CAPIRELEASE}" --bootstrap kubeadm:"${CAPIRELEASE}" --control-plane kubeadm:"${CAPIRELEASE}" --infrastructure=metal3:"${CAPM3RELEASE}" -v5


### PR DESCRIPTION
This PR:
1. addresses [comment](https://github.com/metal3-io/metal3-dev-env/pull/725#discussion_r666725441) 
2. Removes leftover note since ironic inspector repo has been already deprecated and we do not trigger any job in that repo. 
Related patches:
- [gerrit cleanup](https://gerrit.nordix.org/c/infra/cicd/+/9022)
- [project-infra cleanup](https://github.com/metal3-io/project-infra/pull/193)