### PR TITLE
use /usr/bin/python3 for Ansible

### DIFF
--- a/vm-setup/inventory.ini
+++ b/vm-setup/inventory.ini
@@ -1,2 +1,2 @@
 [virthost]
-localhost
+localhost ansible_python_interpreter="auto"


### PR DESCRIPTION
Since default config for [ansible_python_interpreter](https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html) is `auto_legacy`, Ansible tries to use  /usr/bin/python if exists on the system. It is okay to use /usr/bin/python, but the only minor issue - there is deprecation message being printed for every single run as an example below.
```
TASK [Gathering Facts] *********************************************************
[DEPRECATION WARNING]: Distribution ubuntu 20.04 on host localhost should use 
/usr/bin/python3, but is using /usr/bin/python for backward compatibility with 
prior Ansible releases. A future Ansible release will default to using the 
discovered platform python for this host. See https://docs.ansible.com/ansible/
2.11/reference_appendices/interpreter_discovery.html for more information. This
 feature will be removed in version 2.12. Deprecation warnings can be disabled 
by setting deprecation_warnings=False in ansible.cfg.
```
Setting `ansible_python_interpreter` to auto will result in the use of /usr/bin/python3 instead of /usr/bin/python and avoid having depreciation messages.