### PR TITLE
Deploy BMO outside of CAPM3 in metal3-dev-env

### DIFF
--- a/04_verify.sh
+++ b/04_verify.sh
@@ -209,8 +209,8 @@ EXPTD_V1ALPHA5_DEPLOYMENTS="capm3-system:capm3-controller-manager \
   capi-webhook-system:capi-kubeadm-bootstrap-controller-manager \
   capi-webhook-system:capi-kubeadm-control-plane-controller-manager \
   capi-webhook-system:capm3-controller-manager \
-  capm3-system:capm3-baremetal-operator-controller-manager"
-EXPTD_V1ALPHA5_RS="cluster.x-k8s.io/provider:infrastructure-metal3:capm3-system:3 \
+  baremetal-operator-system:baremetal-operator-controller-manager"
+EXPTD_V1ALPHA5_RS="cluster.x-k8s.io/provider:infrastructure-metal3:capm3-system:2 \
   cluster.x-k8s.io/provider:cluster-api:capi-system:1 \
   cluster.x-k8s.io/provider:bootstrap-kubeadm:capi-kubeadm-bootstrap-system:1 \
   cluster.x-k8s.io/provider:control-plane-kubeadm:capi-kubeadm-control-plane-system:1 \

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -166,7 +166,15 @@ export IRONIC_CLIENT_IMAGE=${IRONIC_CLIENT_IMAGE:-"quay.io/metal3-io/ironic-clie
 export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
 export IRONIC_IMAGE_DIR="$IRONIC_DATA_DIR/html/images"
 export IRONIC_KEEPALIVED_IMAGE=${IRONIC_KEEPALIVED_IMAGE:-"quay.io/metal3-io/keepalived"}
-export IRONIC_NAMESPACE=${IRONIC_NAMESPACE:-"capm3-system"}
+
+if [ "${CAPM3_VERSION}" == "v1alpha4" ]; then
+  export IRONIC_NAMESPACE=${IRONIC_NAMESPACE:-"capm3-system"}
+  export NAMEPREFIX=${NAMEPREFIX:-"capm3"}
+else
+  export IRONIC_NAMESPACE=${IRONIC_NAMESPACE:-"baremetal-operator-system"}
+  export NAMEPREFIX=${NAMEPREFIX:-"baremetal-operator"}
+fi
+
 # Enable ironic restart feature when the TLS certificate is updated
 export RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-${IRONIC_TLS_SETUP}}
 
@@ -215,7 +223,7 @@ export KIND_NODE_IMAGE_VERSION=${KIND_NODE_IMAGE_VERSION:-"v1.21.1"}
 # Minikube version (if EPHEMERAL_CLUSTER=minikube)
 export MINIKUBE_VERSION=${MINIKUBE_VERSION:-"v1.22.0"}
 
-# Ansible version
+# Ansible version 
 export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"4.0.0"}
 
 # Test and verification related variables
@@ -405,14 +413,14 @@ differs(){
 #
 function init_minikube() {
     #If the vm exists, it has already been initialized
-    if [[ "$(sudo virsh list --name --all)" != *"minikube"* ]]; then
-      # Restart libvirtd.service as suggested here
+    if [[ "$(sudo virsh list --name --all)" != *"minikube"* ]]; then 
+      # Restart libvirtd.service as suggested here 
       # https://github.com/kubernetes/minikube/issues/3566
       sudo systemctl restart libvirtd.service
       # Even if it fails to start minikube here, lets ignore the error
       # It will be retried again in 03 script
       sudo su -l -c "minikube start --insecure-registry ${REGISTRY}" "$USER" || true
-      sudo su -l -c "minikube stop" "$USER" || true
+      sudo su -l -c "minikube stop" "$USER" || true 
     fi
 
     MINIKUBE_IFACES="$(sudo virsh domiflist minikube)"

--- a/scripts/feature_tests/cleanup_env.sh
+++ b/scripts/feature_tests/cleanup_env.sh
@@ -26,7 +26,7 @@ if [ "${EPHEMERAL_CLUSTER}" == "kind" ]; then
   "$BMOPATH"/tools/remove_local_ironic.sh
 else 
   # Scale down ironic
-  kubectl scale deploy -n "${IRONIC_NAMESPACE}" capm3-ironic --replicas=0
+  kubectl scale deploy -n "${IRONIC_NAMESPACE}" "${NAMEPREFIX}-ironic" --replicas=0
 fi
 
 clusterctl delete --all -v5
@@ -71,7 +71,7 @@ if [ "${EPHEMERAL_CLUSTER}" == "kind" ]; then
   popd || exit
 else 
   # Scale up ironic
-  kubectl scale deploy -n "${IRONIC_NAMESPACE}" capm3-ironic --replicas=1
+  kubectl scale deploy -n "${IRONIC_NAMESPACE}" "${NAMEPREFIX}-ironic" --replicas=1
 fi
 
 # shellcheck disable=SC2153

--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -23,18 +23,34 @@
 
   - name: Remove Ironic from source cluster (Ephemeral Cluster is minikube)
     kubernetes.core.k8s:
-      name: capm3-ironic
+      name: "{{ NAMEPREFIX }}-ironic"
       kind: Deployment
       state: absent
       namespace: "{{ IRONIC_NAMESPACE }}"
     when: EPHEMERAL_CLUSTER == "minikube"
 
+  - name: Label BMO CRDs.
+    shell: "kubectl label --overwrite crds baremetalhosts.metal3.io {{ item }}"
+    with_items:
+       - clusterctl.cluster.x-k8s.io=""
+       - cluster.x-k8s.io/provider="metal3"
+    when: CAPM3_VERSION == "v1alpha5"
+       
   - name: Obtain target cluster kubeconfig
     kubernetes.core.k8s_info:
       kind: secrets
       name: "{{ CLUSTER_NAME }}-kubeconfig"
       namespace: "{{ NAMESPACE }}"
     register: metal3_kubeconfig
+
+    # Install BMO
+  - name: Install Baremetal Operator
+    shell: "{{ BMOPATH }}/tools/deploy.sh true false {{ IRONIC_TLS_SETUP }} {{ IRONIC_BASIC_AUTH }} true"
+    environment:
+      IRONIC_HOST: "{{ IRONIC_HOST }}"
+      IRONIC_HOST_IP: "{{ IRONIC_HOST_IP }}"
+      KUBECTL_ARGS: "{{ KUBECTL_ARGS }}"
+    when: CAPM3_VERSION == "v1alpha5"
 
   - name: Decode and save cluster kubeconfig
     copy:
@@ -81,6 +97,13 @@
 
   - name: Reinstate Ironic Configmap
     shell: "mv {{ BMOPATH }}/ironic-deployment/keepalived/ironic_bmo_configmap.env.orig {{ BMOPATH }}/ironic-deployment/keepalived/ironic_bmo_configmap.env"
+
+  - name: Label BMO CRDs in target cluster.
+    shell: "kubectl --kubeconfig /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml label crds baremetalhosts.metal3.io {{ item }} --overwrite "
+    with_items:
+      - clusterctl.cluster.x-k8s.io=""
+      - cluster.x-k8s.io/provider="metal3"
+    when: CAPM3_VERSION == "v1alpha5"
 
   # Check for pods & nodes on the target cluster
   - name: Check if pods in running state

--- a/vm-setup/roles/v1aX_integration_test/tasks/move_back.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move_back.yml
@@ -3,7 +3,7 @@
   # Remove Ironic from target cluster
   - name: Remove Ironic from target cluster
     kubernetes.core.k8s:
-      name: capm3-ironic
+      name: "{{ NAMEPREFIX }}-ironic"
       kind: Deployment
       state: absent
       namespace: "{{ IRONIC_NAMESPACE }}"

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -38,7 +38,7 @@
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
   - name: Gather variables that were missing on the source cluster
     shell: | 
-            kubectl get cm -n capm3-system capm3-baremetal-operator-ironic -o json | 
+            kubectl get cm -n {{ NAMEPREFIX }}-system {{ NAMEPREFIX }}-baremetal-operator-ironic -o json |
             jq -r '.data' | sed 's/: /=/'| cut -sf1- -d\" | sed 's/^/export/' | 
             tr -d ',' | tr -d '"' | grep -E "_URL|_ENDPOINT" > /tmp/configmap.env.values
             . /tmp/configmap.env.values
@@ -49,7 +49,7 @@
 
   - name: Backup secrets for re-use when pods are re-created during the upgrade process
     shell: |
-           kubectl get secrets -n capm3-system -o json |
+           kubectl get secrets -n {{ NAMEPREFIX }}-system -o json |
            jq '.items[]|del(.metadata|.managedFields,.uid,.resourceVersion)' > /tmp/secrets.with.values.yaml
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
@@ -232,7 +232,7 @@
     kubernetes.core.k8s:
       api_version: v1
       kind: Deployment
-      name: capm3-ironic
+      name: "{{ NAMEPREFIX }}-ironic"
       namespace: "{{ IRONIC_NAMESPACE }}"
       resource_definition:
         spec:
@@ -256,7 +256,7 @@
     kubernetes.core.k8s_info:
       api_version: v1
       kind: Deployment
-      name: capm3-ironic
+      name: "{{ NAMEPREFIX }}-ironic"
       namespace: "{{ IRONIC_NAMESPACE }}"
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
     retries: 100

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -2,7 +2,8 @@
 # Ansible playbook related variables
 HOME: "{{ lookup('env', 'HOME') }}"
 NAMESPACE: "{{ lookup('env', 'NAMESPACE') | default('metal3', true) }}"
-IRONIC_NAMESPACE: "{{ lookup('env', 'IRONIC_NAMESPACE') | default('capm3-system', true) }}"
+IRONIC_NAMESPACE: "{{ lookup('env', 'IRONIC_NAMESPACE') | default('baremetal-operator-system', true) }}"
+NAMEPREFIX: "{{ lookup('env', 'NAMEPREFIX') | default('baremetal-operator', true) }}"
 CRS_PATH: "{{ metal3_dir }}/vm-setup/roles/v1aX_integration_test/templates"
 TEMP_GEN_DIR: "{{ metal3_dir }}/vm-setup/roles/v1aX_integration_test/files/manifests"
 MANIFESTS_DIR: "{{ metal3_dir }}/vm-setup/roles/v1aX_integration_test/files"


### PR DESCRIPTION
CAPM3 plans to remove BMO Deployment in its upcoming v1alpha5 api version. This PR deploys the BMO separately and makes the necessary changes to the pivot scripts. 

PRs [242](https://github.com/metal3-io/cluster-api-provider-metal3/pull/242) and [934](https://github.com/metal3-io/baremetal-operator/pull/934) needs to go in before this PR. 