### PR TITLE
Upgrade Ansible k8s modules to 2.1.1 

### DIFF
--- a/vm-setup/requirements.yml
+++ b/vm-setup/requirements.yml
@@ -1,3 +1,8 @@
-- src: https://github.com/fubarhouse/ansible-role-golang.git
-  version: master
-  name: fubarhouse.golang
+roles:
+  - src: https://github.com/fubarhouse/ansible-role-golang.git
+    version: master
+    name: fubarhouse.golang
+  
+collections:
+  - name: kubernetes.core
+    version: 2.1.1

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -43,7 +43,7 @@ packages:
         - libssl-dev
     pip3:
      - python-apt
-     - openshift==0.11.2
+     - kubernetes==17.17.0
      - pyYAML
      - virtualbmc
      - lxml
@@ -86,6 +86,7 @@ packages:
          - httpd-tools
         pip3:
           - jmespath
+          - kubernetes==17.17.0
 DAEMON_JSON_PATH: "{{ metal3_dir }}/vm-setup/roles/packages_installation/files"
 CONTAINER_RUNTIME: "{{ lookup('env', 'CONTAINER_RUNTIME') }}"
 OS_VERSION_ID: "{{ lookup('env', 'OS_VERSION_ID') }}"

--- a/vm-setup/roles/v1aX_integration_test/tasks/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/main.yml
@@ -1,13 +1,4 @@
 ---
-- name: Install openshift client in CentOS 8 using pip3
-  pip:
-    executable: "pip3"
-    name: openshift==0.11.2
-    state: present
-  become: yes
-  become_user: root
-  when: ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == '8'
-
 - name: Generate templates
   include_tasks: generate_templates.yml
 


### PR DESCRIPTION
This PR upgrade Ansible k8s module to `kubernetes.core 2.1.1` that requires pip3 package` kubernetes>=12.0.0`
Openshift was removed since it is a requirement for the old k8s `version 1.2.1 `and it depends on `kubernetes==11.0.0` which also overrides the new version needed `>=12.0.0`