### PR TITLE
Add furkatgofurov7 as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,9 +3,9 @@
 approvers:
  - hardys
  - maelk
- - russellb
  - stbenjam
  - fmuyassarov
+ - furkatgofurov7
  - kashifest
 
 reviewers:
@@ -13,6 +13,5 @@ reviewers:
  - xenwar
  - Jaakko-Os
  - smoshiur1237
- - furkatgofurov7
  - namnx228
  - macaptain


### PR DESCRIPTION
Based on the [community document](https://github.com/metal3-io/metal3-docs/tree/master/maintainers) of adding approvers, adding @furkatgofurov7 as an approver and dropping @russellb from the list as agreed between  the maintainers. of metal3-dev-env repository. 