### PR TITLE
Bump sushy-tools version

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -2,6 +2,6 @@ FROM docker.io/python:3.9
 
 RUN apt update && \
     apt install -y libvirt-dev && \
-    pip3 install sushy-tools==0.15.0 libvirt-python
+    pip3 install sushy-tools==0.17.0 libvirt-python
 
 CMD sushy-emulator -i :: -p 8000 --config /root/sushy/conf.py


### PR DESCRIPTION
Bump sushy-tools version to 0.17.0 to pick up BIOS attribute registry support for testing.