### PR TITLE
Make Ironic credential available in CAPM3 e2e tests.

### DIFF
--- a/scripts/run_command.sh
+++ b/scripts/run_command.sh
@@ -21,5 +21,11 @@ source "${METAL3_DIR}/lib/network.sh"
 # shellcheck disable=SC1090
 # shellcheck disable=SC1091
 source "${METAL3_DIR}/lib/images.sh"
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
+source "${METAL3_DIR}/lib/ironic_basic_auth.sh"
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
+source "${METAL3_DIR}/lib/ironic_tls_setup.sh"
 
 exec "$@"


### PR DESCRIPTION
Currently, the ironic credential detail is not accessible from the e2e test. This PR aims to fix it.