### PR TITLE
Set namespace in the Metal3DataTemplate template

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
@@ -19,7 +19,7 @@ spec:
         cluster.x-k8s.io/cluster-name: ${ CLUSTER_NAME }
         nodepool: nodepool-0
     spec:
-      nodeDrainTimeout: ${ NODE_DRAIN_TIMEOUT }             
+      nodeDrainTimeout: ${ NODE_DRAIN_TIMEOUT }
       clusterName: ${ CLUSTER_NAME }
       version: ${ KUBERNETES_VERSION }
       bootstrap:
@@ -64,6 +64,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: Metal3DataTemplate
 metadata:
   name: ${ CLUSTER_NAME }-workers-template
+  namespace: ${ NAMESPACE }
 spec:
   clusterName: ${ CLUSTER_NAME }
   metaData:


### PR DESCRIPTION
We already set the namespace for all the other resources in this file so
let's make it consistent.

Currently the Metal3DataTemplate will just get the namespace from the context (`kubectl -n <namespace>`) which is why things are not broken.