### PR TITLE
Use kubernetes.core module for Ansible

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
@@ -23,7 +23,7 @@
           (IMAGE_OS == "")
 
   - name: Check if cluster deprovisioning started.
-    k8s_info:
+    kubernetes.core.k8s_info:
       # TODO: This should be set based on CAPI_VERSION when v1alpha4 is working.
       api_version: cluster.x-k8s.io/v1alpha3
       kind: Cluster
@@ -36,7 +36,7 @@
              (deprovision_cluster.resources[0].status.phase | lower == "deleting"))
 
   - name: Wait until "{{ NUM_NODES }}" bmhs become ready again.
-    k8s_info:
+    kubernetes.core.k8s_info:
       api_version: metal3.io/v1alpha1
       kind: BareMetalHost
       namespace: "{{ NAMESPACE }}"
@@ -50,7 +50,7 @@
            (deprovisioned_nodes.resources | json_query(query) | length == (NUM_NODES | int))
 
   - name: Wait until no metal3machines are remaining
-    k8s_info:
+    kubernetes.core.k8s_info:
       api_version: infrastructure.cluster.x-k8s.io/{{ CAPM3_VERSION }}
       kind: Metal3Machine
       namespace: "{{ NAMESPACE }}"
@@ -61,7 +61,7 @@
            (deprovisioned_m3m.resources | length == 0)
 
   - name: Wait until no machines are remaining
-    k8s_info:
+    kubernetes.core.k8s_info:
       # TODO: This should be set based on CAPI_VERSION when v1alpha4 is working.
       api_version: cluster.x-k8s.io/v1alpha3
       kind: Machine
@@ -73,7 +73,7 @@
            (deprovisioned_machines.resources | length == 0)
 
   - name: Wait until no metal3cluster is remaining
-    k8s_info:
+    kubernetes.core.k8s_info:
       api_version: infrastructure.cluster.x-k8s.io/{{ CAPM3_VERSION }}
       kind: Metal3Cluster
       namespace: "{{ NAMESPACE }}"
@@ -84,7 +84,7 @@
            (deprovisioned_metal3cluster.resources | length ==  0)
 
   - name: Wait until no cluster is remaining
-    k8s_info:
+    kubernetes.core.k8s_info:
       # TODO: This should be set based on CAPI_VERSION when v1alpha4 is working.
       api_version: cluster.x-k8s.io/v1alpha3
       kind: Cluster

--- a/vm-setup/roles/v1aX_integration_test/tasks/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/main.yml
@@ -11,21 +11,21 @@
   when: v1aX_integration_test_action in inspection_action
 
 - name: Provision cluster
-  k8s:
+  kubernetes.core.k8s:
     state: present
     src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_cluster_{{ IMAGE_OS|lower }}.yaml"
     namespace: "{{ NAMESPACE }}"
   when: v1aX_integration_test_action in provision_cluster_actions
 
 - name: Create control plane
-  k8s:
+  kubernetes.core.k8s:
     state: present
     src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_controlplane_{{ IMAGE_OS|lower }}.yaml"
     namespace: "{{ NAMESPACE }}"
   when: v1aX_integration_test_action in provision_controlplane_actions
 
 - name: Create worker nodes
-  k8s:
+  kubernetes.core.k8s:
     state: present
     src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_workers_{{ IMAGE_OS|lower }}.yaml"
     namespace: "{{ NAMESPACE }}"
@@ -52,7 +52,7 @@
   when: v1aX_integration_test_action in repivot_actions
 
 - name: Deprovision worker nodes
-  k8s:
+  kubernetes.core.k8s:
     state: absent
     src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_workers_{{ IMAGE_OS|lower }}.yaml"
     namespace: "{{ NAMESPACE }}"
@@ -60,7 +60,7 @@
   when: v1aX_integration_test_action in deprovision_workers_actions
 
 - name: Deprovision control plane
-  k8s:
+  kubernetes.core.k8s:
     state: absent
     src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_controlplane_{{ IMAGE_OS|lower }}.yaml"
     namespace: "{{ NAMESPACE }}"
@@ -68,7 +68,7 @@
   when: v1aX_integration_test_action in deprovision_controlplane_actions
 
 - name: Deprovision cluster
-  k8s:
+  kubernetes.core.k8s:
     state: absent
     src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_cluster_{{ IMAGE_OS|lower }}.yaml"
     namespace: "{{ NAMESPACE }}"

--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -22,7 +22,7 @@
     when: EPHEMERAL_CLUSTER == "kind"
 
   - name: Remove Ironic from source cluster (Ephemeral Cluster is minikube)
-    k8s:
+    kubernetes.core.k8s:
       name: capm3-ironic
       kind: Deployment
       state: absent
@@ -30,7 +30,7 @@
     when: EPHEMERAL_CLUSTER == "minikube"
 
   - name: Obtain target cluster kubeconfig
-    k8s_info:
+    kubernetes.core.k8s_info:
       kind: secrets
       name: "{{ CLUSTER_NAME }}-kubeconfig"
       namespace: "{{ NAMESPACE }}"
@@ -42,7 +42,7 @@
       dest: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
 
   - name: Create namespace
-    k8s:
+    kubernetes.core.k8s:
       name: "{{ NAMESPACE }}"
       kind: Namespace
       state: present
@@ -59,7 +59,7 @@
 
   # Check for cert-manager pods on the target cluster
   - name: Check if cert-manager  pods in running state
-    k8s_info:
+    kubernetes.core.k8s_info:
       kind: pods
       namespace: cert-manager
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
@@ -84,7 +84,7 @@
 
   # Check for pods & nodes on the target cluster
   - name: Check if pods in running state
-    k8s_info:
+    kubernetes.core.k8s_info:
       kind: pods
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
       field_selectors:
@@ -99,7 +99,7 @@
     shell: "clusterctl move --to-kubeconfig /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml -n {{ NAMESPACE }} -v 10"
 
   - name: Check if machines become running.
-    k8s_info:
+    kubernetes.core.k8s_info:
       api_version: cluster.x-k8s.io/v1alpha3
       kind: machines
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
@@ -110,7 +110,7 @@
            (provisioned_machines.resources | filter_phase("running") | length == (NUMBER_OF_BMH | int))
 
   - name: Check if metal3machines become ready.
-    k8s_info:
+    kubernetes.core.k8s_info:
       api_version: infrastructure.cluster.x-k8s.io/v1alpha4
       kind: metal3machine
       namespace: "{{ NAMESPACE }}"
@@ -122,7 +122,7 @@
            (m3m_machines.resources | filter_ready | length == (NUMBER_OF_BMH | int))
 
   - name: Check if bmh is in provisioned state
-    k8s_info:
+    kubernetes.core.k8s_info:
       api_version: metal3.io/v1alpha1
       kind: BareMetalHost
       namespace: "{{ NAMESPACE }}"

--- a/vm-setup/roles/v1aX_integration_test/tasks/move_back.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move_back.yml
@@ -2,7 +2,7 @@
 
   # Remove Ironic from target cluster
   - name: Remove Ironic from target cluster
-    k8s:
+    kubernetes.core.k8s:
       name: capm3-ironic
       kind: Deployment
       state: absent

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -229,7 +229,7 @@
         # - ironic-endpoint-keepalived
 
   - name: Upgrade ironic image based containers
-    community.kubernetes.k8s:
+    kubernetes.core.k8s:
       api_version: v1
       kind: Deployment
       name: capm3-ironic
@@ -253,7 +253,7 @@
             dict2items(key_name='name', value_name='image') }}"
 
   - name: Wait for ironic update to rollout
-    community.kubernetes.k8s_info:
+    kubernetes.core.k8s_info:
       api_version: v1
       kind: Deployment
       name: capm3-ironic
@@ -301,13 +301,13 @@
       dest: /tmp/wr_new_image.yaml
 
   - name: Create controlplane and worker Metal3MachineTemplates
-    community.kubernetes.k8s:
+    kubernetes.core.k8s:
       state: present
       src: /tmp/cp_new_image.yaml
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
 
   - name: Create controlplane and worker Metal3MachineTemplates
-    community.kubernetes.k8s:
+    kubernetes.core.k8s:
       state: present
       src:  /tmp/wr_new_image.yaml
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
@@ -387,8 +387,8 @@
       src: workload.yaml
       dest: /tmp/workload.yaml
 
-  - name: Deploy workload with nodeAffinity 
-    community.kubernetes.k8s:
+  - name: Deploy workload with nodeAffinity
+    kubernetes.core.k8s:
       state: present
       src: /tmp/workload.yaml
       namespace: default

--- a/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
@@ -4,7 +4,7 @@
       NUMBER_OF_BMH: "{{ NUM_OF_MASTER_REPLICAS|int +  NUM_OF_WORKER_REPLICAS|int }}"
 
   - name: Wait until cluster becomes provisioned.
-    k8s_info:
+    kubernetes.core.k8s_info:
       # TODO: This should be set based on CAPI_VERSION when v1alpha4 is working.
       api_version: cluster.x-k8s.io/v1alpha3
       kind: Cluster
@@ -14,10 +14,10 @@
     delay: 20
     until: (provisioned_cluster is succeeded) and
            (provisioned_cluster.resources | length > 0) and
-           (provisioned_cluster.resources[0].status.phase | lower == "provisioned")
+           (provisioned_cluster.resources[0].status.phase | default("none") | lower == "provisioned")
 
   - name: Wait until "{{ NUMBER_OF_BMH }}" BMHs become provisioned.
-    k8s_info:
+    kubernetes.core.k8s_info:
       api_version: metal3.io/v1alpha1
       kind: BareMetalHost
       namespace: "{{ NAMESPACE }}"
@@ -31,7 +31,7 @@
            (provisioned_bmh.resources | json_query(query) | length ==  (NUMBER_OF_BMH | int))
 
   - name: Wait until "{{ NUMBER_OF_BMH }}" machines become running.
-    k8s_info:
+    kubernetes.core.k8s_info:
       # TODO: This should be set based on CAPI_VERSION when v1alpha4 is working.
       api_version: cluster.x-k8s.io/v1alpha3
       kind: Machine
@@ -46,7 +46,7 @@
            (provisioned_machines.resources | json_query(query) | length == (NUMBER_OF_BMH | int))
 
   - name: Fetch target cluster kubeconfig
-    k8s_info:
+    kubernetes.core.k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ CLUSTER_NAME }}-kubeconfig"
@@ -97,7 +97,7 @@
       IMAGE_OS == "Centos"
 
   - name: Apply Calico manifest
-    k8s:
+    kubernetes.core.k8s:
       state: present
       src: "/tmp/calico.yaml"
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
@@ -105,7 +105,7 @@
 
   # Check for pods & nodes on the target cluster
   - name: Wait for all pods to be in running state
-    k8s_info:
+    kubernetes.core.k8s_info:
       api_version: v1
       kind: Pod
       namespace: "{{ NAMESPACE }}"
@@ -119,7 +119,7 @@
            (not_running_pods.resources | length == 0)
 
   - name: Wait for nodes to be in ready state
-    k8s_info:
+    kubernetes.core.k8s_info:
       api_version: v1
       kind: Node
       kubeconfig: /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml


### PR DESCRIPTION
We have removed the dependency for the old community.kubernetes module
already so we need to make sure all tasks use the new kubernetes.core
module instead.

It is not strictly needed to use the full name (i.e. `kubernetes.core.k8s` not `k8s`), however it is recommended to use the full name and it makes it more obvious what module it used. The most important thing is to get rid of all references to `community.kubernetes` and replace them with `kubernetes.core`.

This should fix the error seen [here](https://jenkins.nordix.org/view/Airship/job/airship_master_feature_tests_upgrade_ubuntu/416/console)

Edit: Added another commit to fix [this](https://jenkins.nordix.org/view/Airship/job/airship_master_feature_tests_ubuntu/557/console). The status field can be missing right when the cluster is created, so we have to set a default value to avoid issues with undefined values.