### PR TITLE
Decrease delay when waiting for reboot

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/remediation.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/remediation.yml
@@ -41,8 +41,8 @@
       command: list_vms
       state: shutdown
     register: shutdown_vms
-    retries: 50
-    delay: 10
+    retries: 170
+    delay: 3
     until: WORKER_VM in shutdown_vms.list_vms
     become: yes
     become_user: root


### PR DESCRIPTION
When the delay is large there is a risk that the VM have time to start
again before we see the "shutdown" state.

This is an attempt to fix the flaky issue we are seeing [here](https://jenkins.nordix.org/view/Airship/job/airship_master_feature_tests_ubuntu/559/console).