### PR TITLE
Add ansible profile_tasks callback to print tasks timing

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,4 +1,5 @@
 [defaults]
+callback_whitelist=ansible.posix.profile_tasks
 stdout_callback=community.general.diy
 
 [callback_diy]

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -31,6 +31,9 @@ source "${METAL3_DIR}/lib/ironic_basic_auth.sh"
 # Disable SSH strong authentication
 export ANSIBLE_HOST_KEY_CHECKING=False
 
+# Ansible config file 
+export ANSIBLE_CONFIG=${METAL3_DIR}/ansible.cfg
+
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
    -e "metal3_dir=$SCRIPTDIR" \
    -e "v1aX_integration_test_action=${ACTION}" \


### PR DESCRIPTION
This PR add timing information to Ansible tasks using [profile_tasks](https://docs.ansible.com/ansible/latest/collections/ansible/posix/profile_tasks_callback.html) that can help identify tasks consuming time and optimize tests.
Fix the config file `ansible.cfg` reference in feature_tests playbooks