### PR TITLE
Decrease delay when waiting for node to be NotReady

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/remediation.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/remediation.yml
@@ -71,8 +71,8 @@
       kind: nodes
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
     register: nodes
-    retries: 150
-    delay: 3
+    retries: 200
+    delay: 2
     vars:
       q: "[? metadata.name == '{{WORKER_NODE}}' && status.conditions[? type=='Ready' && status=='False']]"
     until:


### PR DESCRIPTION
The task that checks when the node becomes `NotReady` may fail since the delay needed for the node to change from `notReady` to ready is close to the delay of task. This may allow the node to become ready before the task checks the `notReady` status.

This PR try to avoid these issues seen [here](https://jenkins.nordix.org/view/Airship/job/airship_master_feature_tests_ubuntu/575/consoleFull).