### PR TITLE
Set default value of FORCE_REPO_UPDATE to true

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -130,7 +130,7 @@ fi
 
 BMOREPO="${BMOREPO:-https://github.com/metal3-io/baremetal-operator.git}"
 BMOBRANCH="${BMOBRANCH:-master}"
-FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-false}"
+FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-true}"
 
 BMO_RUN_LOCAL="${BMO_RUN_LOCAL:-false}"
 CAPM3_RUN_LOCAL="${CAPM3_RUN_LOCAL:-false}"

--- a/vars.md
+++ b/vars.md
@@ -22,7 +22,7 @@ assured that they are persisted.
 | BMOBRANCH | Set the Baremetal Operator branch to checkout | | master |
 | CAPM3REPO | Set the Cluster Api Metal3 provider repository to clone | | https://github.com/metal3-io/cluster-api-provider-metal3.git |
 | CAPM3BRANCH | Set the Cluster Api Metal3 provider branch to checkout | | master |
-| FORCE_REPO_UPDATE | Force deletion of the BMO and CAPM3 repositories before cloning them again | "true", "false" | "false" |
+| FORCE_REPO_UPDATE | Force deletion of the BMO, CAPM3 and IPAM repositories before cloning them again | "true", "false" | "true" |
 | BMO_RUN_LOCAL | Run a local baremetal operator instead of deploying in Kubernetes | "true", "false" | "false" |
 | CAPM3_RUN_LOCAL | Run a local CAPM3 operator instead of deploying in Kubernetes | "true", "false" | "false" |
 | SKIP_RETRIES | Do not retry on failure during verifications or tests of the environment. This should be false. It could only be set to false for verifications of a dev env deployment that fully completed. Otherwise failures will appear as resources are not ready. | "true", "false" | "false" |


### PR DESCRIPTION
It was decided that for most usecase it is better to force
sync/update the metal3-io GO dependencies.