### PR TITLE
Fetch Ironic container logs before pivoting

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -3,6 +3,38 @@
     set_fact:
       NUMBER_OF_BMH: "{{ NUM_OF_MASTER_REPLICAS|int +  NUM_OF_WORKER_REPLICAS|int }}"
 
+  - name: Create directories for storing container logs
+    file:
+      path: "/tmp/{{ CONTAINER_RUNTIME }}/{{ item }}"
+      state: directory
+    loop:
+        - ironic-api
+        - ironic-conductor
+        - ironic-inspector
+        - dnsmasq
+        - httpd-infra
+        - mariadb
+        - ironic-endpoint-keepalived
+        - ironic-log-watch
+        - ironic-inspector-log-watch
+    when: EPHEMERAL_CLUSTER == "kind"
+
+  - name: Fetch container logs before pivoting
+    shell: "sudo {{ CONTAINER_RUNTIME }} logs {{ item }} > /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stdout.log 2> /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stderr.log"
+    with_items:
+        - ironic-api
+        - ironic-conductor
+        - ironic-inspector
+        - dnsmasq
+        - httpd-infra
+        - mariadb
+        - ironic-endpoint-keepalived
+        - ironic-log-watch
+        - ironic-inspector-log-watch
+    become: yes
+    become_user: root
+    when: EPHEMERAL_CLUSTER == "kind"
+
   - name: Remove ironic container from source cluster (Ephemeral Cluster is kind)
     docker_container:
       name: "{{ item }}"


### PR DESCRIPTION
When Ironic is running outside of the cluster, i.e., as docker containers, initial logs of the containers get lost after pivoting to the target cluster. Currently we are fetching Ironic container logs at the end of the CI run, when we are pivoted back to the source cluster and when Ironic containers are recreated. Since Ironic is re-created, we are losing initial logs of Ironic containers, for example when Ironic nodes go from registering to ready state, which happens only on the source cluster. Losing those logs will only make it confusing for someone debugging the Ironic.
This patch adds a task to fetch the logs before containers are deleted and the next step would be to copy those fetched logs from `/tmp` to the CI output (will be done in a seperate pull request in project-infra repository). See the related slack discussion [here](https://kubernetes.slack.com/archives/CHD49TLE7/p1627462885343400)
