### PR TITLE
Use baremetal operator branch image when deploying to target cluster

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -95,7 +95,6 @@ function launch_baremetal_operator() {
   # Deploy BMO using deploy.sh script
 
   # Update container images to use local ones
-  cp "${BMOPATH}/config/manager/manager.yaml" "${BMOPATH}/config/manager/manager.yaml.orig"
   update_kustomization_images "${BMOPATH}/config/manager/manager.yaml"
 
   # Update Configmap parameters with correct urls
@@ -112,7 +111,6 @@ EOF
 
   # Restore original files
   mv "${BMOPATH}/config/default/ironic.env.orig" "${BMOPATH}/config/default/ironic.env"
-  mv "${BMOPATH}/config/manager/manager.yaml.orig" "${BMOPATH}/config/manager/manager.yaml"
 
   # If BMO should run locally, scale down the deployment and run BMO
   if [ "${BMO_RUN_LOCAL}" == "true" ]; then

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -95,6 +95,7 @@ function launch_baremetal_operator() {
   # Deploy BMO using deploy.sh script
 
   # Update container images to use local ones
+  cp "${BMOPATH}/config/manager/manager.yaml" "${BMOPATH}/config/manager/manager.yaml.orig"
   update_kustomization_images "${BMOPATH}/config/manager/manager.yaml"
 
   # Update Configmap parameters with correct urls

--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -119,6 +119,10 @@
       KUBECTL_ARGS: "{{ KUBECTL_ARGS }}"
     when: CAPM3_VERSION == "v1alpha5"
 
+  - name: Reinstate Baremetal Operator Manager
+    shell: "mv {{ BMOPATH }}/config/manager/manager.yaml.orig {{ BMOPATH }}/config/manager/manager.yaml"
+    when: CAPM3_VERSION == "v1alpha5"
+
   # Install Ironic
   - name: Install Ironic
     shell: "{{ BMOPATH }}/tools/deploy.sh false true {{ IRONIC_TLS_SETUP }} {{ IRONIC_BASIC_AUTH }} true"


### PR DESCRIPTION
Baremetal operator is deployed into management cluster using the branch image
built in locally. However, when it is deployed into target cluster, master branch
image is used. This creates conflicts when there are both changes at kustomization
and go code. This PR changes by always using local image built from PR's branch and
this creates consistency between management and target clusters.