### PR TITLE
network: allow use of NATv6 if needed

### DIFF
--- a/vm-setup/roles/common/defaults/main.yml
+++ b/vm-setup/roles/common/defaults/main.yml
@@ -54,6 +54,7 @@ networks:
   - name: baremetal
     bridge: baremetal
     forward_mode: "{% if manage_baremetal == 'y' %}nat{% else %}bridge{% endif %}"
+    enable_natv6: false
     address_v4: "{{ baremetal_network_cidr_v4|nthhost(1)|default('', true) }}"
     netmask_v4: "{{ baremetal_network_cidr_v4|ipaddr('netmask') }}"
     dhcp_range_v4:

--- a/vm-setup/roles/libvirt/templates/network.xml.j2
+++ b/vm-setup/roles/libvirt/templates/network.xml.j2
@@ -17,7 +17,11 @@
 {% if item.forward_mode is defined %}
   <forward mode='{{ item.forward_mode }}'>
   {% if item.forward_mode == 'nat' %}
+    {% if item.enable_natv6 is defined and (item.enable_natv6 | bool) %}
+    <nat ipv6='yes'>
+    {% else %}
     <nat>
+    {% endif %}
       <port start='{{ nat_port_range[0] }}' end='{{ nat_port_range[1] }}' />
     </nat>
   {% endif %}


### PR DESCRIPTION
Since Libvirt 6.5, NATv6 works with IPv6. If a user requests an IPv6
network today with metal3-dev-env, NAT won't work as you have to opt-in
to the feature. This adds the required `ipv6=yes` to the `<nat>` tag to
make this work.

On previous versions of libvirt the unknown attribute just gets ignored
and removed.