### PR TITLE
Clean when deleting minikube

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -423,7 +423,7 @@ function init_minikube() {
         if [[ $minikube_error -eq 0 ]]; then
           break
         fi
-        sudo su -l -c 'minikube delete' "${USER}"
+        sudo su -l -c 'minikube delete --all --purge' "${USER}"
       done
       sudo su -l -c "minikube stop" "$USER"
     fi


### PR DESCRIPTION
This PR adds options `--all --purge ` to `minikube delete` to delete all profiles and the '.minikube' folder. 

This will avoid any potential issue when retrying to create minikube such as : `Message='operation failed: network 'mk-minikube' already exists with uuid c79ec658-7a5d-4453-9836-0dfe2e62188b'` seen [here](https://jenkins.nordix.org/view/Airship/job/airship_master_feature_tests_centos/458/consoleFull).