### PR TITLE
Remove duplicate BMH deletion in cleanup script

### DIFF
--- a/scripts/feature_tests/cleanup_env.sh
+++ b/scripts/feature_tests/cleanup_env.sh
@@ -36,7 +36,6 @@ kubectl delete -f "${WORKING_DIR}/bmhosts_crs.yaml" -n "${NAMESPACE}" --timeout 
 popd || exit
 
 declare -a OBJECTS=("cluster" \
-"baremetalhost" \
 "kubeadmconfig" \
 "kubeadmcontrolplane" \
 "machines" \


### PR DESCRIPTION
Remove deleting of BMH since we delete BMHs' earlier in the same script with:

`kubectl delete -f "${WORKING_DIR}/bmhosts_crs.yaml" -n "${NAMESPACE}" --timeout 10s`

We can see CI output where it tries to delete BMHs' and not being able to find them throwing an error:
```
++ kubectl get baremetalhost -n metal3 -o name
+ kind='baremetalhost.metal3.io/node-0
baremetalhost.metal3.io/node-1
baremetalhost.metal3.io/node-2
baremetalhost.metal3.io/node-3'
+ for item in $kind
+ kubectl patch baremetalhost.metal3.io/node-0 -n metal3 -p '{"metadata":{"finalizers":[]}}' --type=merge
baremetalhost.metal3.io/node-0 patched
+ kubectl delete baremetalhost.metal3.io/node-0 -n metal3 --timeout 10s
Error from server (NotFound): baremetalhosts.metal3.io "node-0" not found
+ for item in $kind
+ kubectl patch baremetalhost.metal3.io/node-1 -n metal3 -p '{"metadata":{"finalizers":[]}}' --type=merge
baremetalhost.metal3.io/node-1 patched
+ kubectl delete baremetalhost.metal3.io/node-1 -n metal3 --timeout 10s
Error from server (NotFound): baremetalhosts.metal3.io "node-1" not found
+ for item in $kind
+ kubectl patch baremetalhost.metal3.io/node-2 -n metal3 -p '{"metadata":{"finalizers":[]}}' --type=merge
baremetalhost.metal3.io/node-2 patched
+ kubectl delete baremetalhost.metal3.io/node-2 -n metal3 --timeout 10s
Error from server (NotFound): baremetalhosts.metal3.io "node-2" not found
+ for item in $kind
+ kubectl patch baremetalhost.metal3.io/node-3 -n metal3 -p '{"metadata":{"finalizers":[]}}' --type=merge
baremetalhost.metal3.io/node-3 patched
+ kubectl delete baremetalhost.metal3.io/node-3 -n metal3 --timeout 10s
Error from server (NotFound): baremetalhosts.metal3.io "node-3" not found
+ process_status 1
+ [[ 1 == 0 ]]
+ echo 'FAIL - '
FAIL -
+ FAILS=1
```