### PR TITLE
Don't try to delete non-existing httpd container

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -44,7 +44,6 @@
        - ironic-conductor
        - ironic-inspector
        - dnsmasq
-       - httpd
        - mariadb
        - ironic-endpoint-keepalived
        - ironic-log-watch


### PR DESCRIPTION
Don't try to delete httpd container which is merged into the Ironic-api.