### PR TITLE
Parameterize resource API versions

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -169,7 +169,7 @@
 
   - name: Check if metal3machines become ready.
     kubernetes.core.k8s_info:
-      api_version: infrastructure.cluster.x-k8s.io/v1alpha4
+      api_version: infrastructure.cluster.x-k8s.io/{{ CAPM3_VERSION }}
       kind: metal3machine
       namespace: "{{ NAMESPACE }}"
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -5,7 +5,7 @@
 
   - name: Update maxSurge and maxUnavailable fields
     kubernetes.core.k8s:
-      api_version: cluster.x-k8s.io/v1alpha3
+      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
       kind: MachineDeployment
       name: "{{ CLUSTER_NAME }}"
       namespace: "{{ NAMESPACE }}"
@@ -25,7 +25,7 @@
 
   - name: Scale worker down to 0
     kubernetes.core.k8s:
-      api_version: cluster.x-k8s.io/v1alpha3
+      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
       kind: MachineDeployment
       name: "{{ CLUSTER_NAME }}"
       namespace: "{{ NAMESPACE }}"
@@ -352,7 +352,7 @@
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
   - name: Get cluster uid
     kubernetes.core.k8s_info:
-      api_version: cluster.x-k8s.io/v1alpha3
+      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
       kind: Cluster
       name: "{{ CLUSTER_NAME }}"
       namespace: "{{ NAMESPACE }}"
@@ -381,7 +381,7 @@
 
   - name: Update boot-disk and kubernetes versions of controlplane nodes
     kubernetes.core.k8s:
-      api_version: controlplane.cluster.x-k8s.io/v1alpha3
+      api_version: controlplane.cluster.x-k8s.io/{{ CAPI_VERSION }}
       kind: KubeadmControlPlane
       name: "{{ CLUSTER_NAME }}"
       namespace: "{{ NAMESPACE }}"
@@ -453,7 +453,7 @@
 
   - name: Scale worker up to 1
     kubernetes.core.k8s:
-      api_version: cluster.x-k8s.io/v1alpha3
+      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
       kind: MachineDeployment
       name: "{{ CLUSTER_NAME }}"
       namespace: "{{ NAMESPACE }}"
@@ -515,7 +515,7 @@
 
   - name: Update boot-disk and kubernetes versions of worker node
     kubernetes.core.k8s:
-      api_version: cluster.x-k8s.io/v1alpha3
+      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
       kind: MachineDeployment
       name: "{{ CLUSTER_NAME }}"
       namespace: "{{ NAMESPACE }}"
@@ -559,7 +559,7 @@
 
   - name: Verify that kubernetes version is upgraded for CP and worker nodes
     kubernetes.core.k8s_info:
-      api_version: cluster.x-k8s.io/v1alpha3
+      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
       kind: Machine
       namespace: "{{ NAMESPACE }}"
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"


### PR DESCRIPTION
Parameterize resource API versions since we run two different API versions of CAPI and CAPM3 resources.
Based on https://github.com/metal3-io/metal3-dev-env/pull/754