### PR TITLE
Don't restore BMO configmap until we deploy it in the target cluster

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -110,9 +110,6 @@ EOF
   # Deploy. Args: <deploy-BMO> <deploy-Ironic> <deploy-TLS> <deploy-Basic-Auth> <deploy-Keepalived>
   "${BMOPATH}/tools/deploy.sh" true false "${IRONIC_TLS_SETUP}" "${IRONIC_BASIC_AUTH}" true
 
-  # Restore original files
-  mv "${BMOPATH}/config/default/ironic.env.orig" "${BMOPATH}/config/default/ironic.env"
-
   # If BMO should run locally, scale down the deployment and run BMO
   if [ "${BMO_RUN_LOCAL}" == "true" ]; then
     if [ "${IRONIC_TLS_SETUP}" == "true" ]; then

--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -130,7 +130,11 @@
       IRONIC_HOST_IP: "{{ IRONIC_HOST_IP }}"
       KUBECTL_ARGS: "{{ KUBECTL_ARGS }}"
 
-  - name: Reinstate Ironic Configmap
+  - name: Restore original BMO Configmap
+    shell: "mv {{ BMOPATH }}/config/default/ironic.env.orig {{ BMOPATH }}/config/default/ironic.env"
+    when: CAPM3_VERSION != "v1alpha4"
+
+  - name: Restore original Ironic Configmap
     shell: "mv {{ BMOPATH }}/ironic-deployment/keepalived/ironic_bmo_configmap.env.orig {{ BMOPATH }}/ironic-deployment/keepalived/ironic_bmo_configmap.env"
 
   - name: Label BMO CRDs in target cluster.


### PR DESCRIPTION
While deploying BMO in the source cluster, we are modifying IRONIC related env vars that are in [ironic.env](https://github.com/metal3-io/baremetal-operator/blob/master/config/default/ironic.env) file. Right after deploying the BMO, we are restoring changes in [ironic.env](https://github.com/metal3-io/baremetal-operator/blob/master/config/default/ironic.env). 

However, when deploying BMO in the target cluster we are relaying on the default env vars from [config/default/ironic.env](https://github.com/metal3-io/baremetal-operator/blob/master/config/default/ironic.env) which doesn't include corrected env vars. So, basically we are missing the step of env vars modification during the BMO deployment in the target cluster.

There are two ways to fix it:
1. Redo the modifications of env vars just before BMO deployment in target cluster and then restore it again
2. Don't restore the modified ironic.env in 03_* script (during BMO deployment in the source cluster) and do it only after we deploy the BMO in the target cluster. 

For now, I've chosen the option-2 and if you think that option-1 is better then please let me know. 