### PR TITLE
Fix flaky reboot task in remediation

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/power_cycle.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/power_cycle.yml
@@ -15,13 +15,13 @@
     k8s_info:
       api_version: v1
       kind: nodes
-      name: "{{K8S_NODE}}"
+      name: "{{ K8S_NODE }}"
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
     register: nodes
     retries: 150
     delay: 3
     vars:
-      q: "[? metadata.name == '{{K8S_NODE}}' && status.conditions[? type=='Ready' && status!='True']]"
+      q: "[? metadata.name == '{{ K8S_NODE }}' && status.conditions[? type=='Ready' && status!='True']]"
     until:
       - nodes is succeeded
       - nodes.resources | json_query(q) | length > 0
@@ -67,7 +67,7 @@
     k8s_info:
       api_version: v1
       kind: nodes
-      name: "{{K8S_NODE}}"
+      name: "{{ K8S_NODE }}"
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
       wait: True
       wait_condition:

--- a/vm-setup/roles/v1aX_integration_test/tasks/reboot.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/reboot.yml
@@ -1,0 +1,48 @@
+  - name: Reboot "{{ BMH_NODE }}"
+    k8s:
+      state: present
+      namespace: "{{ NAMESPACE }}"
+      definition:
+        apiVersion: metal3.io/v1alpha1
+        kind: BareMetalHost
+        metadata:
+          name: "{{ BMH_NODE }}"
+          annotations:
+            reboot.metal3.io: ""
+
+  - name: Wait for "{{ LIBVIRT_VM }}" virtual machine to go into shutdown state
+    virt:
+      command: list_vms
+      state: shutdown
+    register: shutdown_vms
+    retries: 170
+    delay: 3
+    until: LIBVIRT_VM in shutdown_vms.list_vms
+    become: yes
+    become_user: root
+
+  - name: Wait for "{{ LIBVIRT_VM }}" virtual machine to go into running state
+    virt:
+      command: list_vms
+      state: running
+    register: running_vms
+    retries: 170
+    delay: 3
+    until: LIBVIRT_VM in running_vms.list_vms
+    become: yes
+    become_user: root
+
+  - name: Wait until rebooted worker "{{ K8S_NODE }}" becomes Ready
+    k8s_info:
+      api_version: v1
+      kind: nodes
+      name: "{{ K8S_NODE }}"
+      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
+    register: nodes
+    retries: 150
+    delay: 3
+    vars:
+      q: "[? metadata.name == '{{K8S_NODE}}' && status.conditions[? type=='Ready' && status=='True']]"
+    until:
+      - nodes is succeeded
+      - nodes.resources | json_query(q) | length > 0

--- a/vm-setup/roles/v1aX_integration_test/tasks/remediation.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/remediation.yml
@@ -41,70 +41,13 @@
       content: "{{ metal3_kubeconfig.resources[0].data.value | b64decode }}"
       dest: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
 
-  # Reboot a single worker node
-  - name: Reboot "{{ WORKER_BMH }}"
-    k8s:
-      state: present
-      namespace: "{{ NAMESPACE }}"
-      definition:
-        apiVersion: metal3.io/v1alpha1
-        kind: BareMetalHost
-        metadata:
-          name: "{{ WORKER_BMH }}"
-          annotations:
-            reboot.metal3.io: ""
-
-  - name: List only powered off VMs
-    virt:
-      command: list_vms
-      state: shutdown
-    register: shutdown_vms
-    retries: 170
-    delay: 3
-    until: WORKER_VM in shutdown_vms.list_vms
-    become: yes
-    become_user: root
-
-  - name: Wait until rebooted worker "{{ WORKER_NODE }}" becomes NotReady
-    k8s_info:
-      api_version: v1
-      kind: nodes
-      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    register: nodes
-    retries: 200
-    delay: 2
+  - name: Reboot a single worker node
+    include_tasks: reboot.yml
     vars:
-      q: "[? metadata.name == '{{WORKER_NODE}}' && status.conditions[? type=='Ready' && status=='False']]"
-    until:
-      - nodes is succeeded
-      - nodes.resources | json_query(q) | length > 0
+      BMH_NODE: "{{ WORKER_BMH }}"
+      LIBVIRT_VM: "{{ WORKER_VM }}"
+      K8S_NODE: "{{ WORKER_NODE }}"
 
-  - name: Wait until rebooted worker "{{ WORKER_NODE }}" becomes Ready
-    k8s_info:
-      api_version: v1
-      kind: nodes
-      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    register: nodes
-    retries: 150
-    delay: 3
-    vars:
-      q: "[? metadata.name == '{{WORKER_NODE}}' && status.conditions[? type=='Ready' && status=='True']]"
-    until:
-      - nodes is succeeded
-      - nodes.resources | json_query(q) | length > 0
-
-  - name: List only running VMs
-    virt:
-      command: list_vms
-      state: running
-    register: running_vms
-    retries: 50
-    delay: 10
-    until: WORKER_VM in running_vms.list_vms
-    become: yes
-    become_user: root
-
-  # Power cycle a single worker node
   - name: Power cycle a single worker node
     include_tasks: power_cycle.yml
     vars:
@@ -112,7 +55,6 @@
       LIBVIRT_VM: "{{ WORKER_VM }}"
       K8S_NODE: "{{ WORKER_NODE }}"
 
-  # Power cycle a single master node
   - name: Power cycle a single master node
     include_tasks: power_cycle.yml
     vars:


### PR DESCRIPTION
In the remediation tests, if the rebooted node is never spotted going into 'NotReady' by Ansible (i.e. the node recovers quicker than expected), a task loops until the build times out.

https://jenkins.nordix.org/view/Airship/job/airship_master_feature_tests_ubuntu/622/console

This change fixes the flake. Instead of checking for 'NotReady', we confirm that the node was really rebooted by checking the virtual machine goes into shutdown, and then wait for the virtual machine to go into running. This confirms that the machine was rebooted. Then we check that the node has become Ready after the reboot. The reboot tasks have been moved into a separate file with variables matching the names in the similar power_cycle.yaml tasks for consistency.