### PR TITLE
Set cert-manager to v1.4.0

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -334,6 +334,15 @@ function patch_clusterctl(){
   pushd "${CAPM3PATH}"
   mkdir -p "${HOME}"/.cluster-api
   touch "${HOME}"/.cluster-api/clusterctl.yaml
+  
+  ## Remove these lines
+  ## This is hard-coded until we fix the issue with v1.5.0
+  cat << EOF | sudo tee "${HOME}/.cluster-api/clusterctl.yaml"
+cert-manager:
+  version: "v1.4.0" 
+EOF
+  
+  
 
   # At this point the images variables have been updated with update_images
   # Reflect the change in components files


### PR DESCRIPTION
We are fixing cert-manager to v1.4.0 until we find a fix for version: v1.5.0.

In v1.5.0 we are seeing Errors like as follows: 
`Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"selfsigned-cert.169e7cf3af8c4f97", GenerateName:"", Namespace:"cert-manager-test", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"Certificate", Namespace:"cert-manager-test", Name:"selfsigned-cert", UID:"a9cb4591-e5d1-4b29-a437-5edb17cb2fbc", APIVersion:"cert-manager.io/v1", ResourceVersion:"1351", FieldPath:""}, Reason:"Issuing", Message:"Issuing certificate as Secret does not exist", Source:v1.EventSource{Component:"cert-manager", Host:""}, FirstTimestamp:v1.Time{Time:time.Time{wall:0xc0419b1f4d0aad97, ext:27538090122, loc:(*time.Location)(0x3729900)}}, LastTimestamp:v1.Time{Time:time.Time{wall:0xc0419b1f4d0aad97, ext:27538090122, loc:(*time.Location)(0x3729900)}}, Count:1, Type:"Normal", EventTime:v1.MicroTime{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'events "selfsigned-cert.169e7cf3af8c4f97" is forbidden: unable to create new content in namespace cert-manager-test because it is being terminated' (will not retry!)`
