### PR TITLE
Add bool filter to extradisks conditional

### DIFF
--- a/vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml
@@ -90,7 +90,7 @@
     - name: Create additional blockdevice for objectstorage nodes
       command: >
         dd if=/dev/zero of={{ libvirt_volume_path }}/{{ item[0].name }}_{{ item[1] }}.img bs=1 count=0 seek={{ extradisks_size }}
-      when: flavors[item[0].flavor].extradisks|default(false)
+      when: flavors[item[0].flavor].extradisks|default(false)|bool
       with_nested:
         - "{{ vm_nodes }}"
         - "{{ extradisks_list }}"
@@ -98,7 +98,7 @@
     - name: Check if additional blockdevices are attached
       command: >
         virsh domblkinfo {{ item[0].name }} {{ libvirt_volume_path }}/{{ item[0].name }}_{{ item[1] }}.img
-      when: flavors[item[0].flavor].extradisks|default(false)
+      when: flavors[item[0].flavor].extradisks|default(false)|bool
       changed_when: false
       ignore_errors: true
       register: vm_extradisks_check
@@ -118,7 +118,7 @@
         virsh domuuid "{{ item.name }}"
       register: vm_uuid
       with_items: "{{ vm_nodes }}"
-    
+
     - name: set_fact
       set_fact:
         vm_id: "{{ vm_id|default({}) | combine ( {item.item.name: item.stdout} ) }}"


### PR DESCRIPTION
The current logic only considers extradisks as false when the flavor omits
the variable, but if you try to set it from the environment it will always
evaluate to true, even if the value is "false", e.g:

```
  worker:
    memory: "{{ lookup('env', 'WORKER_MEMORY') }}"
    disk: "{{ lookup('env', 'WORKER_DISK') }}"
    vcpu: "{{ lookup('env', 'WORKER_VCPU') }}"
    extradisks: "{{ lookup('env', 'VM_EXTRADISKS') | default(false) }}"
```

In this case, even if you default VM_EXTRADISKS to "false" the conditionals
still evaluate to true.