### PR TITLE
✨ Enhance Ansible retry logs

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,11 +2,13 @@
 callback_whitelist=ansible.posix.profile_tasks
 stdout_callback=community.general.diy
 
+[callback_profile_tasks]
+task_output_limit = 3
+
 [callback_diy]
 ; Note that the action can be both k8s_info and community.kubernetes.k8s_info
-runner_retry_msg='
-  FAILED: {{ ansible_callback_diy.task.name }}
-  {{ ("FAILED: " + ansible_callback_diy.task.name) | length * "-" }}
+runner_retry_msg='{% if ansible_callback_diy.result.output.attempts == 1 %}
+  FAILED retry: {{ ansible_callback_diy.task.name }}
   {% if ansible_callback_diy.task.action is search("k8s_info") %}
   {% for r in ansible_callback_diy.result.output.resources %}
     kind: {{ r.kind }}
@@ -19,6 +21,13 @@ runner_retry_msg='
       {{ r.status | to_nice_yaml | indent(2, first=True) }}
     {% endif %}
   {% endfor %}
+  {% else %}
+    {% if ansible_callback_diy.result.output | to_nice_yaml | length > 5000 %}
+      {{ ansible_callback_diy.result.output }}
+    {% else %}
+      {{ ansible_callback_diy.result.output | to_nice_yaml(indent=2) }}
+    {% endif %}
+  {% endif %}
   {% endif %}
   RETRYING: {{ ansible_callback_diy.task.name }} {{ ansible_callback_diy.result.output.attempts }}/{{ ansible_callback_diy.task.retries }}'
 runner_on_failed_msg='


### PR DESCRIPTION
This PR optimizes Ansible k8s_info logs by printing only the first retry details and omit repeating the same output details for every retry.