### PR TITLE
Refactor CP scale down to avoid hanging conns

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/node_reuse.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/node_reuse.yml
@@ -9,7 +9,13 @@
         kubectl taint nodes --all node-role.kubernetes.io/master-
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    ignore_errors: yes
+    register: kubectl_taint
+    failed_when: >
+      kubectl_taint.rc != 0 and
+      not (
+        kubectl_taint.stderr_lines | unique | length == 1 and 
+        kubectl_taint.stderr.endswith("taint \"node-role.kubernetes.io/master\" not found")
+      )
 
   - name: Scale worker down to 0 to start testing KubeadmControlPlane node reuse test scenario.
     k8s:
@@ -150,7 +156,13 @@
         kubectl taint nodes --all node-role.kubernetes.io/master-
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    ignore_errors: yes
+    register: kubectl_taint
+    failed_when: >
+      kubectl_taint.rc != 0 and
+      not (
+        kubectl_taint.stderr_lines | unique | length == 1 and 
+        kubectl_taint.stderr.endswith("taint \"node-role.kubernetes.io/master\" not found")
+      )
 
   - name: Wait until all "{{ NUMBER_OF_BMH_KCP }}" machines become running and updated with new "{{ UPGRADED_K8S_VERSION }}" k8s version.
     k8s_info:
@@ -209,28 +221,29 @@
         spec:
           replicas: 1
 
-  - pause:
-      minutes: 5
+  - name: Wait until controlplane is scaled down and "{{ NUMBER_OF_BMH_KCP }}" BMHs' are Ready.
+    # we use shell instead of k8s_info module here because the CP may not respond to requests 
+    # while it is scaling down - k8s_info has no request timeout, which can hang the build
+    shell: kubectl get bmh -n "{{ NAMESPACE }}" | grep -w ready | wc -l
+    environment:
+      KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
+    register: num_ready_bmhs
+    retries: 200
+    delay: 30
+    until: num_ready_bmhs.stdout == "3"
 
   - name: Untaint all CP nodes.
     shell: |
         kubectl taint nodes --all node-role.kubernetes.io/master-
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    ignore_errors: yes
-
-  - name: Wait until controlplane is scaled down and "{{ NUMBER_OF_BMH_KCP }}" BMHs' are Ready.
-    k8s_info:
-      api_version: metal3.io/v1alpha1
-      kind: BareMetalHost
-      namespace: "{{ NAMESPACE }}"
-      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    register: bmhs
-    retries: 200
-    delay: 20
-    until:
-      - bmhs is succeeded
-      - bmhs.resources | filter_provisioning("ready") | length == (NUMBER_OF_BMH_KCP | int)
+    register: kubectl_taint
+    failed_when: >
+      kubectl_taint.rc != 0 and
+      not (
+        kubectl_taint.stderr_lines | unique | length == 1 and 
+        kubectl_taint.stderr.endswith("taint \"node-role.kubernetes.io/master\" not found")
+      )
 
   - name: Scale worker up to "{{ NUMBER_OF_BMH_MD }}" to start testing MachineDeployment node reuse test scenario.
     k8s:

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -21,7 +21,13 @@
     ansible.builtin.command: kubectl taint nodes --all node-role.kubernetes.io/master-
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    ignore_errors: yes
+    register: kubectl_taint
+    failed_when: >
+      kubectl_taint.rc != 0 and
+      not (
+        kubectl_taint.stderr_lines | unique | length == 1 and 
+        kubectl_taint.stderr.endswith("taint \"node-role.kubernetes.io/master\" not found")
+      )
 
   - name: Scale worker down to 0
     kubernetes.core.k8s:
@@ -408,7 +414,13 @@
     command: kubectl taint nodes --all node-role.kubernetes.io/master-
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    ignore_errors: yes
+    register: kubectl_taint
+    failed_when: >
+      kubectl_taint.rc != 0 and
+      not (
+        kubectl_taint.stderr_lines | unique | length == 1 and 
+        kubectl_taint.stderr.endswith("taint \"node-role.kubernetes.io/master\" not found")
+      )
 
   - name: Verify that the old controlplane node has left the cluster
     shell: |


### PR DESCRIPTION
Swap around control plane scale down commands and waiting to ensure that
we aren't running kubectl or k8s_info against a cluster where the API
servers / control plane may not yet be ready. This should avoid running
into cases where kubectl commands error or k8s_info module hangs after
scaling down the target cluster's control plane.

The untaint commands are refactored so they don't hide unexpected errors.