### PR TITLE
Add Ironic endpoints checks

### DIFF
--- a/04_verify.sh
+++ b/04_verify.sh
@@ -298,5 +298,20 @@ for container in ${EXPTD_CONTAINERS}; do
 done
 
 
+IRONIC_NODES_ENDPOINT="${IRONIC_URL}nodes"
+status="$(curl -sk -o /dev/null -I -w "%{http_code}" "${IRONIC_NODES_ENDPOINT}")"
+if [[ $status == 200 ]]; then
+    echo "⚠️  ⚠️  ⚠️   WARNING: Ironic endpoint is exposed for unauthenticated users"
+    exit 1
+elif [[ $status == 401 ]]; then
+    echo "OK - Ironic endpoint is secured"
+else
+    echo "FAIL- got $status from ${IRONIC_NODES_ENDPOINT}, expected 401"
+    echo ""
+    exit "$status"
+fi
+echo ""
+
 echo -e "\nNumber of failures : $FAILS"
 exit "${FAILS}"
+

--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -194,3 +194,13 @@
     delay: 20
     until: (bmh is succeeded) and
            (bmh.resources | filter_provisioning("provisioned") | length == (NUMBER_OF_BMH | int))
+
+  # Normally as non authenticated user we should
+  # fail here(get 401) to reach Ironic.       
+  - name: Expect 401 from /v1/nodes ednpoint
+    uri:
+      url: "{{ IRONIC_URL }}nodes"
+      return_content: no
+      validate_certs: no
+      method: GET
+      status_code: [401]


### PR DESCRIPTION
This patch adds two basic checks to verify that unauthenticated user can't reach Ironic endpoint.
[`/nodes`](https://docs.openstack.org/api-ref/baremetal/?expanded=list-nodes-detail#list-nodes)
