### PR TITLE
Fix bug in node reuse where BMHs are not found

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Generate templates
   include_tasks: generate_templates.yml
+  when: v1aX_integration_test_action in provision_actions
 
 - name: Download image for deployment
   include_tasks: download_image.yml

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -108,6 +108,12 @@ provision_workers_actions:
     - "provision_worker"
     - "feature_test_provisioning"
     - "upgrading"
+provision_actions:
+    - "ci_test_provision"
+    - "provision_cluster"
+    - "provision_controlplane"
+    - "feature_test_provisioning"
+    - "upgrading"
 deprovision_cluster_actions:
     - "ci_test_deprovision"
     - "deprovision_cluster"


### PR DESCRIPTION
The BMHs aren't found when generating templates in node reuse because we're pivoted. To fix this, instead we only generate the templates when provisioning.