### PR TITLE
BugFix: Download upgraded image and add variables to M3M template.

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/download_image.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/download_image.yml
@@ -18,7 +18,7 @@
 
           - name: Verify specific centos image containing newer version of cloud-init is downloaded
             get_url:
-              url: "{{ IMAGE_LOCATION_CENTOS }}"
+              url: "{{ IMAGE_LOCATION_CENTOS }}/{{ IMAGE_NAME_CENTOS }}"
               dest: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME_CENTOS }}"
               mode: 0664
 
@@ -63,7 +63,7 @@
 
           - name: Verify specific Ubuntu image containing newer version of cloud-init is downloaded
             get_url:
-              url: "{{ IMAGE_LOCATION }}"
+              url: "{{ IMAGE_LOCATION }}/{{ IMAGE_NAME }}"
               dest: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME }}"
               mode: 0664
 

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -398,6 +398,15 @@
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
 #                       Upgrade K8S version and boot-image                              |
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
+  - name: Download upgraded boot-disk image for deployment
+    include_tasks: download_image.yml
+    vars:
+      IMAGE_NAME: "UBUNTU_20.04_NODE_IMAGE_K8S_{{UPGRADED_K8S_VERSION}}.qcow2"
+      RAW_IMAGE_NAME: "UBUNTU_20.04_NODE_IMAGE_K8S_{{UPGRADED_K8S_VERSION}}-raw.img"
+      IMAGE_LOCATION: "https://artifactory.nordix.org/artifactory/airship/images/k8s_{{UPGRADED_K8S_VERSION}}/"
+      IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"
+      IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
+  
   - name: Get cluster uid
     kubernetes.core.k8s_info:
       api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
@@ -416,6 +425,9 @@
       CLUSTER_UID: "{{ clusters.resources[0].metadata.uid }}"
       M3MT_NAME: "{{CLUSTER_NAME}}-new-controlplane-image"
       DATA_TEMPLATE_NAME: "{{CLUSTER_NAME}}-controlplane-template"
+      RAW_IMAGE_NAME: "UBUNTU_20.04_NODE_IMAGE_K8S_{{UPGRADED_K8S_VERSION}}-raw.img"
+      IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"
+      IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
 
   - name: Create worker Metal3MachineTemplates
     kubernetes.core.k8s:
@@ -426,6 +438,9 @@
       CLUSTER_UID: "{{ clusters.resources[0].metadata.uid }}"
       M3MT_NAME: "{{CLUSTER_NAME}}-new-workers-image"
       DATA_TEMPLATE_NAME: "{{CLUSTER_NAME}}-workers-template"
+      RAW_IMAGE_NAME: "UBUNTU_20.04_NODE_IMAGE_K8S_{{UPGRADED_K8S_VERSION}}-raw.img"
+      IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"
+      IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
 
   - name: Update boot-disk and kubernetes versions of controlplane nodes
     kubernetes.core.k8s:

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -488,18 +488,14 @@
   - name: Get control plane machines
     shell: |
             kubectl get machines -n "{{ NAMESPACE }}" -l cluster.x-k8s.io/control-plane -o json |
-            jq -r '[ .items[] | select(.spec.version == "{{ UPGRADED_K8S_VERSION }}") | .status.nodeRef.name ]'
+            jq -r '[ .items[] | select(.spec.version == "{{ UPGRADED_K8S_VERSION }}") | .status.nodeRef.name ] | length'
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
+    retries: 200
+    delay: 20
     register: new_control_plane_nodes
-    failed_when: >
-      (new_control_plane_nodes.stdout == "[]") or
-      (new_control_plane_nodes.stderr != "") or
-      (new_control_plane_nodes.rc < 3)
-
-  - name: Extract the new node name
-    set_fact:
-      new_cp_node_name: "{{ new_control_plane_nodes.stdout | from_json | first }}"
+    until: new_control_plane_nodes.stdout|int == 3
+    failed_when: new_control_plane_nodes.stdout|int != 3
 
   - name: Register worker nodes
     kubernetes.core.k8s_info:

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -19,7 +19,7 @@ NODE_DRAIN_TIMEOUT: "{{ lookup('env', 'NODE_DRAIN_TIMEOUT') | default('0s', true
 BMOPATH: "{{ lookup('env', 'BMOPATH') }}"
 IRONIC_DATA_DIR: "{{ lookup('env', 'IRONIC_DATA_DIR') }}"
 KUBECONFIG_PATH: "/home/ubuntu/.kube/config"
-KUBERNETES_VERSION: "{{ lookup('env', 'KUBERNETES_VERSION') | default('v1.22.0', true) }}"
+KUBERNETES_VERSION: "{{ lookup('env', 'KUBERNETES_VERSION') | default('v1.21.2', true) }}"
 UPGRADED_K8S_VERSION: "{{ lookup('env', 'UPGRADED_K8S_VERSION') | default('v1.22.0', true) }}"
 MAX_SURGE_VALUE: "{{ lookup('env', 'MAX_SURGE_VALUE') | default('1', true) }}"
 VM_EXTRADISKS: "{{ lookup('env', 'VM_EXTRADISKS') | default('false', true) }}"


### PR DESCRIPTION
There is a bug in upgrade workflow where upgraded version of image needs to be downloaded from artifactory and pass the upgraded variables in Metal3MachineTemplate.