### PR TITLE
chdir into BMOPATH when using deploy.sh

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -117,6 +117,8 @@
       IRONIC_HOST_IP: "{{ IRONIC_HOST_IP }}"
       KUBECTL_ARGS: "{{ KUBECTL_ARGS }}"
     when: CAPM3_VERSION == "v1alpha5"
+    args:
+      chdir: "{{ BMOPATH }}"
 
   - name: Reinstate Baremetal Operator Manager
     shell: "mv {{ BMOPATH }}/config/manager/manager.yaml.orig {{ BMOPATH }}/config/manager/manager.yaml"
@@ -129,6 +131,8 @@
       IRONIC_HOST: "{{ IRONIC_HOST }}"
       IRONIC_HOST_IP: "{{ IRONIC_HOST_IP }}"
       KUBECTL_ARGS: "{{ KUBECTL_ARGS }}"
+    args:
+      chdir: "{{ BMOPATH }}"
 
   - name: Restore original BMO Configmap
     shell: "mv {{ BMOPATH }}/config/default/ironic.env.orig {{ BMOPATH }}/config/default/ironic.env"

--- a/vm-setup/roles/v1aX_integration_test/tasks/move_back.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move_back.yml
@@ -21,6 +21,8 @@
       IRONIC_HOST: "{{ IRONIC_HOST }}"
       IRONIC_HOST_IP: "{{ IRONIC_HOST_IP }}"
     when: EPHEMERAL_CLUSTER == "minikube"
+    args:
+      chdir: "{{ BMOPATH }}"
 
   - name: Re-pivot everything back to source cluster
     shell: "clusterctl move --kubeconfig /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml --to-kubeconfig /home/$USER/.kube/config -n {{ NAMESPACE }} -v 10"


### PR DESCRIPTION
This enables us to use the provided Makefile.

I'm hoping this will fix the integration test issues in https://github.com/metal3-io/baremetal-operator/pull/968