### PR TITLE
Add ansible verbosity to default level

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -40,7 +40,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
     -e "nodes_file=$NODES_FILE" \
     -i vm-setup/inventory.ini \
-    -b vm-setup/teardown-playbook.yml
+    -b -v vm-setup/teardown-playbook.yml
 
 if [ "$USE_FIREWALLD" == "False" ]; then
  ANSIBLE_FORCE_COLOR=true ansible-playbook \
@@ -48,7 +48,7 @@ if [ "$USE_FIREWALLD" == "False" ]; then
     -e "external_subnet_v4: ${EXTERNAL_SUBNET_V4}" \
     -e "firewall_rule_state=absent" \
     -i vm-setup/inventory.ini \
-    -b vm-setup/firewall.yml
+    -b -v vm-setup/firewall.yml
 fi
 
 # There was a bug in this file, it may need to be recreated.

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -38,4 +38,4 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
    -e "metal3_dir=$SCRIPTDIR" \
    -e "v1aX_integration_test_action=${ACTION}" \
    -i "${METAL3_DIR}/vm-setup/inventory.ini" \
-   -b "${METAL3_DIR}/vm-setup/v1aX_integration_test.yml"
+   -b -v "${METAL3_DIR}/vm-setup/v1aX_integration_test.yml"


### PR DESCRIPTION
This PR reinstates ansible verbosity to default level for tasks which are run through `v1aX_integration_test.yml` and cleanup task