### PR TITLE
🐛 Remove certmanager ca-injection workaround

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -8,6 +8,12 @@ source lib/common.sh
 # shellcheck disable=SC1091
 source lib/network.sh
 
+
+if [ "${CAPM3_VERSION}" != "v1alpha4" ]; then
+  mkdir -p "${M3PATH}"
+  clone_repo "${IPAMREPO}" "${IPAMBRANCH}" "${IPAMPATH}"
+fi
+
 # Root needs a private key to talk to libvirt
 # See tripleo-quickstart-config/roles/virtbmc/tasks/configure-vbmc.yml
 if sudo [ ! -f /root/.ssh/id_rsa_virt_power ]; then

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -9,10 +9,8 @@ source lib/common.sh
 source lib/network.sh
 
 
-if [ "${CAPM3_VERSION}" != "v1alpha4" ]; then
-  mkdir -p "${M3PATH}"
-  clone_repo "${IPAMREPO}" "${IPAMBRANCH}" "${IPAMPATH}"
-fi
+mkdir -p "${M3PATH}"
+clone_repo "${IPAMREPO}" "${IPAMBRANCH}" "${IPAMPATH}"
 
 # Root needs a private key to talk to libvirt
 # See tripleo-quickstart-config/roles/virtbmc/tasks/configure-vbmc.yml

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -371,13 +371,6 @@ function patch_clusterctl(){
   rm -rf "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
   mkdir -p "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
   cp out/*.yaml "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
-  # The following sed makes sure the cert-manager ca inject annotation also contains
-  # capm3 namePrefix for ipam-serving cert. This is a bug which has been there since
-  # we use two levels of kustomization one on IPAM and then again on IPAM components
-  # in CAPM3. The following is a quick fix, later once we solve it in IPAM kustomization
-  # the following line would be removed
-  sed -i 's/capm3-system\/ipam-serving-cert/capm3-system\/capm3-ipam-serving-cert/g' "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"/infrastructure-components.yaml
-
   popd
 }
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -114,19 +114,19 @@ export CAPM3PATH="${CAPM3PATH:-${M3PATH}/cluster-api-provider-metal3}"
 export CAPM3_BASE_URL="${CAPM3_BASE_URL:-metal3-io/cluster-api-provider-metal3}"
 export CAPM3REPO="${CAPM3REPO:-https://github.com/${CAPM3_BASE_URL}}"
 
-if [ "${CAPM3_VERSION}" == "v1alpha4" ]; then
-  export IPAMPATH="${IPAMPATH:-${M3PATH}/ip-address-manager}"
-  export IPAM_BASE_URL="${IPAM_BASE_URL:-metal3-io/ip-address-manager}"
-else
-  export IPAMPATH="${IPAMPATH:-${M3PATH}/metal3-ipam}"
-  export IPAM_LOCAL_IMAGE="${IPAM_LOCAL_IMAGE:-${M3PATH}/metal3-ipam}"
-  export IPAM_BASE_URL="${IPAM_BASE_URL:-Nordix/metal3-ipam}"
-fi
+# if [ "${CAPM3_VERSION}" == "v1alpha4" ]; then
+#   export IPAMPATH="${IPAMPATH:-${M3PATH}/ip-address-manager}"
+#   export IPAM_BASE_URL="${IPAM_BASE_URL:-metal3-io/ip-address-manager}"
+# else
+export IPAMPATH="${IPAMPATH:-${M3PATH}/metal3-ipam}"
+export IPAM_LOCAL_IMAGE="${IPAM_LOCAL_IMAGE:-${M3PATH}/metal3-ipam}"
+export IPAM_BASE_URL="${IPAM_BASE_URL:-Nordix/metal3-ipam}"
+# fi
 
 export IPAMREPO="${IPAMREPO:-https://github.com/${IPAM_BASE_URL}}"
 
 if [ "${CAPI_VERSION}" == "v1alpha3" ]; then
-  IPAMBRANCH="${IPAMBRANCH:-release-0.0}"
+  IPAMBRANCH="${IPAMBRANCH:-fix-nameprefix-kustomization-release-0.0/furkat}"
 else
   IPAMBRANCH="${IPAMBRANCH:-fix-nameprefix-kustomization/furkat}"
 fi


### PR DESCRIPTION
This PR removes a workaround where after the two layers of kustomization in m3-dev-env, cert-manager ca inject annotation for ipam-serving-cert does not contain capm3 namePrefix but the name of the certificate does. 