### PR TITLE
Refactor download_image.yaml

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/download_image.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/download_image.yml
@@ -1,90 +1,43 @@
 ---
-  - name: Check IMAGE_OS CentOS
+  - name: Check IMAGE_OS 
     block:
-      - name: Get the facts about local CentOS image
-        stat:
-          path: "{{ IRONIC_IMAGE_DIR }}/{{ RAW_IMAGE_NAME_CENTOS }}"
-        register: image_path_centos
-
-      - debug:
-          msg: "Local image of CentOS is found"
-        when:
-          - image_path_centos.stat.exists == True
-
-      - name: Download CentOS image.
-        block:
-          - debug:
-              msg: "Local image of CentOS is not found, starting to download"
-
-          - name: Verify specific centos image containing newer version of cloud-init is downloaded
-            get_url:
-              url: "{{ IMAGE_LOCATION_CENTOS }}/{{ IMAGE_NAME_CENTOS }}"
-              dest: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME_CENTOS }}"
-              mode: 0664
-
-          - name: Create Centos raw image
-            shell: |
-              qemu-img convert -O raw "{{ IRONIC_IMAGE_DIR }}/{{IMAGE_NAME_CENTOS}}" "{{ IRONIC_IMAGE_DIR }}/{{RAW_IMAGE_NAME_CENTOS}}"
-
-          - name: Calculate md5sum of the centos image
-            stat:
-              path: "{{ IRONIC_IMAGE_DIR }}/{{ RAW_IMAGE_NAME_CENTOS }}"
-              checksum_algorithm: md5
-            register: centos_md5
-
-          - name: Create the md5sum file
-            copy:
-              content: |
-                {{ centos_md5.stat.checksum }}
-
-              dest: "{{ IRONIC_IMAGE_DIR }}/{{ RAW_IMAGE_NAME_CENTOS }}.md5sum"
-              mode: 0664
-        when:
-          - image_path_centos.stat.exists == False
-    when:
-      - IMAGE_OS == "Centos"
-
-  - name: Check IMAGE_OS Ubuntu
-    block:
-      - name: Get the facts about local Ubuntu image
+      - name: Get the facts about local image
         stat:
           path: "{{ IRONIC_IMAGE_DIR }}/{{ RAW_IMAGE_NAME }}"
-        register: image_path_ubuntu
+        register: image_path
 
       - debug:
-          msg: "Local image of Ubuntu is found"
+          msg: "Local image {{ RAW_IMAGE_NAME }} is found"
         when:
-          - image_path_ubuntu.stat.exists == True
+          - image_path.stat.exists == True
 
-      - name: Download Ubuntu image.
+      - name: Download image.
         block:
           - debug:
-              msg: "Local image of Ubuntu is not found, starting to download"
+              msg: "Local image {{ IMAGE_LOCATION }}/{{ IMAGE_NAME }} is not found, starting to download"
 
-          - name: Verify specific Ubuntu image containing newer version of cloud-init is downloaded
+          - name: Verify specific image containing newer version of cloud-init is downloaded
             get_url:
               url: "{{ IMAGE_LOCATION }}/{{ IMAGE_NAME }}"
               dest: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME }}"
               mode: 0664
 
-          - name: Create Ubuntu raw image
+          - name: Create raw image
             shell: |
               qemu-img convert -O raw "{{ IRONIC_IMAGE_DIR }}/{{IMAGE_NAME}}" "{{ IRONIC_IMAGE_DIR }}/{{RAW_IMAGE_NAME}}"
 
-          - name: Calculate md5sum of the Ubuntu image
+          - name: Calculate md5sum of the image
             stat:
               path: "{{ IRONIC_IMAGE_DIR }}/{{ RAW_IMAGE_NAME }}"
               checksum_algorithm: md5
-            register: ubuntu_md5
+            register: image_md5
 
           - name: Create the md5sum file
             copy:
               content: |
-                {{ ubuntu_md5.stat.checksum }}
+                {{ image_md5.stat.checksum }}
 
               dest: "{{ IRONIC_IMAGE_DIR }}/{{ RAW_IMAGE_NAME }}.md5sum"
               mode: 0664
         when:
-          - image_path_ubuntu.stat.exists == False
-    when:
-      - IMAGE_OS == "Ubuntu"
+          - image_path.stat.exists == False

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -74,10 +74,6 @@ IMAGE_FORMAT: "{{ lookup('env', 'IMAGE_FORMAT') | default('raw', true) }}"
 IMAGE_CHECKSUM_TYPE: "{{ lookup('env', 'IMAGE_CHECKSUM_TYPE') | default('md5', true) }}"
 IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
 
-IMAGE_NAME_CENTOS: "{{ lookup('env', 'IMAGE_NAME') | default('CENTOS_8_NODE_IMAGE_K8S_{{KUBERNETES_VERSION}}.qcow2', true)}}"
-RAW_IMAGE_NAME_CENTOS: "{{ lookup('env', 'IMAGE_RAW_NAME') | default('CENTOS_8_NODE_IMAGE_K8S_{{KUBERNETES_VERSION}}-raw.img', true)}}"
-IMAGE_LOCATION_CENTOS: 'https://artifactory.nordix.org/artifactory/airship/images/k8s_{{KUBERNETES_VERSION}}/'
-
 # Environment variables to install Ironic with TLS and Basic Auth
 GOPATH: "{{ lookup('env', 'GOPATH')}}"
 IRONIC_TLS_SETUP: "{{ lookup('env', 'IRONIC_TLS_SETUP') | default('true', true)}}"


### PR DESCRIPTION
This PR refactors download_image.yaml file to allow images other than Ubuntu and Centos to be downloaded. This PR also removes unused legacy centos related variables.