### PR TITLE
Remove hack to override IPAM cert name

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -371,13 +371,7 @@ function patch_clusterctl(){
   rm -rf "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
   mkdir -p "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
   cp out/*.yaml "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
-  # The following sed makes sure the cert-manager ca inject annotation also contains
-  # capm3 namePrefix for ipam-serving cert. This is a bug which has been there since
-  # we use two levels of kustomization one on IPAM and then again on IPAM components
-  # in CAPM3. The following is a quick fix, later once we solve it in IPAM kustomization
-  # the following line would be removed
-  sed -i 's/capm3-system\/ipam-serving-cert/capm3-system\/capm3-ipam-serving-cert/g' "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"/infrastructure-components.yaml
-
+  
   popd
 }
 


### PR DESCRIPTION
This commit removes the hack to override IPAM certificate name in cert-manager ca inject annotation since a proper fix in landing in CAPM3. 