### PR TITLE
Pull container images only if missing

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -87,7 +87,7 @@ else
       curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/"${KIND_VERSION}"/kind-"$(uname)"-amd64
       chmod +x ./kind
       sudo mv kind /usr/local/bin/.
-      sudo "${CONTAINER_RUNTIME}" pull kindest/node:"${KIND_NODE_IMAGE_VERSION}"
+      container_image_pull_if_missing kindest/node:"${KIND_NODE_IMAGE_VERSION}"
   fi
   if [ "${EPHEMERAL_CLUSTER}" == "tilt" ]; then
     curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
@@ -173,7 +173,7 @@ popd
 # Pulling all the images except any local image.
 for IMAGE_VAR in $(env | grep -v "_LOCAL_IMAGE=" | grep "_IMAGE=" | grep -o "^[^=]*") ; do
   IMAGE="${!IMAGE_VAR}"
-  sudo "${CONTAINER_RUNTIME}" pull "${IMAGE}"
+  container_image_pull_if_missing "$IMAGE"
  done
 
 if ${IPA_DOWNLOAD_ENABLED}; then

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -417,6 +417,21 @@ differs(){
   return $RET_CODE
 }
 
+# If a given container with tag doesn't exist locally, pull it. 
+# Otherwise, do nothing.
+# Helps conserve number of API calls to DockerHub to avoid hitting rate limit.
+#
+# Inputs:
+# - Full name of a Docker/podman/crictl image including tag
+#
+function container_image_pull_if_missing() {
+  local IMAGE="$1"
+  if ! sudo "${CONTAINER_RUNTIME}" | grep -q "$IMAGE"; then
+    sudo "${CONTAINER_RUNTIME}" pull "$IMAGE"
+  fi
+}
+
+
 #
 # Kill and remove the infra containers
 #


### PR DESCRIPTION
In the 01 (setup) script, try to pull images only if the image is not already found.

This should help us avoid hitting the DockerHub API rate limit.