### PR TITLE
Bugfix pull image if missing bash function

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -87,7 +87,7 @@ else
       curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/"${KIND_VERSION}"/kind-"$(uname)"-amd64
       chmod +x ./kind
       sudo mv kind /usr/local/bin/.
-      container_image_pull_if_missing kindest/node:"${KIND_NODE_IMAGE_VERSION}"
+      pull_container_image_if_missing kindest/node:"${KIND_NODE_IMAGE_VERSION}"
   fi
   if [ "${EPHEMERAL_CLUSTER}" == "tilt" ]; then
     curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
@@ -173,7 +173,7 @@ popd
 # Pulling all the images except any local image.
 for IMAGE_VAR in $(env | grep -v "_LOCAL_IMAGE=" | grep "_IMAGE=" | grep -o "^[^=]*") ; do
   IMAGE="${!IMAGE_VAR}"
-  container_image_pull_if_missing "$IMAGE"
+  pull_container_image_if_missing "$IMAGE"
  done
 
 if ${IPA_DOWNLOAD_ENABLED}; then

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -424,9 +424,9 @@ differs(){
 # Inputs:
 # - Full name of a Docker/podman/crictl image including tag
 #
-function container_image_pull_if_missing() {
+function pull_container_image_if_missing() {
   local IMAGE="$1"
-  if ! sudo "${CONTAINER_RUNTIME}" | grep -q "$IMAGE"; then
+  if [[ -z $(sudo "${CONTAINER_RUNTIME}" image ls "$IMAGE" | tail -n +2) ]]; then
     sudo "${CONTAINER_RUNTIME}" pull "$IMAGE"
   fi
 }


### PR DESCRIPTION
A bug in the bash function for pulling an image only if it's missing meant that existing images weren't found. This should solve the problem.

I've also renamed the function so it starts with a verb.