### PR TITLE
Use kubectl instead of k8s module for applying

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/main.yml
@@ -12,24 +12,21 @@
   when: v1aX_integration_test_action in inspection_action
 
 - name: Provision cluster
-  kubernetes.core.k8s:
-    state: present
-    src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_cluster_{{ IMAGE_OS|lower }}.yaml"
-    namespace: "{{ NAMESPACE }}"
+  shell: kubectl apply -f "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_cluster_{{ IMAGE_OS|lower }}.yaml" -n "{{ NAMESPACE }}"
+  register: kubectl_apply_cluster
+  changed_when: "'configured' in kubectl_apply_cluster.stdout"
   when: v1aX_integration_test_action in provision_cluster_actions
 
 - name: Create control plane
-  kubernetes.core.k8s:
-    state: present
-    src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_controlplane_{{ IMAGE_OS|lower }}.yaml"
-    namespace: "{{ NAMESPACE }}"
+  shell: kubectl apply -f "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_controlplane_{{ IMAGE_OS|lower }}.yaml" -n "{{ NAMESPACE }}"
+  register: kubectl_apply_controlplane
+  changed_when: "'configured' in kubectl_apply_controlplane.stdout"
   when: v1aX_integration_test_action in provision_controlplane_actions
 
 - name: Create worker nodes
-  kubernetes.core.k8s:
-    state: present
-    src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_workers_{{ IMAGE_OS|lower }}.yaml"
-    namespace: "{{ NAMESPACE }}"
+  shell: kubectl apply -f "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_workers_{{ IMAGE_OS|lower }}.yaml" -n "{{ NAMESPACE }}"
+  register: kubectl_apply_workers
+  changed_when: "'configured' in kubectl_apply_workers.stdout"
   when: v1aX_integration_test_action in provision_workers_actions
 
 - name: verify deployment

--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
@@ -19,12 +19,6 @@ spec:
         cluster.x-k8s.io/cluster-name: ${ CLUSTER_NAME }
         nodepool: nodepool-0
     spec:
-{% if CAPI_VERSION == "v1alpha3" %}
-      nodeDrainTimeout: ${ NODE_DRAIN_TIMEOUT }
-{% else %}
-      machineTemplate:
-        nodeDrainTimeout: ${ NODE_DRAIN_TIMEOUT }
-{% endif %}
       clusterName: ${ CLUSTER_NAME }
       version: ${ KUBERNETES_VERSION }
       bootstrap:
@@ -36,6 +30,7 @@ spec:
         name: ${ CLUSTER_NAME }-workers
         apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPM3_VERSION }}
         kind: Metal3MachineTemplate
+      nodeDrainTimeout: ${ NODE_DRAIN_TIMEOUT }
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/{{ CAPM3_VERSION }}
 kind: Metal3MachineTemplate

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -108,6 +108,7 @@ provision_actions:
     - "ci_test_provision"
     - "provision_cluster"
     - "provision_controlplane"
+    - "provision_worker"
     - "feature_test_provisioning"
     - "upgrading"
 deprovision_cluster_actions:


### PR DESCRIPTION
The k8s module does no validation on the yaml when applying! It's like running kubectl with --validate=false. Furthermore, even adding the validate block to the module won't validate custom resources. This is quite unexpected, and meant that we were applying invalid template (nodeDrainTimeout was skipped from our definitions.)