### PR TITLE
Remove ironic-inspector-log-watch

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -16,7 +16,6 @@
         - mariadb
         - ironic-endpoint-keepalived
         - ironic-log-watch
-        - ironic-inspector-log-watch
     when: EPHEMERAL_CLUSTER == "kind"
 
   - name: Fetch container logs before pivoting
@@ -30,7 +29,6 @@
         - mariadb
         - ironic-endpoint-keepalived
         - ironic-log-watch
-        - ironic-inspector-log-watch
     become: yes
     become_user: root
     when: EPHEMERAL_CLUSTER == "kind"
@@ -47,7 +45,6 @@
        - mariadb
        - ironic-endpoint-keepalived
        - ironic-log-watch
-       - ironic-inspector-log-watch
     become: yes
     become_user: root
     when: EPHEMERAL_CLUSTER == "kind"

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -346,7 +346,6 @@
         - ironic-conductor
         - ironic-log-watch
         - ironic-inspector
-        - ironic-inspector-log-watch
         # There is also a keepalived container in the pods, but it is using a
         # different image than the rest and therefore not included in the list.
         # - ironic-endpoint-keepalived


### PR DESCRIPTION
This is removed since https://github.com/metal3-io/baremetal-operator/pull/945 has removed ironic-inspector-log-watch