### PR TITLE
Disable deployment of controllers in tilt environment

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -484,11 +484,12 @@ if [ "${EPHEMERAL_CLUSTER}" != "tilt" ]; then
   launch_cluster_api_provider_metal3
 fi
 
-if [ "${CAPM3_VERSION}" != "v1alpha4" ]; then 
-  launch_baremetal_operator
+if [ "${EPHEMERAL_CLUSTER}" != "tilt" ]; then
+    if [ "${CAPM3_VERSION}" != "v1alpha4" ]; then
+        launch_baremetal_operator
+    fi
+    launch_ironic
 fi
-
-launch_ironic
 
 if [ "${EPHEMERAL_CLUSTER}" != "tilt" ]; then
   if [ "${CAPM3_VERSION}" == "v1alpha4" ]; then


### PR DESCRIPTION
This PR disables the deployment of BMO and Ironic in tilt environment.

When using tilt, there are three steps required

1. Create kvm virtual machines
2. Create manifest using kustomize
3. Deploy controllers

This PR disables deployment of controllers as the kind kubernetes clusters does not exist yet. The `make tilt-up` command is suppose to create the cluster and deploy the relevant controllers.