### PR TITLE
Add a bash script that only generates the cluster templates

### DIFF
--- a/scripts/generate-template.sh
+++ b/scripts/generate-template.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+METAL3_DIR="$(dirname "$(readlink -f "${0}")")/.."
+
+export ACTION="generate_template"
+
+"${METAL3_DIR}"/scripts/run.sh

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -113,6 +113,7 @@ provision_actions:
     - "provision_worker"
     - "feature_test_provisioning"
     - "upgrading"
+    - "generate_template"
 deprovision_cluster_actions:
     - "ci_test_deprovision"
     - "deprovision_cluster"


### PR DESCRIPTION
This PR adds a script to generate the cluster template only. It can be used by the CAPM3 e2e test framework