### PR TITLE
Do not verify TLS in sushy-tools, real hardware doesn't do it

### DIFF
--- a/vm-setup/roles/virtbmc/defaults/main.yml
+++ b/vm-setup/roles/virtbmc/defaults/main.yml
@@ -1,7 +1,8 @@
 # Can be set to "teardown" to destroy a previous configuration
 virtbmc_action: setup
 sushy_ignore_boot_device: False
-sushy_vmedia_verify_ssl: True
+# This matches how real hardware behaves
+sushy_vmedia_verify_ssl: False
 
 # BMC credentials
 vbmc_username: "admin"


### PR DESCRIPTION
It is only this year when the Redfish standard added a feature to enable
host verification for virtual media. Until we support it, disabling
the host validation is the right thing to do.
