### PR TITLE
Tilt environment setup for metal3 controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ kubectl delete cluster "${CLUSTER_NAME:-"test1"}" -n metal3
 
 ### Deploying with Tilt
 
-It is possible to use Tilt to run the CAPI and CAPM3 components. For this, run:
+It is possible to use Tilt to run the CAPI, BMO and CAPM3 components. For this, run:
 
 ```sh
 export EPHEMERAL_CLUSTER="tilt"
@@ -152,6 +152,7 @@ Once the cluster is running, you can create the BareMetalHosts :
 
 ```sh
 kubectl create namespace metal3
+kubectl apply -f examples/metal3crds/metal3.io_baremetalhosts.yaml
 kubectl apply -n metal3 -f /opt/metal3-dev-env/bmhosts_crs.yaml
 ```
 

--- a/cluster_cleanup.sh
+++ b/cluster_cleanup.sh
@@ -5,11 +5,16 @@ set -xe
 source lib/common.sh
 
 # Delete cluster
-if [ "${EPHEMERAL_CLUSTER}" == "kind" ]; then
+if [ "${EPHEMERAL_CLUSTER}" == "kind" ] ||  [ "${EPHEMERAL_CLUSTER}" == "tilt" ]; then
   sudo su -l -c "kind delete cluster  || true" "${USER}"
   # Kill and remove the running ironic containers
   if [ -f "$BMOPATH/tools/remove_local_ironic.sh" ]; then
     "$BMOPATH"/tools/remove_local_ironic.sh
+  fi
+  if [ "${EPHEMERAL_CLUSTER}" == "tilt" ]; then
+    pushd "${CAPM3PATH}"
+    make kind-reset
+    popd
   fi
 fi
 


### PR DESCRIPTION
Setup tilt environment for development of CAPI, CAPM3 and BMO controllers.
This PR enables tilt based development with TLS and authentication disabled.
```
export IRONIC_BASIC_AUTH=false
export IRONIC_TLS_SETUP=false
```
Supporting TLS and authentication requires more changes on the `03_launch_mgmt_cluster.sh` script.