### PR TITLE
Fix minikube download for v1a4

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -70,7 +70,7 @@ if ! id "$USER" | grep -q libvirt; then
 fi
 
 if [ "${EPHEMERAL_CLUSTER}" == "minikube" ]; then
-  if ! command -v minikube 2>/dev/null ; then
+  if ! command -v minikube 2>/dev/null || [[ "$(minikube version --short)" != "${MINIKUBE_VERSION}" ]]; then
       curl -Lo minikube https://storage.googleapis.com/minikube/releases/"${MINIKUBE_VERSION}"/minikube-linux-amd64
       chmod +x minikube
       sudo mv minikube /usr/local/bin/.


### PR DESCRIPTION
For v1a4 tests minikube version is 1.22.0 but since we pre-run 01 with default values in the image, we have different version than expected for v1a4 tests. This commit is trying to fix that issue.