### PR TITLE
CAPI componets upgrade from v0.4.1 to v0.4.2 for upgrade workflow

### DIFF
--- a/scripts/feature_tests/upgrade/upgrade_vars.sh
+++ b/scripts/feature_tests/upgrade/upgrade_vars.sh
@@ -29,9 +29,10 @@ function get_latest_capi_release() {
 
 # CAPI release version which we upgrade from.
 export CAPIRELEASE="v0.4.1"
-CAPI_REL_TO_VERSION="$(get_latest_capi_release)" || true
+# Workaround to have the CAPI upagrade to v0.4.2
+#CAPI_REL_TO_VERSION="$(get_latest_capi_release)" || true
 # CAPI release version which we upgrade to.
-export CAPI_REL_TO_VERSION
+export CAPI_REL_TO_VERSION="v0.4.2"
 
 export FROM_K8S_VERSION="v1.21.2"
 export KUBERNETES_VERSION=${FROM_K8S_VERSION}


### PR DESCRIPTION
CAPI upgrade from v0.4.1 to v0.4.3 has an issue with Kubeadm controller and failing further activities on KCP. So this PR will add the CAPI objects upgrade with v0.4.1 to v0.4.2. 