### PR TITLE
Pretty print Ansible failure JSON

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -21,3 +21,10 @@ runner_retry_msg='
   {% endfor %}
   {% endif %}
   RETRYING: {{ ansible_callback_diy.task.name }} {{ ansible_callback_diy.result.output.attempts }}/{{ ansible_callback_diy.task.retries }}'
+runner_on_failed_msg='
+  {% set red = "\u001b[31m" %}
+  {% set grey = "\u001b[37m" %}
+  {% set endcolor = "\u001b[0m" %}
+  TASK [{{ ansible_callback_diy.task.role }} : {{ ansible_callback_diy.task.name }}
+  {{ grey }}test action: {{ vars.get("v1aX_integration_test_action", "no action") }}
+  {{ red }}fatal: [{{ ansible_callback_diy.result.host }}]: FAILED! => {{ ansible_callback_diy.result.output | to_nice_json }}{{ endcolor }}'


### PR DESCRIPTION
The test action is now added as a line when we fail, so we can see which test we were running, and the JSON details in the result are pretty printed for easier reading.

![image](https://user-images.githubusercontent.com/9812774/135597023-a074cf89-534c-4481-8191-6eb790909719.png)
