### PR TITLE
Generate clusterctl binary with latest CAPI release in upgrade workflow

### DIFF
--- a/scripts/feature_tests/upgrade/upgrade_vars.sh
+++ b/scripts/feature_tests/upgrade/upgrade_vars.sh
@@ -29,11 +29,9 @@ function get_latest_capi_release() {
 
 # CAPI release version which we upgrade from.
 export CAPIRELEASE="v0.4.1"
-# Workaround to have the CAPI upagrade to v0.4.2
-#CAPI_REL_TO_VERSION="$(get_latest_capi_release)" || true
+CAPI_REL_TO_VERSION="$(get_latest_capi_release)" || true
 # CAPI release version which we upgrade to.
-export CAPI_REL_TO_VERSION="v0.4.2"
-
+export CAPI_REL_TO_VERSION
 export FROM_K8S_VERSION="v1.21.2"
 export KUBERNETES_VERSION=${FROM_K8S_VERSION}
 export UPGRADED_K8S_VERSION="v1.22.0"

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -77,7 +77,7 @@
     ansible.builtin.git:
       repo: 'https://github.com/kubernetes-sigs/cluster-api.git'
       dest: /tmp/cluster-api-clone
-      version: "{{ CAPIRELEASE }}"
+      version: "{{ CAPI_REL_TO_VERSION }}"
 
   - name: Create clusterctl-settings.json for cluster-api and capm3 repo
     ansible.builtin.template:


### PR DESCRIPTION
This PR will fix the issue to do upgrade CAPI components from v0.4.1 to v0.4.3. It was failing because of missing clusterctl latest binary and unable to have KCP RBAC permissions. 