### PR TITLE
🐛 Fix image pulling for podman

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -428,8 +428,14 @@ differs(){
 #
 function pull_container_image_if_missing() {
   local IMAGE="$1"
-  if [[ -z $(sudo "${CONTAINER_RUNTIME}" image ls "$IMAGE" | tail -n +2) ]]; then
-    sudo "${CONTAINER_RUNTIME}" pull "$IMAGE"
+  if [ "${CONTAINER_RUNTIME}" == "docker" ]; then
+    if [[ -z $(sudo "${CONTAINER_RUNTIME}" image ls "$IMAGE" | tail -n +2) ]]; then
+      sudo "${CONTAINER_RUNTIME}" pull "$IMAGE"
+    fi
+  else
+    if ! sudo "${CONTAINER_RUNTIME}" image exists "$IMAGE"; then  
+      sudo "${CONTAINER_RUNTIME}" pull "$IMAGE"
+    fi
   fi
 }
 


### PR DESCRIPTION
When pulling images from quay with `podman`, it tries to pull already existing images which starts with same string (in this case **ironic**) instead of desired one leaving that image unpulled and breaking the **CentOS** tests with:

```
+ sudo podman tag quay.io/metal3-io/ironic 192.168.111.1:5000/localimages/ironic
Error: quay.io/metal3-io/ironic: image not known
make: *** [Makefile:7: configure_host] Error 125
```
**ref.** Jenkins run: https://jenkins.nordix.org/job/airship_metal3io_capi_m3_v1a5_integration_test_centos/27/console

Image pulling function where actual problem hides:
```
+ pull_container_image_if_missing quay.io/metal3-io/ironic
+ local IMAGE=quay.io/metal3-io/ironic
++ sudo podman image ls quay.io/metal3-io/ironic
++ tail -n +2
+ [[ -z quay.io/metal3-io/ironic-ipa-downloader  latest      96c905be59f4  5 months ago  321 MB
quay.io/metal3-io/ironic-client          latest      012b3427a728  6 months ago  374 MB ]]
```

**Local test:**
```
fgofurov@fgofurov-Latitude-7400:~$ sudo podman images -a
REPOSITORY                               TAG         IMAGE ID      CREATED       SIZE
quay.io/metal3-io/ironic-ipa-downloader  latest      96c905be59f4  5 months ago  321 MB
quay.io/metal3-io/ironic-client          latest      012b3427a728  6 months ago  374 MB

fgofurov@fgofurov-Latitude-7400:~$ sudo podman image ls quay.io/metal3-io/ironic | tail -n +2
quay.io/metal3-io/ironic-ipa-downloader  latest      96c905be59f4  5 months ago  321 MB
quay.io/metal3-io/ironic-client          latest      012b3427a728  6 months ago  374 MB
```