### PR TITLE
🐛Run upgrade tests with proper CAPM3 releases

### DIFF
--- a/scripts/feature_tests/upgrade/upgrade_vars.sh
+++ b/scripts/feature_tests/upgrade/upgrade_vars.sh
@@ -12,15 +12,9 @@ function get_latest_capm3_release() {
 
 # CAPM3 release version which we upgrade from.
 export CAPM3RELEASE="v0.5.0"
-
-# We set CAPM3_REL_TO_VERSION to CAPM3RELEASE if there is no any newer release version
-# of CAPM3 than CAPM3RELEASE value. Otherwise fetch the latest release version of CAPM3.
-if get_latest_capm3_release | grep -q 'Already'; then
-    export CAPM3_REL_TO_VERSION=${CAPM3RELEASE}
-else
-    # CAPM3 release version which we upgrade to.
-    export CAPM3_REL_TO_VERSION
-fi
+CAPM3_REL_TO_VERSION="$(get_latest_capm3_release)" || true
+# CAPM3 release version which we upgrade to.
+export CAPM3_REL_TO_VERSION
 
 # Fetch latest release version of CAPI from the output of clusterctl command.
 function get_latest_capi_release() {

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -132,10 +132,10 @@
     - dev-repository/cluster-api/{{ CAPIRELEASE }}
     - dev-repository/bootstrap-kubeadm/{{ CAPIRELEASE }}
     - dev-repository/control-plane-kubeadm/{{ CAPIRELEASE }}
-    - overrides/infrastructure-metal3/{{ CAPM3RELEASE }}
     - dev-repository/cluster-api/{{ CAPI_REL_TO_VERSION }}
     - dev-repository/bootstrap-kubeadm/{{ CAPI_REL_TO_VERSION }}
     - dev-repository/control-plane-kubeadm/{{ CAPI_REL_TO_VERSION }}
+    - overrides/infrastructure-metal3/{{ CAPM3RELEASE }}
     - overrides/infrastructure-metal3/{{ CAPM3_REL_TO_VERSION }}
 
   - name: Copy controlplane components files
@@ -216,14 +216,6 @@
         src: "overrides/infrastructure-metal3/{{ CAPM3RELEASE }}/metadata.yaml",
         dest: "overrides/infrastructure-metal3/{{ CAPM3_REL_TO_VERSION }}/metadata.yaml"
       }
-    - {
-        src: "dev-repository/infrastructure-metal3/{{ CAPM3RELEASE }}/infrastructure-components.yaml",
-        dest: "dev-repository/infrastructure-metal3/{{ CAPM3_REL_TO_VERSION }}/infrastructure-components.yaml"
-      }
-    - {
-        src: "dev-repository/infrastructure-metal3/{{ CAPM3RELEASE }}/metadata.yaml",
-        dest: "dev-repository/infrastructure-metal3/{{ CAPM3_REL_TO_VERSION }}/metadata.yaml"
-      }
 
   - name: Make changes on CRDs
     vars:
@@ -243,9 +235,6 @@
         regexp: 'description: KubeadmControlPlane'
         replace: "description: upgradedKubeadmControlPlane"
       # TODO: Should we use something more generic than "m3c2020"? Say "m3cnext" or "upgm3c"?
-      - path: "{{working_dir}}/dev-repository/infrastructure-metal3/{{CAPM3_REL_TO_VERSION}}/infrastructure-components.yaml"
-        regexp: '\bm3c\b'
-        replace: "m3c2020"
       - path: "{{working_dir}}/overrides/infrastructure-metal3/{{CAPM3_REL_TO_VERSION}}/infrastructure-components.yaml"
         regexp: '\bm3c\b'
         replace: "m3c2020"


### PR DESCRIPTION
CAPM3 [v.0.5.1](https://github.com/metal3-io/cluster-api-provider-metal3/releases/tag/v0.5.1) is out and we should be running upgrade tests from/to (v0.5.0 ==> v0.5.1) proper CAPM3 releases. Removing previous workaround where we had single CAPM3 release which tested no-op upgrade and since new release `CAPM3_REL_TO_VERSION` was set to empty. 

