### PR TITLE
Create provider-id by combining bmh and metal3machine resources

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
@@ -31,7 +31,11 @@ spec:
         name: "{{ '{{ ds.meta_data.name }}' }}"
         kubeletExtraArgs:
           node-labels: "metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}"
+{% if CAPM3_VERSION == "v1alpha5" %}
           provider-id: "metal3://{{ '{{ ds.meta_data.uuid }}' }}"
+{% else %}
+          provider-id: "metal3://{{ '{{ ds.meta_data.providerid }}' }}"
+{% endif %}
           feature-gates: "AllAlpha=false"
           container-runtime: "remote"
           cgroup-driver: "systemd"
@@ -42,7 +46,11 @@ spec:
         name: "{{ '{{ ds.meta_data.name }}' }}"
         kubeletExtraArgs:
           node-labels: "metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}"
+{% if CAPM3_VERSION == "v1alpha5" %}
           provider-id: "metal3://{{ '{{ ds.meta_data.uuid }}' }}"
+{% else %}
+          provider-id: "metal3://{{ '{{ ds.meta_data.providerid }}' }}"
+{% endif %}
           feature-gates: "AllAlpha=false"
           container-runtime: "remote"
           cgroup-driver: "systemd"

--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
@@ -65,7 +65,11 @@ spec:
           name: "{{ '{{ ds.meta_data.name }}' }}"
           kubeletExtraArgs:
             node-labels: "metal3.io/uuid={{ '{{ ds.meta_data.uuid }}' }}"
+{% if CAPM3_VERSION == "v1alpha5" %}
             provider-id: "metal3://{{ '{{ ds.meta_data.uuid }}' }}"
+{% else %}
+            provider-id: "metal3://{{ '{{ ds.meta_data.providerid }}' }}"
+{% endif %}
             feature-gates: "AllAlpha=false"
             container-runtime: "remote"
             cgroup-driver: "systemd"


### PR DESCRIPTION
With https://github.com/metal3-io/cluster-api-provider-metal3/pull/563, we have introduced a new field providerID, which is constructed from `namespace`, `BareMetalHost` and `Metal3Machine` names. The templates need to be updated accordingly.

Currently, we support two providerID values. But, this could change in the future. 
```
          provider-id: "metal3://{{ '{{ ds.meta_data.uid }}' }}"
or
          provider-id: "metal3://{{ '{{ ds.meta_data.providerid }}' }}"

```
The purpose of this PR is to update the template to use the newer format.