### PR TITLE
Revert prettify json on errors

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 callback_whitelist=ansible.posix.profile_tasks
 stdout_callback=community.general.diy
+show_task_path_on_failure=true
 
 [callback_profile_tasks]
 task_output_limit = 3
@@ -30,10 +31,3 @@ runner_retry_msg='{% if ansible_callback_diy.result.output.attempts == 1 %}
   {% endif %}
   {% endif %}
   RETRYING: {{ ansible_callback_diy.task.name }} {{ ansible_callback_diy.result.output.attempts }}/{{ ansible_callback_diy.task.retries }}'
-runner_on_failed_msg='
-  {% set red = "\u001b[31m" %}
-  {% set grey = "\u001b[37m" %}
-  {% set endcolor = "\u001b[0m" %}
-  TASK [{{ ansible_callback_diy.task.role }} : {{ ansible_callback_diy.task.name }}
-  {{ grey }}test action: {{ vars.get("v1aX_integration_test_action", "no action") }}
-  {{ red }}fatal: [{{ ansible_callback_diy.result.host }}]: FAILED! => {{ ansible_callback_diy.result.output | to_nice_json }}{{ endcolor }}'


### PR DESCRIPTION
The pretty JSON meant there was a lot of scrolling in the logs to find out which task failed. This reverts so that at least the failed task appears at the bottom of the Ansible output. Additionally, the file name of the task is given, so we can see what test / task was running:

```
TASK [packages_installation : Install common packages using standard package manager for Ubuntu] ***
task path: /home/ubuntu/metal3-dev-env/vm-setup/roles/packages_installation/tasks/main.yml:5
fatal: [localhost]: FAILED! => {"changed": false, "msg": "No package matching 'foofail' is available"}
```