### PR TITLE
Install epel-release before anything else in centos

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -23,6 +23,7 @@ if [[ $OS == ubuntu ]]; then
   fi
 
 else
+  sudo dnf update -y && sudo dnf install -y epel-release 
   sudo dnf -y install python3-pip
   sudo alternatives --set python /usr/bin/python3
 fi


### PR DESCRIPTION
Install epel-release for package singning so that we can install
packages and their dependencies without failure in centos.

In CI, we usually use our custom images, which already installs
epel-release in [provision_metal3_image_centos.sh](https://github.com/Nordix/airship-dev-tools/blob/master/ci/scripts/image_scripts/provision_metal3_image_centos.sh). When I tried to
run dev-env  in a vanilla CentOS 8 Stream OS, make failed to pass
01* script, and running these changes helped to move