### PR TITLE
⚠️ Parameterize container image registry var

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -147,17 +147,21 @@
 #
 #export IMAGE_USERNAME="metal3"
 
+# Registry to pull metal3 container images from
+#
+#export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-"quay.io"}
+
 # Container image for ironic pod
 #
-#export IRONIC_IMAGE="quay.io/metal3-io/ironic"
+#export IRONIC_IMAGE="${CONTAINER_REGISTRY}/metal3-io/ironic"
 
 # Container image for vbmc container
 #
-#export VBMC_IMAGE="quay.io/metal3-io/vbmc"
+#export VBMC_IMAGE="${CONTAINER_REGISTRY}/metal3-io/vbmc"
 
 # Container image for sushy-tools container
 #
-#export SUSHY_TOOLS_IMAGE="quay.io/metal3-io/sushy-tools"
+#export SUSHY_TOOLS_IMAGE="${CONTAINER_REGISTRY}/metal3-io/sushy-tools"
 
 # APIEndpoint IP for target cluster
 #export CLUSTER_APIENDPOINT_IP="192.168.111.249"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -159,19 +159,22 @@ export MAX_SURGE_VALUE="${MAX_SURGE_VALUE:-"1"}"
 # Docker registry for local images
 export DOCKER_REGISTRY_IMAGE=${DOCKER_REGISTRY_IMAGE:-"registry:2.7.1"}
 
+# Registry to pull metal3 container images from
+export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-"quay.io"}
+
 # VBMC and Redfish images
-export VBMC_IMAGE=${VBMC_IMAGE:-"quay.io/metal3-io/vbmc"}
-export SUSHY_TOOLS_IMAGE=${SUSHY_TOOLS_IMAGE:-"quay.io/metal3-io/sushy-tools"}
+export VBMC_IMAGE=${VBMC_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/vbmc"}
+export SUSHY_TOOLS_IMAGE=${SUSHY_TOOLS_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/sushy-tools"}
 
 # Ironic vars
 export IRONIC_TLS_SETUP=${IRONIC_TLS_SETUP:-"true"}
 export IRONIC_BASIC_AUTH=${IRONIC_BASIC_AUTH:-"true"}
-export IPA_DOWNLOADER_IMAGE=${IPA_DOWNLOADER_IMAGE:-"quay.io/metal3-io/ironic-ipa-downloader"}
-export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic"}
-export IRONIC_CLIENT_IMAGE=${IRONIC_CLIENT_IMAGE:-"quay.io/metal3-io/ironic-client"}
+export IPA_DOWNLOADER_IMAGE=${IPA_DOWNLOADER_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ironic-ipa-downloader"}
+export IRONIC_IMAGE=${IRONIC_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ironic"}
+export IRONIC_CLIENT_IMAGE=${IRONIC_CLIENT_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ironic-client"}
 export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
 export IRONIC_IMAGE_DIR="$IRONIC_DATA_DIR/html/images"
-export IRONIC_KEEPALIVED_IMAGE=${IRONIC_KEEPALIVED_IMAGE:-"quay.io/metal3-io/keepalived"}
+export IRONIC_KEEPALIVED_IMAGE=${IRONIC_KEEPALIVED_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/keepalived"}
 
 if [ "${CAPM3_VERSION}" == "v1alpha4" ]; then
   export IRONIC_NAMESPACE=${IRONIC_NAMESPACE:-"capm3-system"}
@@ -185,18 +188,18 @@ fi
 export RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-${IRONIC_TLS_SETUP}}
 
 # Baremetal operator image
-export BAREMETAL_OPERATOR_IMAGE=${BAREMETAL_OPERATOR_IMAGE:-"quay.io/metal3-io/baremetal-operator"}
+export BAREMETAL_OPERATOR_IMAGE=${BAREMETAL_OPERATOR_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/baremetal-operator"}
 
 # Config for OpenStack CLI
 export OPENSTACK_CONFIG=$HOME/.config/openstack/clouds.yaml
 
 # CAPM3 and IPAM controller images
 if [ "${CAPM3_VERSION}" == "v1alpha4" ]; then
-  export CAPM3_IMAGE=${CAPM3_IMAGE:-"quay.io/metal3-io/cluster-api-provider-metal3:release-0.4"}
-  export IPAM_IMAGE=${IPAM_IMAGE:-"quay.io/metal3-io/ip-address-manager:release-0.0"}
+  export CAPM3_IMAGE=${CAPM3_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/cluster-api-provider-metal3:release-0.4"}
+  export IPAM_IMAGE=${IPAM_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ip-address-manager:release-0.0"}
 else
-  export CAPM3_IMAGE=${CAPM3_IMAGE:-"quay.io/metal3-io/cluster-api-provider-metal3:main"}
-  export IPAM_IMAGE=${IPAM_IMAGE:-"quay.io/metal3-io/ip-address-manager:main"}
+  export CAPM3_IMAGE=${CAPM3_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/cluster-api-provider-metal3:main"}
+  export IPAM_IMAGE=${IPAM_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ip-address-manager:main"}
 fi
 
 # Default hosts memory

--- a/vars.md
+++ b/vars.md
@@ -36,9 +36,10 @@ assured that they are persisted.
 | IMAGE_NAME | Image for target hosts deployment | | "CENTOS_8_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2" |
 | IMAGE_LOCATION | Location of the image to download | | https://artifactory.nordix.org/artifactory/airship/images/${KUBERNETES_VERSION} |
 | IMAGE_USERNAME | Image username for ssh | | "metal3" |
-| IRONIC_IMAGE | Container image for local ironic services | | "quay.io/metal3-io/ironic" |
-| VBMC_IMAGE | Container image for vbmc container | | "quay.io/metal3-io/vbmc" |
-| SUSHY_TOOLS_IMAGE | Container image for sushy-tools container | | "quay.io/metal3-io/sushy-tools" |
+| CONTAINER_REGISTRY | Registry to pull metal3 container images from | | "quay.io" |
+| IRONIC_IMAGE | Container image for local ironic services | | "$CONTAINER_REGISTRY/metal3-io/ironic" |
+| VBMC_IMAGE | Container image for vbmc container | | "$CONTAINER_REGISTRY/metal3-io/vbmc" |
+| SUSHY_TOOLS_IMAGE | Container image for sushy-tools container | | "$CONTAINER_REGISTRY/metal3-io/sushy-tools" |
 | CAPM3_VERSION | Version of Cluster API provider Metal3 | "v1alpha4", "v1alpha5" | "v1alpha5" |
 | CAPI_VERSION | Version of Cluster API | "v1alpha3", "v1alpha4" | "v1alpha4" |
 | CLUSTER_APIENDPOINT_IP | API endpoint IP for target cluster | "x.x.x.x" | "192.168.111.249" |

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -298,7 +298,7 @@
       # 3. Convert it to a list of {name: container_name, image: image_name}
       containers:
         "{{ dict(ironic_image_containers |
-              zip_longest([], fillvalue='quay.io/metal3-io/ironic:'+IRONIC_IMAGE_TAG)) |
+              zip_longest([], fillvalue=CONTAINER_REGISTRY+'/metal3-io/ironic:'+IRONIC_IMAGE_TAG)) |
             dict2items(key_name='name', value_name='image') }}"
 
   - name: Wait for ironic update to rollout

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -53,24 +53,24 @@ CAPM3RELEASE: "{{ lookup('env', 'CAPM3RELEASE') | default('v0.5.0', true) }}"
 CAPIRELEASE: "{{ lookup('env', 'CAPIRELEASE') | default('v0.4.0', true) }}"
 SSH_PRIVATE_KEY: "{{ lookup('env', 'SSH_KEY') }}"
 SSH_PUB_KEY_CONTENT: "{{ lookup('file', '{{ HOME }}/.ssh/id_rsa.pub') }}"
-IMAGE_USERNAME: "{{ lookup('env', 'IMAGE_USERNAME') | default('metal3', true)}}"
-REGISTRY: "{{ lookup('env', 'REGISTRY') | default('192.168.111.1:5000', true)}}"
+IMAGE_USERNAME: "{{ lookup('env', 'IMAGE_USERNAME') | default('metal3', true) }}"
+REGISTRY: "{{ lookup('env', 'REGISTRY') | default('192.168.111.1:5000', true) }}"
 
 # Environment variables for deployment. IMAGE_OS can be Centos or Ubuntu, change accordingly to your needs.
-IMAGE_OS: "{{ lookup('env', 'IMAGE_OS') | default('Centos', true)}}"
-CONTAINER_RUNTIME: "{{ lookup('env', 'CONTAINER_RUNTIME') | default('podman', true)}}"
-DEFAULT_HOSTS_MEMORY: "{{ lookup('env', 'DEFAULT_HOSTS_MEMORY') | default('4096', true)}}"
-CAPI_VERSION: "{{ lookup('env', 'CAPI_VERSION') | default('v1alpha4', true)}}"
-CAPM3_VERSION: "{{ lookup('env', 'CAPM3_VERSION') | default('v1alpha5', true)}}"
-IRONIC_IMAGE_DIR: "{{ lookup('env', 'IRONIC_IMAGE_DIR') | default('/opt/metal3-dev-env/ironic/html/images')}}"
-IRONIC_ENDPOINT_BRIDGE: "{{ lookup('env', 'CLUSTER_PROVISIONING_INTERFACE') | default('provisioning', true)}}"
+IMAGE_OS: "{{ lookup('env', 'IMAGE_OS') | default('Centos', true) }}"
+CONTAINER_RUNTIME: "{{ lookup('env', 'CONTAINER_RUNTIME') | default('podman', true) }}"
+DEFAULT_HOSTS_MEMORY: "{{ lookup('env', 'DEFAULT_HOSTS_MEMORY') | default('4096', true) }}"
+CAPI_VERSION: "{{ lookup('env', 'CAPI_VERSION') | default('v1alpha4', true) }}"
+CAPM3_VERSION: "{{ lookup('env', 'CAPM3_VERSION') | default('v1alpha5', true) }}"
+IRONIC_IMAGE_DIR: "{{ lookup('env', 'IRONIC_IMAGE_DIR') | default('/opt/metal3-dev-env/ironic/html/images') }}"
+IRONIC_ENDPOINT_BRIDGE: "{{ lookup('env', 'CLUSTER_PROVISIONING_INTERFACE') | default('provisioning', true) }}"
 UPGRADED_IMAGE_NAME: "{{ lookup('env', 'UPGRADED_IMAGE_NAME') }}"
 UPGRADED_RAW_IMAGE_NAME: "{{ lookup('env', 'UPGRADED_RAW_IMAGE_NAME') }}"
 
 # Distibution specific environment variables
-IMAGE_NAME: "{{ lookup('env', 'IMAGE_NAME') | default('UBUNTU_20.04_NODE_IMAGE_K8S_{{KUBERNETES_VERSION}}.qcow2', true)}}"
-RAW_IMAGE_NAME: "{{ lookup('env', 'IMAGE_RAW_NAME') | default('UBUNTU_20.04_NODE_IMAGE_K8S_{{KUBERNETES_VERSION}}-raw.img', true)}}"
-IMAGE_LOCATION: "{{ lookup('env', 'IMAGE_LOCATION') | default('https://artifactory.nordix.org/artifactory/airship/images/k8s_{{KUBERNETES_VERSION}}/', true)}}"
+IMAGE_NAME: "{{ lookup('env', 'IMAGE_NAME') | default('UBUNTU_20.04_NODE_IMAGE_K8S_{{KUBERNETES_VERSION}}.qcow2', true) }}"
+RAW_IMAGE_NAME: "{{ lookup('env', 'IMAGE_RAW_NAME') | default('UBUNTU_20.04_NODE_IMAGE_K8S_{{KUBERNETES_VERSION}}-raw.img', true) }}"
+IMAGE_LOCATION: "{{ lookup('env', 'IMAGE_LOCATION') | default('https://artifactory.nordix.org/artifactory/airship/images/k8s_{{KUBERNETES_VERSION}}/', true) }}"
 IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"
 IMAGE_FORMAT: "{{ lookup('env', 'IMAGE_FORMAT') | default('raw', true) }}"
 IMAGE_CHECKSUM_TYPE: "{{ lookup('env', 'IMAGE_CHECKSUM_TYPE') | default('md5', true) }}"
@@ -78,11 +78,12 @@ IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM
 
 # Environment variables to install Ironic with TLS and Basic Auth
 GOPATH: "{{ lookup('env', 'GOPATH')}}"
-IRONIC_TLS_SETUP: "{{ lookup('env', 'IRONIC_TLS_SETUP') | default('true', true)}}"
-IRONIC_BASIC_AUTH: "{{ lookup('env', 'IRONIC_BASIC_AUTH') | default('true', true)}}"
+IRONIC_TLS_SETUP: "{{ lookup('env', 'IRONIC_TLS_SETUP') | default('true', true) }}"
+IRONIC_BASIC_AUTH: "{{ lookup('env', 'IRONIC_BASIC_AUTH') | default('true', true) }}"
 
 # Environment variables for upgrade workflow
 IRONIC_IMAGE_TAG: "master"
+CONTAINER_REGISTRY: "{{ lookup('env', 'CONTAINER_REGISTRY') }}"
 NUM_IRONIC_IMAGES: 8
 CAPIRELEASE_HARDCODED: "{{ lookup('env', 'CAPIRELEASE_HARDCODED') }}"
 M3PATH: "{{ lookup('env', 'M3PATH') }}"


### PR DESCRIPTION
This patch should help us:
- to overcome a problem of quay.io inaccessibility and when we are not able to pull container images from that registry. 
- to download container images faster since it's local infra

[Proxy Cache](https://goharbor.io/docs/2.1.0/administration/configure-proxy-cache/) in [Nordix Harbor registry](https://registry.nordix.org/) was configured so where we can pull container images through it and all of them will be cached in [quay-io-proxy](https://registry.nordix.org/harbor/projects/32/repositories) repo in Nordix Harbor making them available always.

Upd:
Related to [project-infra#252](https://github.com/metal3-io/project-infra/pull/252)