### PR TITLE
Clarify BMC_DRIVER usage to include redfish-virtualmedia

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -111,7 +111,7 @@
 
 #
 # Set the driver. The default value is 'mixed' (alternate nodes between ipmi
-# and redfish).
+# and redfish). Can also be set explicitly to ipmi/redfish/redfish-virtualmedia.
 #
 #export BMC_DRIVER="mixed"
 

--- a/vars.md
+++ b/vars.md
@@ -31,7 +31,7 @@ assured that they are persisted.
 | SKIP_RETRIES | Do not retry on failure during verifications or tests of the environment. This should be false. It could only be set to false for verifications of a dev env deployment that fully completed. Otherwise failures will appear as resources are not ready. | "true", "false" | "false" |
 | TEST_TIME_INTERVAL | Interval between retries after verification or test failure (seconds) | | 10 |
 | TEST_MAX_TIME | Number of maximum verification or test retries | | 120 |
-| BMC_DRIVER | Set the BMC driver | "ipmi", "redfish" | "mixed" |
+| BMC_DRIVER | Set the BMC driver | "ipmi", "redfish", "redfish-virtualmedia" | "mixed" |
 | IMAGE_OS | OS of the image to boot the nodes from, overriden by IMAGE\_\* if set | "Centos", "Cirros", "FCOS", "Ubuntu" | "Centos" |
 | IMAGE_NAME | Image for target hosts deployment | | "CENTOS_8_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2" |
 | IMAGE_LOCATION | Location of the image to download | | https://artifactory.nordix.org/artifactory/airship/images/${KUBERNETES_VERSION} |


### PR DESCRIPTION
redfish-virtualmedia is also a valid option for this variable