### PR TITLE
Make BOOT_MODE configurable

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -22,6 +22,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "virthost=$HOSTNAME" \
     -e "platform=$NODES_PLATFORM" \
     -e "libvirt_firmware=$LIBVIRT_FIRMWARE" \
+    -e "libvirt_secure_boot=$LIBVIRT_SECURE_BOOT" \
     -e "default_memory=$DEFAULT_HOSTS_MEMORY" \
     -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
     -e "provisioning_url_host=$PROVISIONING_URL_HOST" \

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -241,7 +241,7 @@ function make_bm_hosts() {
       -password "$password" \
       -user "$user" \
       -boot-mac "$mac" \
-      -boot-mode "legacy" \
+      -boot-mode "${BOOT_MODE}" \
       "$name"
   done
 }

--- a/config_example.sh
+++ b/config_example.sh
@@ -115,6 +115,12 @@
 #
 #export BMC_DRIVER="mixed"
 
+#
+# Set libvirt firmware and BMC bootMode
+# Choose "legacy" (bios), "UEFI", or "UEFISecureBoot"
+# Defaults to legacy for ipv4, UEFI for ipv6
+# export BOOT_MODE="UEFI"
+
 # Select the Cluster API provider Metal3 version
 # Accepted values : v1alpha4, v1alpha5, v1beta1
 # default: v1alpha4

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -39,13 +39,23 @@ export POD_CIDR=${POD_CIDR:-"192.168.0.0/18"}
 PROVISIONING_IPV6=${PROVISIONING_IPV6:-false}
 IPV6_ADDR_PREFIX=${IPV6_ADDR_PREFIX:-"fd2e:6f44:5dd8:b856"}
 
-if [[ "${PROVISIONING_IPV6}" == "true" ]];
-then
-  export LIBVIRT_FIRMWARE=uefi
+if [[ "${PROVISIONING_IPV6}" == "true" ]]; then
+  export BOOT_MODE=${BOOT_MODE:-UEFI}
   export PROVISIONING_NETWORK=${PROVISIONING_NETWORK:-fd2e:6f44:5dd8:b856::/64}
 else
-  export LIBVIRT_FIRMWARE=bios
+  export BOOT_MODE=${BOOT_MODE:-legacy}
   export PROVISIONING_NETWORK=${PROVISIONING_NETWORK:-172.22.0.0/24}
+fi
+
+if [[ "${BOOT_MODE}" == "legacy" ]]; then
+  export LIBVIRT_FIRMWARE="bios"
+  export LIBVIRT_SECURE_BOOT="false"
+elif [[ "${BOOT_MODE}" == "UEFI" ]]; then
+  export LIBVIRT_FIRMWARE="uefi"
+  export LIBVIRT_SECURE_BOOT="false"
+elif [[ "${BOOT_MODE}" == "UEFISecureBoot" ]]; then
+  export LIBVIRT_FIRMWARE="uefi"
+  export LIBVIRT_SECURE_BOOT="true"
 fi
 
 # shellcheck disable=SC2155

--- a/vars.md
+++ b/vars.md
@@ -32,6 +32,7 @@ assured that they are persisted.
 | TEST_TIME_INTERVAL | Interval between retries after verification or test failure (seconds) | | 10 |
 | TEST_MAX_TIME | Number of maximum verification or test retries | | 120 |
 | BMC_DRIVER | Set the BMC driver | "ipmi", "redfish", "redfish-virtualmedia" | "mixed" |
+| BOOT_MODE  | Set libvirt firmware and BMH bootMode | "legacy", "UEFI", "UEFISecureBoot" | "legacy" |
 | IMAGE_OS | OS of the image to boot the nodes from, overriden by IMAGE\_\* if set | "Centos", "Cirros", "FCOS", "Ubuntu" | "Centos" |
 | IMAGE_NAME | Image for target hosts deployment | | "CENTOS_8_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2" |
 | IMAGE_LOCATION | Location of the image to download | | https://artifactory.nordix.org/artifactory/airship/images/${KUBERNETES_VERSION} |


### PR DESCRIPTION
Currently this is hard-coded to default to uefi for ipv6, and bios for
ipv4, but there are times when you may wish to override these defaults