### PR TITLE
Add quay.io as the registry

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -169,7 +169,10 @@ export MAX_SURGE_VALUE="${MAX_SURGE_VALUE:-"1"}"
 export DOCKER_REGISTRY_IMAGE=${DOCKER_REGISTRY_IMAGE:-"registry:2.7.1"}
 
 # Registry to pull metal3 container images from
-export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-"quay.io"}
+# Overriding project-infra export because of a bug. 
+# Please uncomment the next line once a proper fix has landed 
+#export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-"quay.io"}
+export CONTAINER_REGISTRY="quay.io"
 
 # VBMC and Redfish images
 export VBMC_IMAGE=${VBMC_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/vbmc"}


### PR DESCRIPTION
Because of recent change regarding container registry parameterization a bug  was introduced in metal3-dev-env which resulted in the local images not being checked in case of PRs in CAPM3, BMO, IPAM etc repositories. The reason being these commands are trying to find `registry.nordix.org/quay-io-proxy/metal3-io/baremetal-operator ` as image in manager.yml but in manager.yaml of all repositories we have `quay.io`. This resulted in sed being a no-op and local images were not tested anymore. This quick fix is falling back to quay.io until proper fix lands.