### PR TITLE
Replace clusterctl config by generate

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/generate_templates.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/generate_templates.yml
@@ -33,7 +33,7 @@
 
   - name: Generate templates
     shell: >
-      clusterctl config cluster {{ CLUSTER_NAME }}
+      clusterctl generate cluster {{ CLUSTER_NAME }}
       --from {{ HOME }}/.cluster-api/overrides/infrastructure-metal3/{{ CAPM3RELEASE }}/cluster-template-{{ item }}.yaml
       --kubernetes-version {{ KUBERNETES_VERSION }}
       --control-plane-machine-count={{ NUM_OF_MASTER_REPLICAS }}


### PR DESCRIPTION
`clusterctl config cluster` is deprecated now, instead use
`clusterctl generate cluster`.