### PR TITLE
disable cert verification in clouds.yaml.j2

### DIFF
--- a/clouds.yaml.j2
+++ b/clouds.yaml.j2
@@ -12,6 +12,7 @@ clouds:
     cacert: /etc/openstack/ironic-ca.crt
     baremetal_endpoint_override: https://{{ env.CLUSTER_URL_HOST }}:{{ env.IRONIC_API_PORT }}
     baremetal_introspection_endpoint_override: https://{{ env.CLUSTER_URL_HOST }}:{{ env.IRONIC_INSPECTOR_PORT }}
+    verify: false
 {% else %}
     baremetal_endpoint_override: http://{{ env.CLUSTER_URL_HOST }}:{{ env.IRONIC_API_PORT }}
     baremetal_introspection_endpoint_override: http://{{ env.CLUSTER_URL_HOST }}:{{ env.IRONIC_INSPECTOR_PORT }}


### PR DESCRIPTION
Currently e.g `baremetal node list` fails due to cert verification,
I guess since we're using a self-signed cert

For debugging it's useful to have the baremetal client work without
needing to modify the generated clouds.yaml file