### PR TITLE
Add configurable support for additional networks

### DIFF
--- a/vars.md
+++ b/vars.md
@@ -87,3 +87,23 @@ assured that they are persisted.
 | MARIADB_CERT_FILE | Path to the cert of MariaDB | | /opt/metal3-dev-env/certs/mariadb.crt |
 | MARIADB_CAKEY_FILE | Path to the CA key of MariaDB | | /opt/metal3-dev-env/certs/ironic-ca.key |
 | MARIADB_CACERT_FILE | Path to the CA certificate of MariaDB | | /opt/metal3-dev-env/certs/ironic-ca.pem |
+
+## Additional networks
+
+By default two libvirt networks are created `baremetal` and `provisioning`
+but in some circumstances it can be useful to define additional secondary
+networks.
+
+This can also be enabled via environment variables, the
+`EXTRA_NETWORK_NAMES` variable defines a list of network names,
+and then ipv4, ipv6 or dual stack subnets can be defined as in the
+following example (note that the name prefix in the subnet variables
+is always uppercase, even if the `EXTRA_NETWORK_NAMES` are lowercase):
+
+```
+export EXTRA_NETWORK_NAMES="nmstate1 nmstate2"
+export NMSTATE1_NETWORK_SUBNET_V4='192.168.221.0/24'
+export NMSTATE1_NETWORK_SUBNET_V6='fd2e:6f44:5dd8:ca56::/120'
+export NMSTATE2_NETWORK_SUBNET_V4='192.168.222.0/24'
+export NMSTATE2_NETWORK_SUBNET_V6='fd2e:6f44:5dd8:cc56::/120'
+```

--- a/vm-setup/roles/common/defaults/main.yml
+++ b/vm-setup/roles/common/defaults/main.yml
@@ -48,10 +48,11 @@ ssh_user: root
 # the vm nodes in the order in which they are defined with the following caveats:
 #   *  The first bridge network defined will be used for pxe booting
 manage_baremetal: 'y'
-networks:
+provisioning_network:
   - name: provisioning
     bridge: provisioning
     forward_mode: bridge
+external_network:
   - name: baremetal
     bridge: baremetal
     forward_mode: "{% if manage_baremetal == 'y' %}nat{% else %}bridge{% endif %}"
@@ -78,3 +79,5 @@ networks:
         - domain: "apps.{{ cluster_domain }}"
           addr: "{% if baremetal_network_cidr_v4|ipv4 != False %}127.0.0.1{% else %}::1{% endif %}"
       srvs: "{{dns_externalsrvs | default([])}}"
+
+networks: "{{ provisioning_network + external_network }}"

--- a/vm-setup/roles/common/tasks/extra_networks_tasks.yml
+++ b/vm-setup/roles/common/tasks/extra_networks_tasks.yml
@@ -1,0 +1,55 @@
+---
+
+- name: "Processing extra network {{network_name}}"
+  debug:
+    var: network_name
+
+# Get the CIDR for ipv4 and/or ipv6
+- name: "Set {{network_name}}_cidr_v4 from {{network_name.upper()}}_NETWORK_SUBNET_V4"
+  set_fact:
+    "{{network_name}}_cidr_v4": "{{lookup('env', network_name.upper()+'_NETWORK_SUBNET_V4')}}"
+
+- name: "Set {{network_name}}_cidr_v6 from {{network_name.upper()}}_NETWORK_SUBNET_V6"
+  set_fact:
+    "{{network_name}}_cidr_v6": "{{lookup('env', network_name.upper()+'_NETWORK_SUBNET_V6')}}"
+
+# Validate that we have at least one CIDR, and that the format is correct
+- fail:
+    msg: "Must specify at least one of {{network_name.upper()}}_NETWORK_SUBNET_V4 or {{network_name.upper()}}_NETWORK_SUBNET_V6"
+  when: "{{ lookup('vars', network_name + '_cidr_v4') == '' and lookup('vars', network_name + '_cidr_v6') == '' }}"
+
+- name: Calculate v4 extra_network data
+  block:
+    - set_fact:
+        extra_network_v4: "{{ [{
+        'address_v4': cidr|nthhost(1),
+        'netmask_v4': cidr|ipaddr('netmask'),
+        'dhcp_range_v4': [ cidr|nthhost(20), cidr|nthhost(60)],
+        }]}}"
+  when: "{{ lookup('vars', network_name + '_cidr_v4') != '' }}"
+  vars:
+    cidr: "{{lookup('vars', network_name + '_cidr_v4')}}"
+
+- name: Calculate v6 extra_network data
+  block:
+    - set_fact:
+        extra_network_v6: "{{ [{
+        'address_v6': cidr|nthhost(1),
+        'prefix_v6': cidr|ipaddr('prefix'),
+        'dhcp_range_v6': [ cidr|nthhost(20), cidr|nthhost(60)],
+        }]}}"
+  when: "{{ lookup('vars', network_name + '_cidr_v6') != '' }}"
+  vars:
+    cidr: "{{lookup('vars', network_name + '_cidr_v6')}}"
+
+- name: "Add extra network {{network_name}} to extra_networks"
+  set_fact:
+    extra_networks: "{{ extra_networks|default([]) + [
+      {
+        'name': network_name,
+        'bridge': network_name,
+        'forward_mode': 'nat',
+        'nat_port_range': ['1024', '65535'],
+        'lease_expiry': '60',
+      } | combine(extra_network_v4|default({}), extra_network_v6|default({}))
+      ]}}"

--- a/vm-setup/roles/common/tasks/main.yml
+++ b/vm-setup/roles/common/tasks/main.yml
@@ -18,3 +18,23 @@
 - debug:
     var: vm_nodes
   when: generate_vm_nodes
+
+- name: "Check if EXTRA_NETWORK_NAMES is configured"
+  set_fact:
+    generate_extra_networks: "{{lookup('env', 'EXTRA_NETWORK_NAMES') and extra_networks is not defined}}"
+
+- name: Calculate extra_networks if EXTRA_NETWORK_NAMES is defined
+  include_tasks: extra_networks_tasks.yml
+  loop: "{{lookup('env', 'EXTRA_NETWORK_NAMES')|split()}}"
+  loop_control:
+    loop_var: network_name
+  when: generate_extra_networks
+
+- name: "Append extra networks when EXTRA_NETWORK_NAMES is configured"
+  set_fact:
+    networks: "{{ networks + extra_networks}}"
+  when: generate_extra_networks
+
+- name: "Show networks data for debugging"
+  debug:
+    var: networks


### PR DESCRIPTION
Sometimes it's useful to define additional networks, which currently can only be
done by copying the networks map and manually appending (or processing some
vars file outside of metal3-dev-env which does the same).

Instead we can add optional support for arbitrary additional networks,
which can be used like:

```
export EXTRA_NETWORK_NAMES="nmstate1 nmstate2"
export NMSTATE1_NETWORK_SUBNET_V4='192.168.221.0/24'
export NMSTATE1_NETWORK_SUBNET_V6='fd2e:6f44:5dd8:ca56::/120'
export NMSTATE2_NETWORK_SUBNET_V4='192.168.222.0/24'
export NMSTATE2_NETWORK_SUBNET_V6='fd2e:6f44:5dd8:cc56::/120'
```

Not all fields are currently parameterized, in an attempt to simplify
the user experience (only the network name and at least one CIDR
are needed) - we could add more flexibility in future if needed.