### PR TITLE
Add krew installation to 01 script

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -63,6 +63,19 @@ fi
 # shellcheck disable=SC1091
 source lib/releases.sh
 
+## Install krew
+if ! kubectl krew > /dev/null 2>&1; then
+  cd "$(mktemp -d)" &&
+  OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+  ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+  KREW="krew-${OS}_${ARCH}" &&
+  curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+  tar zxvf "${KREW}.tar.gz" &&
+  rm -f "${KREW}.tar.gz" &&
+  ./"${KREW}" install krew
+  echo export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH" >> ~/.bashrc
+fi
+
 # Allow local non-root-user access to libvirt
 # Restart libvirtd service to get the new group membership loaded
 if ! id "$USER" | grep -q libvirt; then


### PR DESCRIPTION
This PR will add [krew](https://krew.sigs.k8s.io/) installation as part of the 01 script. 

Krew is the plugin manager for `kubectl` command-line tool. Krew will be used to install `promdump`. [Promdump](https://github.com/ihcsim/promdump) is used to dump the head and persistent blocks of Prometheus. 