### PR TITLE
🐛 Refactor node reuse testing

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/node_reuse.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/node_reuse.yml
@@ -49,58 +49,7 @@
       IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"
       IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
 
-  - name: Get cluster uid
-    kubernetes.core.k8s_info:
-      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
-      kind: Cluster
-      name: "{{ CLUSTER_NAME }}"
-      namespace: "{{ NAMESPACE }}"
-      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    register: clusters
-
-  - name: Create controlplane Metal3MachineTemplates
-    kubernetes.core.k8s:
-      state: present
-      template: Metal3MachineTemplate.yml
-      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    vars:
-      CLUSTER_UID: "{{ clusters.resources[0].metadata.uid }}"
-      M3MT_NAME: "{{CLUSTER_NAME}}-new-controlplane-image"
-      DATA_TEMPLATE_NAME: "{{CLUSTER_NAME}}-controlplane-template"
-      RAW_IMAGE_NAME: "{{ UPGRADED_RAW_IMAGE_NAME }}"
-      IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"
-      IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
-      NODE_REUSE_STATUS: "true"
-
-  - name: Create worker Metal3MachineTemplates
-    kubernetes.core.k8s:
-      state: present
-      template: Metal3MachineTemplate.yml
-      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    vars:
-      CLUSTER_UID: "{{ clusters.resources[0].metadata.uid }}"
-      M3MT_NAME: "{{CLUSTER_NAME}}-new-workers"
-      DATA_TEMPLATE_NAME: "{{CLUSTER_NAME}}-workers-template"
-      RAW_IMAGE_NAME: "{{ UPGRADED_RAW_IMAGE_NAME }}"
-      IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"
-      IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
-      NODE_REUSE_STATUS: "true"
-  
-  - name: Create worker Metal3MachineTemplates for node re-use test
-    kubernetes.core.k8s:
-      state: present
-      template: Metal3MachineTemplate.yml
-      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    vars:
-      CLUSTER_UID: "{{ clusters.resources[0].metadata.uid }}"
-      M3MT_NAME: "{{CLUSTER_NAME}}-new-workers-image"
-      DATA_TEMPLATE_NAME: "{{CLUSTER_NAME}}-workers-template"
-      RAW_IMAGE_NAME: "{{ UPGRADED_RAW_IMAGE_NAME }}"
-      IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"
-      IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
-      NODE_REUSE_STATUS: "true"
-
-  - name: Update Metal3MachineTemplate nodeReuse field to 'True'.
+  - name: Update KCP Metal3MachineTemplate with upgraded image and nodeReuse field set to 'True'.
     k8s:
       api_version: infrastructure.cluster.x-k8s.io/{{ CAPM3_VERSION }}
       kind: Metal3MachineTemplate
@@ -110,8 +59,15 @@
       definition:
         spec:
           nodeReuse: true
+          template:
+            spec:
+              image:
+                checksum: "http://172.22.0.1/images/{{ UPGRADED_RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
+                checksumType: "{{IMAGE_CHECKSUM_TYPE}}"
+                format: "{{IMAGE_FORMAT}}"
+                url: "http://172.22.0.1/images/{{ UPGRADED_RAW_IMAGE_NAME }}"
 
-  - name: Upgrade KubeadmControlPlane k8s version from "{{ KUBERNETES_VERSION }}" to "{{ UPGRADED_K8S_VERSION }}" to test KCP scale-in feature.
+  - name: Change KCP to upgrade k8s version and binaries from "{{ KUBERNETES_VERSION }}" to "{{ UPGRADED_K8S_VERSION }}".
     k8s:
       api_version: controlplane.cluster.x-k8s.io/{{ CAPI_VERSION }}
       kind: KubeadmControlPlane
@@ -121,9 +77,6 @@
       definition:
         spec:
           version: "{{ UPGRADED_K8S_VERSION }}"
-          machineTemplate:
-            infrastructureRef:
-              name: "{{CLUSTER_NAME}}-new-controlplane-image"
           rolloutStrategy:
             rollingUpdate:
               maxSurge: 0
@@ -164,7 +117,7 @@
       - saved_bmhs is succeeded
       - saved_bmhs.resources | filter_provisioning("deprovisioning") | length == (NUMBER_OF_BMH_MD | int)
 
-  - name: Wait until the previous deprovisioning BMH becomes available.
+  - name: Wait until the previously deprovisioned BMH becomes available.
     k8s_info:
       api_version: metal3.io/v1alpha1
       kind: BareMetalHost
@@ -179,7 +132,7 @@
         bmhs.resources | filter_provisioning("available,ready") | map(attribute='metadata.name')
         )
 
-  - name: Check if the deprovisioned BMH is re-used for the next provisioning.
+  - name: Check if just deprovisioned BMH is re-used for the next provisioning.
     k8s_info:
       api_version: metal3.io/v1alpha1
       kind: BareMetalHost
@@ -280,8 +233,6 @@
           replicas: 1
 
   - name: Wait until controlplane is scaled down and "{{ NUMBER_OF_BMH_KCP }}" BMHs' are available.
-    # we use shell instead of k8s_info module here because the CP may not respond to requests 
-    # while it is scaling down - k8s_info has no request timeout, which can hang the build
     shell: kubectl get bmh -n "{{ NAMESPACE }}" | egrep -c '\b(available)|(ready)\b'
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
@@ -300,11 +251,6 @@
       definition:
         spec:
           replicas: 1
-          template:
-            spec:
-              version: "{{ UPGRADED_K8S_VERSION }}"
-              infrastructureRef:
-                name: "{{ CLUSTER_NAME }}-new-workers"
 
   - name: Wait until "{{ NUMBER_OF_BMH_MD }}" more BMH is provisioned.
     k8s_info:
@@ -366,7 +312,7 @@
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
     register: bmhs
 
-  - name: Mark all available BMHs' with unhealthy annotation.
+  - name: Remove nodeReuse label from all available BMHs.
     k8s:
       state: present
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
@@ -376,11 +322,29 @@
         kind: BareMetalHost
         metadata:
           name: "{{ item }}"
-          annotations:
-            capi.metal3.io/unhealthy: ""
+          labels:
+            infrastructure.cluster.x-k8s.io/node-reuse: null
     loop: "{{ bmhs.resources | filter_provisioning('available,ready') | map(attribute='metadata.name') }}"
 
-  - name: Upgrade MachineDeployment with new Metal3MachineTemplate".
+  - name: Update MD Metal3MachineTemplate with upgraded image and nodeReuse field set to 'True'.
+    k8s:
+      api_version: infrastructure.cluster.x-k8s.io/{{ CAPM3_VERSION }}
+      kind: Metal3MachineTemplate
+      name: "{{ CLUSTER_NAME }}-workers"
+      namespace: "{{ NAMESPACE }}"
+      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
+      definition:
+        spec:
+          nodeReuse: true
+          template:
+            spec:
+              image:
+                checksum: "http://172.22.0.1/images/{{ UPGRADED_RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
+                checksumType: "{{IMAGE_CHECKSUM_TYPE}}"
+                format: "{{IMAGE_FORMAT}}"
+                url: "http://172.22.0.1/images/{{ UPGRADED_RAW_IMAGE_NAME }}"
+
+  - name: Change MD to upgrade k8s version and binaries from "{{ KUBERNETES_VERSION }}" to "{{ UPGRADED_K8S_VERSION }}".
     k8s:
       api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
       kind: MachineDeployment
@@ -391,8 +355,7 @@
         spec:
           template:
             spec:
-              infrastructureRef:
-                name: "{{ CLUSTER_NAME }}-new-workers-image"
+              version: "{{ UPGRADED_K8S_VERSION }}"
 
   - name: Wait until "{{ NUMBER_OF_BMH_MD }}" BMH is in deprovisioning state.
     k8s_info:
@@ -405,7 +368,7 @@
     delay: 10
     until: saved_bmhs.resources | filter_provisioning("deprovisioning") | length == (NUMBER_OF_BMH_MD | int)
 
-  - name: Wait until the previous deprovisioning BMH becomes available.
+  - name: Wait until the previously deprovisioned BMH becomes available.
     k8s_info:
       api_version: metal3.io/v1alpha1
       kind: BareMetalHost
@@ -419,23 +382,8 @@
       - saved_bmhs.resources | filter_provisioning("deprovisioning") | first | json_query('metadata.name') in (
         bmhs.resources | filter_provisioning("available,ready") | map(attribute='metadata.name')
         )
- 
 
-  - name: Unmark all available BMHs' with unhealthy annotation.
-    k8s:
-      state: present
-      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-      namespace: "{{ NAMESPACE }}"
-      definition:
-        apiVersion: metal3.io/v1alpha1
-        kind: BareMetalHost
-        metadata:
-          name: "{{ item }}"
-          annotations:
-            capi.metal3.io/unhealthy: null
-    loop: "{{ saved_bmhs.resources | map(attribute='metadata.name') }}"
-
-  - name: Check if the previous deprovisioned BMH is re-used for the next provisioning.
+  - name: Check if just deprovisioned BMH is re-used for the next provisioning.
     k8s_info:
       api_version: metal3.io/v1alpha1
       kind: BareMetalHost
@@ -518,25 +466,3 @@
     until:
       - machines is succeeded
       - machines.resources | filter_phase("running") | length == (NUMBER_OF_ALL_BMH | int)
-  
-  - name: Update control plane Metal3MachineTemplate nodeReuse field to 'false'.
-    k8s:
-      api_version: infrastructure.cluster.x-k8s.io/{{ CAPM3_VERSION }}
-      kind: Metal3MachineTemplate
-      name: "{{ CLUSTER_NAME }}-new-controlplane-image"
-      namespace: "{{ NAMESPACE }}"
-      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-      definition:
-        spec:
-          nodeReuse: false
-    
-  - name: Update worker Metal3MachineTemplate nodeReuse field to 'false'.
-    k8s:
-      api_version: infrastructure.cluster.x-k8s.io/{{ CAPM3_VERSION }}
-      kind: Metal3MachineTemplate
-      name: "{{ CLUSTER_NAME }}-new-workers-image"
-      namespace: "{{ NAMESPACE }}"
-      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-      definition:
-        spec:
-          nodeReuse: false


### PR DESCRIPTION
This patch fixes the issue in node reuse testing workflow in features tests workflow where:
- after testing KCP node reuse use case, we do scale down KCP to 1 and and it triggers de provisioning of BMHs to start testing MD use case, thus all BMH that were used before would have node reuse labels on them. So while testing MD case, we do not remove them and it will always chooses the same host since other BMHs have already KCP name set in node reuse label. To fix it, we remove old labels from all BMHs and then test MD use case to check if node reuse feature is working.
- also removing marking/unmarking of BMHs with unhealthy annotation, since now when MD maxSurge field is updated with 0 it deletes the existing machine first and then recreates a new one, resulting in unneeded unhealthy annotation setting/unsetting.
- removes unnecessary creation of multiple new M3MTs and workarounds like setting node reuse field to "False" at the end of the tests.
