### PR TITLE
✨ Test local images properly when using container images from Nordix registry

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -12,6 +12,7 @@ source lib/network.sh
 
 export IRONIC_HOST="${CLUSTER_URL_HOST}"
 export IRONIC_HOST_IP="${CLUSTER_PROVISIONING_IP}"
+export REPO_IMAGE_PREFIX="quay.io"
 
 sudo mkdir -p "${IRONIC_DATA_DIR}"
 sudo chown -R "${USER}:${USER}" "${IRONIC_DATA_DIR}"
@@ -77,6 +78,11 @@ function update_kustomization_images(){
     OLD_IMAGE_VAR="${IMAGE_VAR%_LOCAL_IMAGE}_IMAGE"
     # Strip the tag for image replacement
     OLD_IMAGE="${!OLD_IMAGE_VAR%:*}"
+    if [[ $OLD_IMAGE == *"$CONTAINER_REGISTRY"* ]]; then
+      #shellcheck disable=SC2116
+      OLD_IMAGE="$(echo "${OLD_IMAGE/$CONTAINER_REGISTRY/$REPO_IMAGE_PREFIX}")"
+      echo "Image $OLD_IMAGE will be replaced with local image $LOCAL_IMAGE in image kustomization"
+    fi
     sed -i -E "s $OLD_IMAGE$ $LOCAL_IMAGE g" "$FILE_PATH"
   done
   # Assign images from local image registry for kustomization
@@ -85,6 +91,11 @@ function update_kustomization_images(){
     #shellcheck disable=SC2086
     IMAGE_NAME="${IMAGE##*/}"
     LOCAL_IMAGE="${REGISTRY}/localimages/$IMAGE_NAME"
+    if [[ $IMAGE == *"$CONTAINER_REGISTRY"* ]]; then
+      #shellcheck disable=SC2116
+      IMAGE="$(echo "${IMAGE/$CONTAINER_REGISTRY/$REPO_IMAGE_PREFIX}")"
+      echo "Image $IMAGE will be replaced with local image $LOCAL_IMAGE in image kustomization"
+    fi
     sed -i -E "s $IMAGE$ $LOCAL_IMAGE g" "$FILE_PATH"
   done
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -167,10 +167,7 @@ export MAX_SURGE_VALUE="${MAX_SURGE_VALUE:-"1"}"
 export DOCKER_REGISTRY_IMAGE=${DOCKER_REGISTRY_IMAGE:-"registry:2.7.1"}
 
 # Registry to pull metal3 container images from
-# Overriding project-infra export because of a bug. 
-# Please uncomment the next line once a proper fix has landed 
-#export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-"quay.io"}
-export CONTAINER_REGISTRY="quay.io"
+export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-"quay.io"}
 
 # VBMC and Redfish images
 export VBMC_IMAGE=${VBMC_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/vbmc"}


### PR DESCRIPTION
This patch ensures to test local images properly in case of PRs in CAPM3, BMO, IPAM etc repositories. The `sed` command now properly replaces container images starting with `quay.io_` prefix while image kustomization with local image pulled from Nordix registry.

Reverts #845 