### PR TITLE
Fix BMO CRDs labelling

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -61,7 +61,6 @@
     shell: "kubectl label --overwrite crds baremetalhosts.metal3.io {{ item }}"
     with_items:
        - clusterctl.cluster.x-k8s.io=""
-       - cluster.x-k8s.io/provider="metal3"
     when: CAPM3_VERSION != "v1alpha4"
        
   - name: Obtain target cluster kubeconfig
@@ -142,7 +141,6 @@
     shell: "kubectl --kubeconfig /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml label crds baremetalhosts.metal3.io {{ item }} --overwrite "
     with_items:
       - clusterctl.cluster.x-k8s.io=""
-      - cluster.x-k8s.io/provider="metal3"
     when: CAPM3_VERSION != "v1alpha4"
 
   # Check for pods & nodes on the target cluster


### PR DESCRIPTION
`cluster.x-k8s.io/provider="metal3"` label is not necessary for BMO. 