### PR TITLE
Print commands as they are executed during fetch_manifests.sh

### DIFF
--- a/scripts/fetch_manifests.sh
+++ b/scripts/fetch_manifests.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -x
 mkdir -p /tmp/manifests
 
 manifests=(
@@ -30,6 +31,6 @@ for kind in "${manifests[@]}"; do
   mkdir -p /tmp/manifests/"$kind"
   for name in $(kubectl get -n metal3 -o name "$kind" || true)
   do
-    kubectl get -n metal3 -o yaml "$name" > /tmp/manifests/"$kind"/"$(basename "$name")".yaml || true
+    kubectl get -n metal3 -o yaml "$name" | tee /tmp/manifests/"$kind"/"$(basename "$name")".yaml || true
   done
 done


### PR DESCRIPTION
For some reason, when we fetch custom resources during 05 script,
metal3Machine objects don't include the status. This addition is to
see how YAMLs of those all the CRs is being obtained.