### PR TITLE
Migrate upgrade tests to v1beta1 APIs + Point mariadb container spec to the separate image.

### DIFF
--- a/scripts/feature_tests/upgrade/upgrade.sh
+++ b/scripts/feature_tests/upgrade/upgrade.sh
@@ -9,4 +9,4 @@ source "upgrade_vars.sh"
 
 export ACTION="upgrading"
 
-"${METAL3_DIR}"/scripts/run.sh
+"${METAL3_DIR}"/scripts/run.sh 

--- a/scripts/feature_tests/upgrade/upgrade_vars.sh
+++ b/scripts/feature_tests/upgrade/upgrade_vars.sh
@@ -4,28 +4,13 @@ set -eux
 # Folder created for specific capi release when running
 # ${CLUSTER_API_REPO}/cmd/clusterctl/hack/create-local-repository.py
 
-export CAPIRELEASE_HARDCODED="v0.4.99"
+export CAPIRELEASE_HARDCODED="v1.0.99"
 
-function get_latest_capm3_release() {
-    clusterctl upgrade plan | grep infrastructure-metal3 | awk 'NR == 1 {print $5}'
-}
+export CAPIRELEASE="v1.0.0"
+export CAPI_REL_TO_VERSION="v1.0.1"
 
-# CAPM3 release version which we upgrade from.
-export CAPM3RELEASE="v0.5.0"
-CAPM3_REL_TO_VERSION="$(get_latest_capm3_release)" || true
-# CAPM3 release version which we upgrade to.
-export CAPM3_REL_TO_VERSION
-
-# Fetch latest release version of CAPI from the output of clusterctl command.
-function get_latest_capi_release() {
-    clusterctl upgrade plan | grep cluster-api | awk 'NR == 1 {print $5}'
-}
-
-# CAPI release version which we upgrade from.
-export CAPIRELEASE="v0.4.1"
-CAPI_REL_TO_VERSION="$(get_latest_capi_release)" || true
-# CAPI release version which we upgrade to.
-export CAPI_REL_TO_VERSION
+export CAPM3RELEASE="v1.0.0"
+export CAPM3_REL_TO_VERSION="v1.0.0"
 export FROM_K8S_VERSION="v1.22.2"
 export KUBERNETES_VERSION=${FROM_K8S_VERSION}
 export UPGRADED_K8S_VERSION="v1.22.3"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -xe
-
 METAL3_DIR="$(dirname "$(readlink -f "${0}")")/.."
 
 ACTION="${ACTION:-""}"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -xe
 
 METAL3_DIR="$(dirname "$(readlink -f "${0}")")/.."
 

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -14,7 +14,7 @@
 
   - name: Cleanup - remove existing next versions of controlplane components CRDs
     vars:
-      working_dir: "{{HOME}}/.cluster-api/dev-repository/"
+      working_dir: "{{HOME}}/.cluster-api/dev-repository"
     file:
       state: absent
       path: "{{item}}"
@@ -185,7 +185,7 @@
         replace: "upgm3c"
 
   - name: Perform upgrade on the target cluster
-    ansible.builtin.command: clusterctl upgrade apply --contract v1alpha4
+    ansible.builtin.command: clusterctl upgrade apply --contract v1beta1
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
 
@@ -202,7 +202,7 @@
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
 
   - name: Perform upgrade on the source cluster
-    ansible.builtin.command: clusterctl upgrade apply --contract v1alpha4
+    ansible.builtin.command: clusterctl upgrade apply --contract v1beta1
 
   # TODO: Can we check this somehow instead of just waiting?
   # Relevant issue: https://github.com/kubernetes-sigs/cluster-api/issues/4474
@@ -260,6 +260,7 @@
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
     register: crd
     failed_when: '"upgm3c" not in crd.resources[0].spec.names.shortNames'
+    when: 'CAPM3RELEASE != CAPM3_REL_TO_VERSION'
 
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
 #                       Upgrade Ironic                                                  |

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -268,7 +268,6 @@
   - name: Set expected ironic image based containers
     set_fact:
       ironic_image_containers:
-        - mariadb
         - ironic-api
         - ironic-dnsmasq
         - ironic-conductor
@@ -288,7 +287,7 @@
         spec:
           template:
             spec:
-              containers: "{{ containers }}"
+              containers: "{{ ironic_based_containers + mariadb_container }}"
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
     vars:
       # Generate a list of name/image pairs from the ironic_image_containers.
@@ -297,10 +296,14 @@
       #    (all have the same image)
       # 2. Turn it into a dict so we have {container_name: image_name, ...}
       # 3. Convert it to a list of {name: container_name, image: image_name}
-      containers:
+      ironic_based_containers:
         "{{ dict(ironic_image_containers |
               zip_longest([], fillvalue=CONTAINER_REGISTRY+'/metal3-io/ironic:'+IRONIC_IMAGE_TAG)) |
             dict2items(key_name='name', value_name='image') }}"
+      mariadb_container:
+      - name:  mariadb
+        image: "{{CONTAINER_REGISTRY+'/metal3-io/mariadb:'+MARIADB_IMAGE_TAG}}"
+      
 
   - name: Wait for ironic update to rollout
     kubernetes.core.k8s_info:

--- a/vm-setup/roles/v1aX_integration_test/templates/clusterctl-upgrade-test.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/clusterctl-upgrade-test.yaml
@@ -16,7 +16,7 @@ providers:
   - name: kubeadm
     url: {{ HOME }}/.cluster-api/dev-repository/control-plane-kubeadm/{{CAPIRELEASE}}/control-plane-components.yaml
     type: ControlPlaneProvider
-  - name: infrastructure-metal3
+  - name: metal3
     url: {{ HOME }}/.cluster-api/overrides/infrastructure-metal3/{{CAPM3RELEASE}}/infrastructure-components.yaml
     type: InfrastructureProvider
 images:

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -85,6 +85,7 @@ IRONIC_BASIC_AUTH: "{{ lookup('env', 'IRONIC_BASIC_AUTH') | default('true', true
 
 # Environment variables for upgrade workflow
 IRONIC_IMAGE_TAG: "master"
+MARIADB_IMAGE_TAG: "main"
 CONTAINER_REGISTRY: "{{ lookup('env', 'CONTAINER_REGISTRY') }}"
 NUM_IRONIC_IMAGES: 8
 CAPIRELEASE_HARDCODED: "{{ lookup('env', 'CAPIRELEASE_HARDCODED') }}"


### PR DESCRIPTION
This PR modifies the upgrade test scripts to make it compatible with new api versions of CAPI and CAPM3 v1beta1.
Also, this PR fixes the issue with upgrade where mariadb container needs to be deployed by a separate mariadb image