### PR TITLE
Don't start fetching CRs until M3Machine status is rebuilt

### DIFF
--- a/05_test.sh
+++ b/05_test.sh
@@ -11,6 +11,13 @@ export ACTION="ci_test_provision"
 
 "${METAL3_DIR}"/scripts/run.sh
 
+# wait until status of Metal3Machine is rebuilt
+while [ -z "${status}" ]
+do
+    status=$(kubectl get m3m -n "${NAMESPACE}" -o=jsonpath="{.items[*]['status.ready']}")
+    sleep 1s
+done
+
 "${METAL3_DIR}"/scripts/fetch_manifests.sh
 
 kubectl get secrets "${CLUSTER_NAME}-kubeconfig" -n "${NAMESPACE}" -o json | jq -r '.data.value'| base64 -d > "/tmp/kubeconfig-${CLUSTER_NAME}.yaml"


### PR DESCRIPTION
Currently we don't have status of Metal3Machine objects in the
tar of manifests we get at the end of the run. And the reason is
we call fetch_manifests.sh after we pivot back and it starts very
quick even before Metal3Machine controller rebuilds the status
after metal3Machine objects are pivoted back. This patch holds on
running fetch_manifests.sh script until the status of metal3Machine
is available.
Note: when clusterctl move, status is not moved, and it is job of
controllers to rebuild the status.