### PR TITLE
Pin calico version to v3.21.0

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
@@ -94,6 +94,20 @@
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
     register: install_cni
 
+  - name: Wait (maximum 3 mins) until Calico pods start running
+    kubernetes.core.k8s_info:
+      api_version: v1
+      kind: Pod
+      namespace: kube-system
+      kubeconfig: /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml
+      field_selectors:
+        - status.phase!=Running
+    retries: 9
+    delay: 20
+    register: calico_pods
+    until: (calico_pods is succeeded) and
+           (calico_pods.resources | length == 0)
+
   # Check for pods & nodes on the target cluster
   - name: Wait for all pods to be in running state
     kubernetes.core.k8s_info:

--- a/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
@@ -58,12 +58,18 @@
       block: "{{ kubeconfig_secret.resources[0].data.value | b64decode }}"
 
   # Install Calico
-  - name: Download Calico manifest
+  - name: Download Calico v3.21.x manifests
     get_url:
-      url: https://docs.projectcalico.org/manifests/calico.yaml
+      url: "https://docs.projectcalico.org/archive/{{ CALICO_MINOR_RELEASE }}/manifests/calico.yaml"
       dest: /tmp/
       mode: '664'
     register: calico_manifest
+
+  - name: Pin calico version to v3.21.0
+    ansible.builtin.replace:
+      path: /tmp/calico.yaml
+      regexp: 'image: docker.io/calico/(.+):v(.+)$'
+      replace: 'image: docker.io/calico/\1:{{ CALICO_PATCH_RELEASE }}'
 
   - name: Replace the POD_CIDR in calico config
     replace:

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -55,6 +55,8 @@ SSH_PRIVATE_KEY: "{{ lookup('env', 'SSH_KEY') }}"
 SSH_PUB_KEY_CONTENT: "{{ lookup('file', '{{ HOME }}/.ssh/id_rsa.pub') }}"
 IMAGE_USERNAME: "{{ lookup('env', 'IMAGE_USERNAME') | default('metal3', true) }}"
 REGISTRY: "{{ lookup('env', 'REGISTRY') | default('192.168.111.1:5000', true) }}"
+CALICO_MINOR_RELEASE: "{{ lookup('env', 'CALICO_MINOR_RELEASE') | default('v3.21', true) }}"
+CALICO_PATCH_RELEASE: "{{ lookup('env', 'CALICO_PATCH_RELEASE') | default('v3.21.0', true) }}"
 
 # Environment variables for deployment. IMAGE_OS can be Centos or Ubuntu, change accordingly to your needs.
 IMAGE_OS: "{{ lookup('env', 'IMAGE_OS') | default('Centos', true) }}"


### PR DESCRIPTION
This will avoid patching calico version in airship-dev-tools
repo, where we pre pull these images. As such, we won't need
to merge renovate patches, then build node images, and finally
build source cluster images every time new minor/patch release
of Calico is out. This will ensure that we do those steps only when
necessary (i.e. when we really need to bump image version for some
reason).