### PR TITLE
Fetch container logs before pivoting when it is minikube cluster

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -2,54 +2,65 @@
   - name: Define number of BMH's
     set_fact:
       NUMBER_OF_BMH: "{{ NUM_OF_MASTER_REPLICAS|int +  NUM_OF_WORKER_REPLICAS|int }}"
+      general_containers:
+          - httpd-infra
+          - registry
+          - sushy-tools
+          - vbmc
+      ironic_containers:
+          - ironic-api
+          - ironic-conductor
+          - ironic-inspector
+          - ironic-endpoint-keepalived
+          - ironic-log-watch
+          - dnsmasq
+          - mariadb
 
-  - name: Create directories for storing container logs
-    file:
-      path: "/tmp/{{ CONTAINER_RUNTIME }}/{{ item }}"
-      state: directory
-    loop:
-        - ironic-api
-        - ironic-conductor
-        - ironic-inspector
-        - dnsmasq
-        - httpd-infra
-        - mariadb
-        - ironic-endpoint-keepalived
-        - ironic-log-watch
+  - name: Fetch container logs (kind cluster)
+    block:
+
+      - name: Create directories for storing container logs (kind cluster)
+        file:
+          path: "/tmp/{{ CONTAINER_RUNTIME }}/{{ item }}"
+          state: directory
+        with_items:
+          - "{{ ironic_containers }}"
+          - "{{ general_containers }}"
+          
+      - name: Fetch container logs before pivoting (kind cluster)
+        shell: "sudo {{ CONTAINER_RUNTIME }} logs {{ item }} > /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stdout.log 2> /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stderr.log"
+        with_items:
+          - "{{ ironic_containers }}"
+          - "{{ general_containers }}"
+
+      - name: Remove ironic container from source cluster (kind cluster)
+        docker_container:
+          name: "{{ item }}"
+          state: absent
+        with_items: "{{ ironic_containers }}"
+
     when: EPHEMERAL_CLUSTER == "kind"
+    become: yes
+    become_user: root 
 
-  - name: Fetch container logs before pivoting
-    shell: "sudo {{ CONTAINER_RUNTIME }} logs {{ item }} > /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stdout.log 2> /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stderr.log"
-    with_items:
-        - ironic-api
-        - ironic-conductor
-        - ironic-inspector
-        - dnsmasq
-        - httpd-infra
-        - mariadb
-        - ironic-endpoint-keepalived
-        - ironic-log-watch
+  - name: Fetch container logs (minikube cluster)
+    block:
+
+      - name: Create directories for storing container logs (minikube cluster)
+        file:
+          path: "/tmp/{{ CONTAINER_RUNTIME }}/{{ item }}"
+          state: directory
+        with_items: "{{ general_containers }}"
+
+      - name: Fetch container logs before pivoting (minikube cluster)
+        shell: "sudo {{ CONTAINER_RUNTIME }} logs {{ item }} > /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stdout.log 2> /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stderr.log"
+        with_items: "{{ general_containers }}"
+  
     become: yes
     become_user: root
-    when: EPHEMERAL_CLUSTER == "kind"
+    when: EPHEMERAL_CLUSTER == "minikube"
 
-  - name: Remove ironic container from source cluster (Ephemeral Cluster is kind)
-    docker_container:
-      name: "{{ item }}"
-      state: absent
-    with_items:
-       - ironic-api
-       - ironic-conductor
-       - ironic-inspector
-       - dnsmasq
-       - mariadb
-       - ironic-endpoint-keepalived
-       - ironic-log-watch
-    become: yes
-    become_user: root
-    when: EPHEMERAL_CLUSTER == "kind"
-
-  - name: Remove Ironic from source cluster (Ephemeral Cluster is minikube)
+  - name: Remove Ironic from source cluster (minikube cluster)
     kubernetes.core.k8s:
       name: "{{ NAMEPREFIX }}-ironic"
       kind: Deployment


### PR DESCRIPTION
When host is CentOS (minikube cluster), we skip /tmp/podman dir creation, because
we don't fetch any container logs as we do for Ubuntu host (kind cluster). For that
reason, copying of logs which don't exist fails in https://github.com/metal3-io/project-infra/blob/83a5967f2c97886664adeaf714f79d72be47834b/jenkins/scripts/files/run_fetch_logs.sh#L60.
```
Warning: Permanently added '31.132.58.190' (ECDSA) to the list of known hosts.
cp: cannot stat '/tmp/podman/*': No such file or directory
```
Adding container logs fetching for minikube cluster based setup, and this will also
avoid failure with `cp`.
Also added registry, sushy-tools, vbmc containers to the list.
