### PR TITLE
WIP: Fallback to pulling container images from quay if Harbor is down

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -12,7 +12,6 @@ source lib/network.sh
 
 export IRONIC_HOST="${CLUSTER_URL_HOST}"
 export IRONIC_HOST_IP="${CLUSTER_PROVISIONING_IP}"
-export REPO_IMAGE_PREFIX="quay.io"
 
 sudo mkdir -p "${IRONIC_DATA_DIR}"
 sudo chown -R "${USER}:${USER}" "${IRONIC_DATA_DIR}"
@@ -80,7 +79,7 @@ function update_kustomization_images(){
     OLD_IMAGE="${!OLD_IMAGE_VAR%:*}"
     if [[ $OLD_IMAGE == *"$CONTAINER_REGISTRY"* ]]; then
       #shellcheck disable=SC2116
-      OLD_IMAGE="$(echo "${OLD_IMAGE/$CONTAINER_REGISTRY/$REPO_IMAGE_PREFIX}")"
+      OLD_IMAGE="$(echo "${OLD_IMAGE/$CONTAINER_REGISTRY/$FALLBACK_REGISTRY}")"
       echo "Image $OLD_IMAGE will be replaced with local image $LOCAL_IMAGE in image kustomization"
     fi
     sed -i -E "s $OLD_IMAGE$ $LOCAL_IMAGE g" "$FILE_PATH"
@@ -93,7 +92,7 @@ function update_kustomization_images(){
     LOCAL_IMAGE="${REGISTRY}/localimages/$IMAGE_NAME"
     if [[ $IMAGE == *"$CONTAINER_REGISTRY"* ]]; then
       #shellcheck disable=SC2116
-      IMAGE="$(echo "${IMAGE/$CONTAINER_REGISTRY/$REPO_IMAGE_PREFIX}")"
+      IMAGE="$(echo "${IMAGE/$CONTAINER_REGISTRY/$FALLBACK_REGISTRY}")"
       echo "Image $IMAGE will be replaced with local image $LOCAL_IMAGE in image kustomization"
     fi
     sed -i -E "s $IMAGE$ $LOCAL_IMAGE g" "$FILE_PATH"


### PR DESCRIPTION
Nordix harbor where we pull container images from using proxy cache to be prepared for quay outage, is itself down due to some unrelated issues of Nordix infra itself, i.e:
`Error response from daemon: Get "https://registry.nordix.org/v2/": x509: certificate has expired or is not yet valid: current time 2021-11-29T06:14:29Z is after 2021-11-29T02:28:37Z `

To avoid this and not fail in the middle of tests in the future, we can fall back to pulling container images from quay itself since the chances where both registries are down at the same time is low and if that is the case even we have nothing to try . This patch does not add a retry logic for pulling images since this does not make much sense to try pulling N times when default registry is down, so it just falls back to latter option where it pulls them from quay. 