### PR TITLE
Add flag to allow disabling of DHCP

### DIFF
--- a/lib/network.sh
+++ b/lib/network.sh
@@ -118,6 +118,8 @@ else
     exit 1
 fi
 
+export DHCP_ENABLED=${DHCP_ENABLED:-"true"}
+
 if [[ "${EPHEMERAL_CLUSTER}" == "minikube" ]] && [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
     network_address MINIKUBE_BMNET_V6_IP "${EXTERNAL_SUBNET_V6}" 9
 fi

--- a/vm-setup/roles/common/defaults/main.yml
+++ b/vm-setup/roles/common/defaults/main.yml
@@ -32,6 +32,7 @@ virsh_dhcp_v4_end: "{{ lookup('env', 'VIRSH_DHCP_V4_END')|default('', true) }}"
 virsh_dhcp_v6_start: "{{ lookup('env', 'VIRSH_DHCP_V6_START')|default('', true) }}"
 virsh_dhcp_v6_end: "{{ lookup('env', 'VIRSH_DHCP_V6_END')|default('', true) }}"
 
+virsh_dhcp_enabled: "{{ lookup('env', 'DHCP_ENABLED')|bool|default('', true) }}"
 
 # Set this to `false` if you don't want your vms
 # to have a VNC console available.
@@ -58,6 +59,7 @@ external_network:
     forward_mode: "{% if manage_baremetal == 'y' %}nat{% else %}bridge{% endif %}"
     address_v4: "{{ baremetal_network_cidr_v4|nthhost(1)|default('', true) }}"
     netmask_v4: "{{ baremetal_network_cidr_v4|ipaddr('netmask') }}"
+    dhcp_enabled: "{{ virsh_dhcp_enabled }}"
     dhcp_range_v4:
       - "{{ virsh_dhcp_v4_start }}"
       - "{{ virsh_dhcp_v4_end }}"

--- a/vm-setup/roles/libvirt/templates/network.xml.j2
+++ b/vm-setup/roles/libvirt/templates/network.xml.j2
@@ -31,7 +31,7 @@
 {# IPv4 Configuration #}
 {% if item.address_v4 is defined and item.address_v4 != '' and item.forward_mode != 'bridge' %}
   <ip address='{{ item.address_v4 }}' netmask='{{ netmask_v4 }}'>
-  {% if item.dhcp_range_v4 is defined %}
+  {% if item.dhcp_range_v4 is defined and item.dhcp_enabled %}
     <dhcp>
       <range start='{{ item.dhcp_range_v4[0] }}' end='{{ item.dhcp_range_v4[1] }}'/>
     {% set ns = namespace(index=0) %}
@@ -80,7 +80,7 @@
 {# IPv6 Configuration #}
 {% if item.address_v6 is defined and item.address_v6 != '' and item.forward_mode != 'bridge' %}
   <ip family="ipv6" address='{{ item.address_v6 }}' prefix='{{ prefix_v6 }}'>
-  {% if item.dhcp_range_v6 is defined %}
+  {% if item.dhcp_range_v6 is defined and item.dhcp_enabled %}
     <dhcp>
       <range start='{{ item.dhcp_range_v6[0] }}' end='{{ item.dhcp_range_v6[1] }}'/>
     {% set ns = namespace(index=0) %}


### PR DESCRIPTION
In order to verify static IP functionality in the installer, we need to allow disabling of DHCP in our virtual networks.

Co-Authored-By: Caleb Boylan <cboylan@redhat.com>