### PR TITLE
Add deprovision target to clean up target cluster

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -208,6 +208,7 @@ IRONIC_INSPECTOR_ENDPOINT=${IRONIC_INSPECTOR_URL}
 CACHEURL=http://${PROVISIONING_URL_HOST}/images
 IRONIC_FAST_TRACK=true
 RESTART_CONTAINER_CERTIFICATE_UPDATED="${RESTART_CONTAINER_CERTIFICATE_UPDATED}"
+IRONIC_RAMDISK_SSH_KEY=${SSH_PUB_KEY_CONTENT}
 EOF
 
   if [ -n "${DEPLOY_ISO_URL}" ]; then
@@ -232,7 +233,7 @@ EOF
 
     # Copy the generated configmap for ironic deployment
     cp "$IRONIC_DATA_DIR/ironic_bmo_configmap.env"  "${BMOPATH}/ironic-deployment/keepalived/ironic_bmo_configmap.env"
-    
+
     # Deploy. Args: <deploy-BMO> <deploy-Ironic> <deploy-TLS> <deploy-Basic-Auth> <deploy-Keepalived>
     "${BMOPATH}/tools/deploy.sh" false true "${IRONIC_TLS_SETUP}" "${IRONIC_BASIC_AUTH}" true
 
@@ -240,7 +241,7 @@ EOF
     mv "${BMOPATH}/ironic-deployment/ironic/ironic.yaml.orig" "${BMOPATH}/ironic-deployment/ironic/ironic.yaml"
     mv "${BMOPATH}/ironic-deployment/keepalived/keepalived_patch.yaml.orig" "${BMOPATH}/ironic-deployment/keepalived/keepalived_patch.yaml"
   fi
-  
+
   # Restore original files
   mv "${BMOPATH}/ironic-deployment/keepalived/ironic_bmo_configmap.env.orig" "${BMOPATH}/ironic-deployment/keepalived/ironic_bmo_configmap.env"
   popd
@@ -296,7 +297,7 @@ function update_capm3_imports(){
     sed -i "s/ironic-cacert/empty-ironic-cacert/g" "config/bmo/secret_mount_patch.yaml"
   fi
   # Modify the kustomization imports to use local BMO repo instead of Github Master
-  if [ "${CAPM3_VERSION}" == "v1alpha4" ]; then 
+  if [ "${CAPM3_VERSION}" == "v1alpha4" ]; then
     cp config/bmo/kustomization.yaml config/bmo/kustomization.yaml.orig
   fi
 
@@ -356,7 +357,7 @@ function patch_clusterctl(){
   pushd "${CAPM3PATH}"
   mkdir -p "${HOME}"/.cluster-api
   touch "${HOME}"/.cluster-api/clusterctl.yaml
-  
+
   # At this point the images variables have been updated with update_images
   # Reflect the change in components files
   if [ -n "${CAPM3_LOCAL_IMAGE}" ]; then
@@ -393,7 +394,7 @@ function patch_clusterctl(){
   rm -rf "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
   mkdir -p "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
   cp out/*.yaml "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
-  
+
   popd
 }
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ delete_mgmt_cluster:
 host_cleanup:
 	./host_cleanup.sh
 
+deprovision:
+	ACTION="ci_test_deprovision" ./scripts/run.sh
+
 test:
 	./05_test.sh
 
@@ -58,4 +61,4 @@ feature_tests: setup_env inspection_test remediation_test cleanup_env pivoting_t
 
 feature_tests_upgrade: setup_env_ug upgrade_test
 
-.PHONY: all install_requirements configure_host launch_mgmt_cluster clean delete_mgmt_cluster host_cleanup verify test lint
+.PHONY: all install_requirements configure_host launch_mgmt_cluster clean delete_mgmt_cluster host_cleanup deprovision verify test lint

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -76,6 +76,8 @@ if [ ! -f "${SSH_KEY}" ]; then
   mkdir -p "$(dirname "$SSH_KEY")"
   ssh-keygen -f "${SSH_KEY}" -P ""
 fi
+SSH_PUB_KEY_CONTENT="$(cat "${SSH_PUB_KEY}")"
+export SSH_PUB_KEY_CONTENT
 
 FILESYSTEM=${FILESYSTEM:="/"}
 
@@ -241,7 +243,7 @@ if [ "${KUBERNETES_VERSION}" == "v1.21.2" ]; then
   export KIND_NODE_IMAGE_VERSION="v1.21.2"
   # Minikube version (if EPHEMERAL_CLUSTER=minikube)
   export MINIKUBE_VERSION=${MINIKUBE_VERSION:-"v1.22.0"}
-else 
+else
   export KIND_NODE_IMAGE_VERSION=${KIND_NODE_IMAGE_VERSION:-"v1.22.2"}
   # Minikube version (if EPHEMERAL_CLUSTER=minikube)
   export MINIKUBE_VERSION=${MINIKUBE_VERSION:-"v1.23.2"}
@@ -432,7 +434,7 @@ differs(){
   return $RET_CODE
 }
 
-# If a given container with tag doesn't exist locally, pull it. 
+# If a given container with tag doesn't exist locally, pull it.
 # Otherwise, do nothing.
 # Helps conserve number of API calls to DockerHub to avoid hitting rate limit.
 #
@@ -446,7 +448,7 @@ function pull_container_image_if_missing() {
       sudo "${CONTAINER_RUNTIME}" pull "$IMAGE"
     fi
   else
-    if ! sudo "${CONTAINER_RUNTIME}" image exists "$IMAGE"; then  
+    if ! sudo "${CONTAINER_RUNTIME}" image exists "$IMAGE"; then
       sudo "${CONTAINER_RUNTIME}" pull "$IMAGE"
     fi
   fi


### PR DESCRIPTION
~~This makes the `host_cleanup.sh` script delete the local registry container. It should eliminate problems with stale images being used when using `pull-if-not-present`.~~

**Edit:** Adds deprovision target to the Makefile that cleans up the target cluster. This is useful when the BMHs are not VMs that can be thrown away. We could use this in the BML pipeline, see https://github.com/metal3-io/project-infra/pull/292

I also made Ironic inject the public ssh key in the ramdisk. If this is not wanted I can drop the commit, but I think it can be useful for debugging.