### PR TITLE
CI: prepare for the new ironic container

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -8,6 +8,7 @@
           - sushy-tools
           - vbmc
       ironic_containers:
+          - ironic
           - ironic-api
           - ironic-conductor
           - ironic-inspector
@@ -29,6 +30,9 @@
           
       - name: Fetch container logs before pivoting (kind cluster)
         shell: "sudo {{ CONTAINER_RUNTIME }} logs {{ item }} > /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stdout.log 2> /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stderr.log"
+        # FIXME(dtantsur): remove ignore_errors after the transition period
+        # from ironic-api+conductor to just ironic
+        ignore_errors: yes
         with_items:
           - "{{ ironic_containers }}"
           - "{{ general_containers }}"
@@ -37,6 +41,9 @@
         docker_container:
           name: "{{ item }}"
           state: absent
+        # FIXME(dtantsur): remove ignore_errors after the transition period
+        # from ironic-api+conductor to just ironic
+        ignore_errors: yes
         with_items: "{{ ironic_containers }}"
 
     when: EPHEMERAL_CLUSTER == "kind"

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -265,7 +265,25 @@
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
 #                       Upgrade Ironic                                                  |
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
-  - name: Set expected ironic image based containers
+
+# NOTE(dtantsur): the logic to determine the currently used containers can be
+# removed once we finally switch to the combined ironic executable
+  - name: Get the current deployment
+    kubernetes.core.k8s_info:
+      api_version: v1
+      kind: Deployment
+      name: "{{ NAMEPREFIX }}-ironic"
+      namespace: "{{ IRONIC_NAMESPACE }}"
+      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
+    register: ironic_deployment
+
+  - name: Determine if the new ironic executable is used
+    set_fact:
+      has_combined_ironic: >
+        {{ "ironic" in (ironic_deployment.resources[0].spec.template.spec.containers
+                        | map(attribute="name")) }}
+
+  - name: Set expected ironic image based containers (old version)
     set_fact:
       ironic_image_containers:
         - ironic-api
@@ -273,9 +291,20 @@
         - ironic-conductor
         - ironic-log-watch
         - ironic-inspector
+    when: not has_combined_ironic | bool
+
+  - name: Set expected ironic image based containers
+    set_fact:
+      ironic_image_containers:
+        - ironic
+        - ironic-dnsmasq
+        - ironic-httpd
+        - ironic-log-watch
+        - ironic-inspector
         # There is also a keepalived container in the pods, but it is using a
         # different image than the rest and therefore not included in the list.
         # - ironic-endpoint-keepalived
+    when: has_combined_ironic | bool
 
   - name: Upgrade ironic image based containers
     kubernetes.core.k8s:


### PR DESCRIPTION
We will switch to using a combined API+conductor Ironic process in https://github.com/metal3-io/baremetal-operator/pull/1065.