### PR TITLE
Support proxy for Docker Hub

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -23,7 +23,7 @@ if [[ $OS == ubuntu ]]; then
   fi
 
 else
-  sudo dnf update -y && sudo dnf install -y epel-release 
+  sudo dnf update -y && sudo dnf install -y epel-release
   sudo dnf -y install python3-pip
   sudo alternatives --set python /usr/bin/python3
 fi
@@ -101,7 +101,6 @@ else
       curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/"${KIND_VERSION}"/kind-"$(uname)"-amd64
       chmod +x ./kind
       sudo mv kind /usr/local/bin/.
-      pull_container_image_if_missing kindest/node:"${KIND_NODE_IMAGE_VERSION}"
   fi
   if [ "${EPHEMERAL_CLUSTER}" == "tilt" ]; then
     curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
@@ -214,7 +213,7 @@ function init_minikube() {
       # Loop to ignore minikube issues
       while /bin/true; do
         minikube_error=0
-        # Restart libvirtd.service as suggested here 
+        # Restart libvirtd.service as suggested here
         # https://github.com/kubernetes/minikube/issues/3566
         sudo systemctl restart libvirtd.service
         configure_minikube

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -233,7 +233,7 @@ EOF
 
     # Copy the generated configmap for ironic deployment
     cp "$IRONIC_DATA_DIR/ironic_bmo_configmap.env"  "${BMOPATH}/ironic-deployment/keepalived/ironic_bmo_configmap.env"
-    
+
     # Deploy. Args: <deploy-BMO> <deploy-Ironic> <deploy-TLS> <deploy-Basic-Auth> <deploy-Keepalived>
     "${BMOPATH}/tools/deploy.sh" false true "${IRONIC_TLS_SETUP}" "${IRONIC_BASIC_AUTH}" true
 
@@ -241,7 +241,7 @@ EOF
     mv "${BMOPATH}/ironic-deployment/ironic/ironic.yaml.orig" "${BMOPATH}/ironic-deployment/ironic/ironic.yaml"
     mv "${BMOPATH}/ironic-deployment/keepalived/keepalived_patch.yaml.orig" "${BMOPATH}/ironic-deployment/keepalived/keepalived_patch.yaml"
   fi
-  
+
   # Restore original files
   mv "${BMOPATH}/ironic-deployment/keepalived/ironic_bmo_configmap.env.orig" "${BMOPATH}/ironic-deployment/keepalived/ironic_bmo_configmap.env"
   popd
@@ -297,7 +297,7 @@ function update_capm3_imports(){
     sed -i "s/ironic-cacert/empty-ironic-cacert/g" "config/bmo/secret_mount_patch.yaml"
   fi
   # Modify the kustomization imports to use local BMO repo instead of Github Main
-  if [ "${CAPM3_VERSION}" == "v1alpha4" ]; then 
+  if [ "${CAPM3_VERSION}" == "v1alpha4" ]; then
     cp config/bmo/kustomization.yaml config/bmo/kustomization.yaml.orig
   fi
 
@@ -357,7 +357,7 @@ function patch_clusterctl(){
   pushd "${CAPM3PATH}"
   mkdir -p "${HOME}"/.cluster-api
   touch "${HOME}"/.cluster-api/clusterctl.yaml
-  
+
   # At this point the images variables have been updated with update_images
   # Reflect the change in components files
   if [ -n "${CAPM3_LOCAL_IMAGE}" ]; then
@@ -394,7 +394,7 @@ function patch_clusterctl(){
   rm -rf "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
   mkdir -p "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
   cp out/*.yaml "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
-  
+
   popd
 }
 
@@ -453,7 +453,7 @@ function create_clouds_yaml() {
 # Start a KinD management cluster
 #
 function launch_kind() {
-  cat <<EOF | sudo su -l -c "kind create cluster --name kind --image=kindest/node:${KIND_NODE_IMAGE_VERSION} --config=- " "$USER"
+  cat <<EOF | sudo su -l -c "kind create cluster --name kind --image=${KIND_NODE_IMAGE} --config=- " "$USER"
   kind: Cluster
   apiVersion: kind.x-k8s.io/v1alpha4
   containerdConfigPatches:
@@ -500,26 +500,17 @@ create_clouds_yaml
 if [ "${EPHEMERAL_CLUSTER}" != "tilt" ]; then
   start_management_cluster
   kubectl create namespace metal3
-fi
 
-if [ "${EPHEMERAL_CLUSTER}" != "tilt" ]; then
   patch_clusterctl
   launch_cluster_api_provider_metal3
-fi
 
-if [ "${EPHEMERAL_CLUSTER}" != "tilt" ]; then
-    if [ "${CAPM3_VERSION}" != "v1alpha4" ]; then
-        launch_baremetal_operator
-    fi
-    launch_ironic
-fi
-
-if [ "${EPHEMERAL_CLUSTER}" != "tilt" ]; then
   if [ "${CAPM3_VERSION}" == "v1alpha4" ]; then
     BMO_NAME_PREFIX="${NAMEPREFIX}-baremetal-operator"
   else
     BMO_NAME_PREFIX="${NAMEPREFIX}"
+    launch_baremetal_operator
   fi
+  launch_ironic
 
   if [[ "${BMO_RUN_LOCAL}" != true ]]; then
     if ! kubectl rollout status deployment "${BMO_NAME_PREFIX}"-controller-manager -n "${IRONIC_NAMESPACE}" --timeout=5m; then

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -166,8 +166,11 @@ export VM_EXTRADISKS_MOUNT_DIR=${VM_EXTRADISKS_MOUNT_DIR:-"/mnt/disk2"}
 export NODE_DRAIN_TIMEOUT=${NODE_DRAIN_TIMEOUT:-"0s"}
 export MAX_SURGE_VALUE="${MAX_SURGE_VALUE:-"1"}"
 
+# Docker Hub proxy registry (or docker.io if no proxy)
+export DOCKER_HUB_PROXY=${DOCKER_HUB_PROXY:-"docker.io"}
+
 # Docker registry for local images
-export DOCKER_REGISTRY_IMAGE=${DOCKER_REGISTRY_IMAGE:-"registry:2.7.1"}
+export DOCKER_REGISTRY_IMAGE=${DOCKER_REGISTRY_IMAGE:-"${DOCKER_HUB_PROXY}/library/registry:2.7.1"}
 
 # Registry to pull metal3 container images from
 export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-"quay.io"}
@@ -245,11 +248,12 @@ if [ "${KUBERNETES_VERSION}" == "v1.21.2" ]; then
   export KIND_NODE_IMAGE_VERSION="v1.21.2"
   # Minikube version (if EPHEMERAL_CLUSTER=minikube)
   export MINIKUBE_VERSION=${MINIKUBE_VERSION:-"v1.22.0"}
-else 
+else
   export KIND_NODE_IMAGE_VERSION=${KIND_NODE_IMAGE_VERSION:-"v1.22.2"}
   # Minikube version (if EPHEMERAL_CLUSTER=minikube)
   export MINIKUBE_VERSION=${MINIKUBE_VERSION:-"v1.23.2"}
 fi
+export KIND_NODE_IMAGE=${KIND_NODE_IMAGE:-"${DOCKER_HUB_PROXY}/kindest/node:${KIND_NODE_IMAGE_VERSION}"}
 
 # Ansible version
 export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"4.9.0"}
@@ -436,7 +440,7 @@ differs(){
   return $RET_CODE
 }
 
-# If a given container with tag doesn't exist locally, pull it. 
+# If a given container with tag doesn't exist locally, pull it.
 # Otherwise, do nothing.
 # Helps conserve number of API calls to DockerHub to avoid hitting rate limit.
 #
@@ -450,7 +454,7 @@ function pull_container_image_if_missing() {
       sudo "${CONTAINER_RUNTIME}" pull "$IMAGE"
     fi
   else
-    if ! sudo "${CONTAINER_RUNTIME}" image exists "$IMAGE"; then  
+    if ! sudo "${CONTAINER_RUNTIME}" image exists "$IMAGE"; then
       sudo "${CONTAINER_RUNTIME}" pull "$IMAGE"
     fi
   fi

--- a/scripts/deploy_tilt_env.sh
+++ b/scripts/deploy_tilt_env.sh
@@ -24,7 +24,7 @@ cat <<EOF > tilt-settings.json
 EOF
 sed -i 's/yaml = str(kustomizesub(context + "\/config"))/yaml = str(kustomizesub(context + "\/config\/tls"))/' Tiltfile
 make kind-reset
-kind create cluster --name capm3 --image="kindest/node:${KIND_NODE_IMAGE_VERSION}"
+kind create cluster --name capm3 --image="${KIND_NODE_IMAGE}"
 kubectl create namespace "${NAMESPACE}"
 kubectl create namespace "${IRONIC_NAMESPACE}"
 mkdir -p "${HOME}/.cluster-api/overrides/infrastructure-metal3/${CAPM3RELEASE}"
@@ -46,7 +46,7 @@ export IRONIC_SECRET_NAME=$(kubectl get secrets  -n "${IRONIC_NAMESPACE}" -oname
 # shellcheck disable=SC1001
 export IRONICINSPECTOR_SECRET_NAME=$(kubectl get secrets  -n "${IRONIC_NAMESPACE}" -oname | grep "ironic-inspector-credentials" | cut -f2 -d\/)
 
-# use existing ironic and inspector secrets 
+# use existing ironic and inspector secrets
 # Tilt cannot generate new credentials and certificates as it would mismatch with what ironic is already configured with
 cat <<EOF >> config/tls/tls_ca_patch.yaml
 
@@ -68,12 +68,12 @@ spec:
           - mountPath: /opt/metal3/auth/ironic-inspector
             name: ironic-inspector-credentials
             readOnly: true
-      volumes:  
+      volumes:
       - name: ironic-credentials
         secret:
           secretName: ${IRONICINSPECTOR_SECRET_NAME}
       - name: ironic-inspector-credentials
-        secret: 
+        secret:
           secretName: ${IRONIC_SECRET_NAME}
 EOF
 tools/bin/kustomize build config/tls/
@@ -93,4 +93,3 @@ cat <<EOF > tilt-settings.json
 }
 EOF
 popd
-

--- a/vars.md
+++ b/vars.md
@@ -38,6 +38,7 @@ assured that they are persisted.
 | IMAGE_LOCATION | Location of the image to download | | https://artifactory.nordix.org/artifactory/airship/images/${KUBERNETES_VERSION} |
 | IMAGE_USERNAME | Image username for ssh | | "metal3" |
 | CONTAINER_REGISTRY | Registry to pull metal3 container images from | | "quay.io" |
+| DOCKER_HUB_PROXY | Registry to pull docker hub images from | | "docker.io" |
 | IRONIC_IMAGE | Container image for local ironic services | | "$CONTAINER_REGISTRY/metal3-io/ironic" |
 | VBMC_IMAGE | Container image for vbmc container | | "$CONTAINER_REGISTRY/metal3-io/vbmc" |
 | SUSHY_TOOLS_IMAGE | Container image for sushy-tools container | | "$CONTAINER_REGISTRY/metal3-io/sushy-tools" |

--- a/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
@@ -69,7 +69,7 @@
     ansible.builtin.replace:
       path: /tmp/calico.yaml
       regexp: 'image: docker.io/calico/(.+):v(.+)$'
-      replace: 'image: docker.io/calico/\1:{{ CALICO_PATCH_RELEASE }}'
+      replace: 'image: {{ DOCKER_HUB_PROXY }}/calico/\1:{{ CALICO_PATCH_RELEASE }}'
 
   - name: Replace the POD_CIDR in calico config
     replace:

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -24,7 +24,7 @@ UPGRADED_K8S_VERSION: "{{ lookup('env', 'UPGRADED_K8S_VERSION') | default('v1.22
 MAX_SURGE_VALUE: "{{ lookup('env', 'MAX_SURGE_VALUE') | default('1', true) }}"
 VM_EXTRADISKS: "{{ lookup('env', 'VM_EXTRADISKS') | default('false', true) }}"
 VM_EXTRADISKS_FILE_SYSTEM: "{{ lookup('env', 'VM_EXTRADISKS_FILE_SYSTEM') | default('ext4', true) }}"
-VM_EXTRADISKS_MOUNT_DIR: "{{ lookup('env', 'VM_EXTRADISKS_MOUNT_DIR') | default('/mnt/disk2') }}" 
+VM_EXTRADISKS_MOUNT_DIR: "{{ lookup('env', 'VM_EXTRADISKS_MOUNT_DIR') | default('/mnt/disk2') }}"
 KUBERNETES_BINARIES_VERSION: "{{ lookup('env', 'KUBERNETES_BINARIES_VERSION') | default(lookup('env', 'KUBERNETES_VERSION') | default('v1.18.0', true), true) }}"
 KUBERNETES_BINARIES_CONFIG_VERSION: "{{ lookup('env', 'KUBERNETES_BINARIES_CONFIG_VERSION') | default('v0.2.7', true) }}"
 IP_STACK: "{{ lookup('env', 'IP_STACK') | default('v4', true) }}"
@@ -57,6 +57,7 @@ IMAGE_USERNAME: "{{ lookup('env', 'IMAGE_USERNAME') | default('metal3', true) }}
 REGISTRY: "{{ lookup('env', 'REGISTRY') | default('192.168.111.1:5000', true) }}"
 CALICO_MINOR_RELEASE: "{{ lookup('env', 'CALICO_MINOR_RELEASE') | default('v3.21', true) }}"
 CALICO_PATCH_RELEASE: "{{ lookup('env', 'CALICO_PATCH_RELEASE') | default('v3.21.0', true) }}"
+DOCKER_HUB_PROXY: "{{ lookup('env', 'DOCKER_HUB_PROXY') }}"
 
 # Environment variables for deployment. IMAGE_OS can be Centos or Ubuntu, change accordingly to your needs.
 IMAGE_OS: "{{ lookup('env', 'IMAGE_OS') | default('Centos', true) }}"


### PR DESCRIPTION
We already have `CONTAINER_REGISTRY` for setting the "main" registry to use (basically quay.io proxy). With this PR we can also set `DOCKER_HUB_PROXY` to use a different proxy for Docker Hub. The default is `docker.io`, which basically means no change.

For the registry image, we used to just specify `registry`. I changed this to include the Docker Hub proxy and set the path to `library/registry` since this is the "real" image on Docker Hub. It defaults to `library/` if nothing is specified on Docker Hub, but this does not work well with proxies.