### PR TITLE
Make upgrade test CAPI v1a4 -> v1b1

### DIFF
--- a/scripts/feature_tests/upgrade/upgrade_vars.sh
+++ b/scripts/feature_tests/upgrade/upgrade_vars.sh
@@ -6,11 +6,17 @@ set -eux
 
 export CAPIRELEASE_HARDCODED="v1.0.99"
 
-export CAPIRELEASE="v1.0.0"
+export CAPI_VERSION="v1alpha4"
+export CAPIRELEASE="v0.4.5"
 export CAPI_REL_TO_VERSION="v1.0.1"
 
-export CAPM3RELEASE="v1.0.0"
+export CAPM3_VERSION="v1alpha5"
+export CAPM3RELEASE="v0.5.3"
 export CAPM3_REL_TO_VERSION="v1.0.0"
+export UPGRADED_CAPM3_VERSION="v1beta1"
+
+# Ubuntu is hard coded in the upgrade tests. Make sure we use it throughout.
+export IMAGE_OS="Ubuntu"
 export FROM_K8S_VERSION="v1.22.2"
 export KUBERNETES_VERSION=${FROM_K8S_VERSION}
 export UPGRADED_K8S_VERSION="v1.22.3"

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -1,5 +1,12 @@
 ---
 
+  - name: Fetch container images before upgrade
+    shell: |
+      kubectl get pods -A -o jsonpath="{range .items[*].spec.containers[*]}{.image}{'\n'}{end}" |
+      sort | uniq > /tmp/manifests/container_images_before_upgrade.txt
+    environment:
+      KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
+
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
 #                       Upgrade controlplane components                                 |
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
@@ -35,6 +42,16 @@
       dest: /tmp/cluster-api-clone
       version: "{{ CAPI_REL_TO_VERSION }}"
 
+  - name: Checkout upgraded version of capm3
+    ansible.builtin.git:
+      repo: 'https://github.com/metal3-io/cluster-api-provider-metal3.git'
+      dest: "{{ CAPM3PATH }}"
+      version: "{{ upgraded_capm3_branch }}"
+      # No need to clone, it is already available
+      clone: no
+      # The repo is modified as part of deploying capm3 so we must force
+      force: yes
+
   - name: Create clusterctl-settings.json for cluster-api and capm3 repos
     ansible.builtin.template:
       src: "{{ item.src }}"
@@ -66,6 +83,48 @@
       chdir: /tmp/cluster-api-clone/
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
+
+  - name: Update kustomizations with images to use
+    ansible.builtin.command: "{{ item }}"
+    args:
+      chdir: "{{ CAPM3PATH }}"
+    environment:
+      MANIFEST_IMG: "{{ upgraded_capm3_image }}"
+      MANIFEST_TAG: "{{ upgraded_capm3_tag }}"
+      MANIFEST_IMG_IPAM: "{{ upgraded_ipam_image }}"
+      MANIFEST_TAG_IPAM: "{{ upgraded_ipam_tag }}"
+    loop:
+      - make set-manifest-image
+      - make set-manifest-image-ipam
+
+  - name: Build IPAM manifests
+    ansible.builtin.command: "{{ item }}"
+    args:
+      chdir: "{{ CAPM3PATH }}"
+    loop:
+      - make hack/tools/bin/kustomize
+      - ./hack/tools/bin/kustomize build "{{ IPAMPATH }}/config/default" --output config/ipam/metal3-ipam-components.yaml
+
+  - name: Update CAPM3 imports to use local IPAM manifest
+    ansible.builtin.replace:
+      path: "{{ CAPM3PATH }}/config/ipam/kustomization.yaml"
+      regexp: https://github\.com/metal3-io/ip-address-manager/releases/download/v.*/ipam-components\.yaml
+      replace: metal3-ipam-components.yaml
+
+  - name: Make capm3 release manifests
+    ansible.builtin.command: make release-manifests
+    args:
+      chdir: "{{ CAPM3PATH }}"
+
+  # Note: release manifests are not impacted by this (they are in .gitignore)
+  - name: Clean CAPM3 repo after building release manifests
+    ansible.builtin.git:
+      repo: 'https://github.com/metal3-io/cluster-api-provider-metal3.git'
+      dest: "{{ CAPM3PATH }}"
+      version: "{{ upgraded_capm3_branch }}"
+      clone: no
+      # Force to discard local changes
+      force: yes
 
   - name: Create folder structure for next version controlplane components
     vars:
@@ -127,62 +186,29 @@
 
   - name: Create next version controller CRDs
     vars:
-      working_dir: "{{HOME}}/.cluster-api"
-    copy: src="{{working_dir}}/{{item.src}}" dest="{{working_dir}}/{{item.dest}}"
-    with_items:
-    - {
-        src: "dev-repository/cluster-api/{{CAPIRELEASE}}/core-components.yaml",
-        dest: "dev-repository/cluster-api/{{CAPI_REL_TO_VERSION}}/core-components.yaml"
-      }
-    - {
-        src: "dev-repository/cluster-api/{{CAPIRELEASE}}/metadata.yaml",
-        dest: "dev-repository/cluster-api/{{CAPI_REL_TO_VERSION}}/metadata.yaml"
-      }
-    - {
-        src: "dev-repository/bootstrap-kubeadm/{{CAPIRELEASE}}/bootstrap-components.yaml",
-        dest: "dev-repository/bootstrap-kubeadm/{{CAPI_REL_TO_VERSION}}/bootstrap-components.yaml"
-      }
-    - {
-        src: "dev-repository/bootstrap-kubeadm/{{CAPIRELEASE}}/metadata.yaml",
-        dest: "dev-repository/bootstrap-kubeadm/{{CAPI_REL_TO_VERSION}}/metadata.yaml"
-      }
-    - {
-        src: "dev-repository/control-plane-kubeadm/{{CAPIRELEASE}}/control-plane-components.yaml",
-        dest: "dev-repository/control-plane-kubeadm/{{CAPI_REL_TO_VERSION}}/control-plane-components.yaml"
-      }
-    - {
-        src: "dev-repository/control-plane-kubeadm/{{CAPIRELEASE}}/metadata.yaml",
-        dest: "dev-repository/control-plane-kubeadm/{{CAPI_REL_TO_VERSION}}/metadata.yaml"
-      }
-    - {
-        src: "overrides/infrastructure-metal3/{{ CAPM3RELEASE }}/infrastructure-components.yaml",
-        dest: "overrides/infrastructure-metal3/{{ CAPM3_REL_TO_VERSION }}/infrastructure-components.yaml"
-      }
-    - {
-        src: "overrides/infrastructure-metal3/{{ CAPM3RELEASE }}/metadata.yaml",
-        dest: "overrides/infrastructure-metal3/{{ CAPM3_REL_TO_VERSION }}/metadata.yaml"
-      }
-
-  - name: Make changes on CRDs
-    vars:
-      working_dir: "{{HOME}}/.cluster-api"
-    ansible.builtin.replace:
-      path: "{{ item.path }}"
-      regexp: "{{ item.regexp }}"
-      replace: "{{ item.replace }}"
+      dev_repository: "{{HOME}}/.cluster-api/dev-repository"
+      overrides: "{{HOME}}/.cluster-api/overrides"
+    copy:
+      src: "{{item.src}}"
+      dest: "{{item.dest}}"
     loop:
-      - path: "{{working_dir}}/dev-repository/cluster-api/{{CAPI_REL_TO_VERSION}}/core-components.yaml"
-        regexp: 'description: Machine'
-        replace: "description: upgradedMachine"
-      - path: "{{working_dir}}/dev-repository//bootstrap-kubeadm/{{CAPI_REL_TO_VERSION}}/bootstrap-components.yaml"
-        regexp: 'description: KubeadmConfig'
-        replace: "description: upgradedKubeadmConfig"
-      - path: "{{working_dir}}/dev-repository//control-plane-kubeadm/{{CAPI_REL_TO_VERSION}}/control-plane-components.yaml"
-        regexp: 'description: KubeadmControlPlane'
-        replace: "description: upgradedKubeadmControlPlane"
-      - path: "{{working_dir}}/overrides/infrastructure-metal3/{{CAPM3_REL_TO_VERSION}}/infrastructure-components.yaml"
-        regexp: '\bm3c\b'
-        replace: "upgm3c"
+    - src: "{{ dev_repository }}/cluster-api/{{CAPIRELEASE}}/core-components.yaml"
+      dest: "{{ dev_repository }}/cluster-api/{{CAPI_REL_TO_VERSION}}/core-components.yaml"
+    - src: "{{ dev_repository }}/cluster-api/{{CAPIRELEASE}}/metadata.yaml"
+      dest: "{{ dev_repository }}/cluster-api/{{CAPI_REL_TO_VERSION}}/metadata.yaml"
+    - src: "{{ dev_repository }}/bootstrap-kubeadm/{{CAPIRELEASE}}/bootstrap-components.yaml"
+      dest: "{{ dev_repository }}/bootstrap-kubeadm/{{CAPI_REL_TO_VERSION}}/bootstrap-components.yaml"
+    - src: "{{ dev_repository }}/bootstrap-kubeadm/{{CAPIRELEASE}}/metadata.yaml"
+      dest: "{{ dev_repository }}/bootstrap-kubeadm/{{CAPI_REL_TO_VERSION}}/metadata.yaml"
+    - src: "{{ dev_repository }}/control-plane-kubeadm/{{CAPIRELEASE}}/control-plane-components.yaml"
+      dest: "{{ dev_repository }}/control-plane-kubeadm/{{CAPI_REL_TO_VERSION}}/control-plane-components.yaml"
+    - src: "{{ dev_repository }}/control-plane-kubeadm/{{CAPIRELEASE}}/metadata.yaml"
+      dest: "{{ dev_repository }}/control-plane-kubeadm/{{CAPI_REL_TO_VERSION}}/metadata.yaml"
+
+    - src: "{{ CAPM3PATH }}/out/infrastructure-components.yaml"
+      dest: "{{ overrides }}/infrastructure-metal3/{{ CAPM3_REL_TO_VERSION }}/infrastructure-components.yaml"
+    - src: "{{ CAPM3PATH }}/out/metadata.yaml"
+      dest: "{{ overrides }}/infrastructure-metal3/{{ CAPM3_REL_TO_VERSION }}/metadata.yaml"
 
   - name: Perform upgrade on the target cluster
     ansible.builtin.command: clusterctl upgrade apply --contract v1beta1
@@ -196,8 +222,7 @@
       seconds: 30
 
   - name: Restore secrets to fill missing secret fields after performing target cluster upgrade
-    shell: |
-           kubectl replace -f /tmp/secrets.with.values.yaml
+    ansible.builtin.command: kubectl replace -f /tmp/secrets.with.values.yaml
     environment:
       KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
 
@@ -227,40 +252,14 @@
     until: (controller_deployments is succeeded) and
            (controller_deployments.resources | json_query(query) | length == 0)
 
-  - name: Verify that CRDs are upgraded
-    kubernetes.core.k8s_info:
-      api_version: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: "{{ item.name }}"
+  - name: Verify upgraded API resources for CAPI and CAPM3
+    kubernetes.core.k8s_cluster_info:
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    register: crd
-    vars:
-      query: "[?name == 'v1alpha3'].schema.openAPIV3Schema.description"
-    failed_when: crd.resources[0].spec.versions | json_query(query) is not search("{{ item.search }}")
-    loop:
-      - name: machines.cluster.x-k8s.io
-        search: upgradedMachine
-      - name: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io
-        search: upgradedKubeadmControlPlane
-      - name: kubeadmconfigs.bootstrap.cluster.x-k8s.io
-        search: upgradedKubeadmConfig
-
-  # Due to https://github.com/ansible-collections/kubernetes.core/issues/17
-  # we cannot use k8s_cluster_info. A fix is to be included in 2.0.0 of kubernetes.core
-  # - name: Verify upgraded API resource for Metal3Clusters
-  #   kubernetes.core.k8s_cluster_info:
-  #   register: api_status
-  #   # failed_when: api_status.apis not contains the upgraded m3c resource(s)?
-
-  - name: Verify upgraded API resource for Metal3Clusters
-    kubernetes.core.k8s_info:
-      api_version: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: metal3clusters.infrastructure.cluster.x-k8s.io
-      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    register: crd
-    failed_when: '"upgm3c" not in crd.resources[0].spec.names.shortNames'
-    when: 'CAPM3RELEASE != CAPM3_REL_TO_VERSION'
+    register: api_status
+    failed_when: ('cluster.x-k8s.io/' + upgraded_capi_version not in api_status.apis) or
+                 ('controlplane.cluster.x-k8s.io/' + upgraded_capi_version not in api_status.apis) or
+                 ('bootstrap.cluster.x-k8s.io/' + upgraded_capi_version not in api_status.apis) or
+                 ('infrastructure.cluster.x-k8s.io/' + UPGRADED_CAPM3_VERSION not in api_status.apis)
 
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
 #                       Upgrade Ironic                                                  |
@@ -303,7 +302,7 @@
       mariadb_container:
       - name:  mariadb
         image: "{{CONTAINER_REGISTRY+'/metal3-io/mariadb:'+MARIADB_IMAGE_TAG}}"
-      
+
 
   - name: Wait for ironic update to rollout
     kubernetes.core.k8s_info:
@@ -325,6 +324,13 @@
            (ironic_deployment.resources[0].status.availableReplicas | default(0) == 1) and
            (ironic_deployment.resources[0].status.replicas | default(0) == 1)
 
+  - name: Fetch container images after upgrade
+    shell: |
+      kubectl get pods -A -o jsonpath="{range .items[*].spec.containers[*]}{.image}{'\n'}{end}" |
+      sort | uniq > /tmp/manifests/container_images_after_upgrade.txt
+    environment:
+      KUBECONFIG: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
+
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
 #                       Upgrade K8S version and boot-image                              |
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
@@ -336,10 +342,10 @@
       IMAGE_LOCATION: "https://artifactory.nordix.org/artifactory/airship/images/k8s_{{UPGRADED_K8S_VERSION}}/"
       IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"
       IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
-  
+
   - name: Get cluster uid
     kubernetes.core.k8s_info:
-      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
+      api_version: cluster.x-k8s.io/{{ upgraded_capi_version }}
       kind: Cluster
       name: "{{ CLUSTER_NAME }}"
       namespace: "{{ NAMESPACE }}"
@@ -359,6 +365,8 @@
       IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"
       IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
       NODE_REUSE_STATUS: "false"
+      CAPI_VERSION: "{{ upgraded_capi_version }}"
+      CAPM3_VERSION: "{{ UPGRADED_CAPM3_VERSION }}"
 
   - name: Create worker Metal3MachineTemplates
     kubernetes.core.k8s:
@@ -373,10 +381,12 @@
       IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"
       IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
       NODE_REUSE_STATUS: "false"
+      CAPI_VERSION: "{{ upgraded_capi_version }}"
+      CAPM3_VERSION: "{{ UPGRADED_CAPM3_VERSION }}"
 
   - name: Update boot-disk and kubernetes versions of controlplane nodes
     kubernetes.core.k8s:
-      api_version: controlplane.cluster.x-k8s.io/{{ CAPI_VERSION }}
+      api_version: controlplane.cluster.x-k8s.io/{{ upgraded_capi_version }}
       kind: KubeadmControlPlane
       name: "{{ CLUSTER_NAME }}"
       namespace: "{{ NAMESPACE }}"
@@ -464,10 +474,10 @@
     until: (workload_pods is succeeded) and
            (workload_pods.resources | length > 0) and
            (workload_pods.resources[0].status.readyReplicas == workload_pods.resources[0].spec.replicas)
-  
+
   - name: Update MachineDeployment maxSurge and maxUnavailable fields
     kubernetes.core.k8s:
-      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
+      api_version: cluster.x-k8s.io/{{ upgraded_capi_version }}
       kind: MachineDeployment
       name: "{{ CLUSTER_NAME }}"
       namespace: "{{ NAMESPACE }}"
@@ -481,7 +491,7 @@
 
   - name: Update boot-disk and kubernetes versions of worker node
     kubernetes.core.k8s:
-      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
+      api_version: cluster.x-k8s.io/{{ upgraded_capi_version }}
       kind: MachineDeployment
       name: "{{ CLUSTER_NAME }}"
       namespace: "{{ NAMESPACE }}"
@@ -525,7 +535,7 @@
 
   - name: Verify that kubernetes version is upgraded for CP and worker nodes
     kubernetes.core.k8s_info:
-      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
+      api_version: cluster.x-k8s.io/{{ upgraded_capi_version }}
       kind: Machine
       namespace: "{{ NAMESPACE }}"
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -92,9 +92,27 @@ NUM_IRONIC_IMAGES: 8
 CAPIRELEASE_HARDCODED: "{{ lookup('env', 'CAPIRELEASE_HARDCODED') }}"
 M3PATH: "{{ lookup('env', 'M3PATH') }}"
 CAPM3PATH: "{{M3PATH}}/cluster-api-provider-metal3"
+IPAMPATH: "{{ lookup('env', 'IPAMPATH') }}"
 
 CAPM3_REL_TO_VERSION: "{{ lookup('env', 'CAPM3_REL_TO_VERSION') }}"
 CAPI_REL_TO_VERSION: "{{ lookup('env', 'CAPI_REL_TO_VERSION') }}"
+UPGRADED_CAPM3_VERSION: "{{ lookup('env', 'UPGRADED_CAPM3_VERSION') }}"
+
+capm3_version_to_branch:
+  v1alpha4: release-0.4
+  v1alpha5: release-0.5
+  v1beta1: main
+capm3_version_to_capi_version:
+  v1alpha4: v1alpha3
+  v1alpha5: v1alpha4
+  v1beta1: v1beta1
+
+upgraded_capm3_image: "{{ CONTAINER_REGISTRY }}/metal3-io/cluster-api-provider-metal3"
+upgraded_capm3_tag: main
+upgraded_ipam_image: "{{ CONTAINER_REGISTRY }}/metal3-io/ip-address-manager"
+upgraded_ipam_tag: main
+upgraded_capm3_branch: "{{ capm3_version_to_branch[UPGRADED_CAPM3_VERSION] }}"
+upgraded_capi_version: "{{ capm3_version_to_capi_version[UPGRADED_CAPM3_VERSION] }}"
 
 provision_cluster_actions:
     - "ci_test_provision"


### PR DESCRIPTION
The upgrade tests previously just did a patch version upgrade. In order
to properly test changes in the contract we now test upgrades where CAPI
goes from v1alpha4 to v1beta1 and CAPM3 follows from v1alpha5 to
vabeta1.