### PR TITLE
Handle zero length dhcp_range variables

### DIFF
--- a/vm-setup/roles/libvirt/templates/network.xml.j2
+++ b/vm-setup/roles/libvirt/templates/network.xml.j2
@@ -31,7 +31,7 @@
 {# IPv4 Configuration #}
 {% if item.address_v4 is defined and item.address_v4 != '' and item.forward_mode != 'bridge' %}
   <ip address='{{ item.address_v4 }}' netmask='{{ netmask_v4 }}'>
-  {% if item.dhcp_range_v4 is defined %}
+  {% if item.dhcp_range_v4 is defined and item.dhcp_range_v4|length != 0 %}
     <dhcp>
       <range start='{{ item.dhcp_range_v4[0] }}' end='{{ item.dhcp_range_v4[1] }}'/>
     {% set ns = namespace(index=0) %}
@@ -80,7 +80,7 @@
 {# IPv6 Configuration #}
 {% if item.address_v6 is defined and item.address_v6 != '' and item.forward_mode != 'bridge' %}
   <ip family="ipv6" address='{{ item.address_v6 }}' prefix='{{ prefix_v6 }}'>
-  {% if item.dhcp_range_v6 is defined %}
+  {% if item.dhcp_range_v6 is defined and item.dhcp_range_v6|length != 0 %}
     <dhcp>
       <range start='{{ item.dhcp_range_v6[0] }}' end='{{ item.dhcp_range_v6[1] }}'/>
     {% set ns = namespace(index=0) %}


### PR DESCRIPTION
In this case, we treat it the same as the lists being undefined since
it implies DHCP is disabled.

This means it's possible to do a conditional in a vars file e.g:
```
dhcp_range_v4: "{{ [ <IP>, <IP>] if lookup('env', 'STATIC_IPS') == '' else [] }}"
```
Which is more convenient that conditionally generating the map keys.