### PR TITLE
Add the new epel-next repository for CentOS Stream

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -21,9 +21,10 @@ if [[ $OS == ubuntu ]]; then
   elif [[ ${DISTRO} == "ubuntu20" ]]; then
     sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
   fi
-
-else
-  sudo dnf update -y && sudo dnf install -y epel-release
+elif [[ $OS == "centos" || $OS == "rhel" ]]; then
+  sudo dnf upgrade -y
+  sudo dnf config-manager --set-enabled powertools
+  sudo dnf install -y epel-release epel-next-release
   sudo dnf -y install python3-pip
   sudo alternatives --set python /usr/bin/python3
 fi


### PR DESCRIPTION
EPEL Next is an additional repository that contains packages built
specifically against CentOS Stream to allow version requirements for
software already present in CentOS Stream but not in RHEL.
For more info see [1]

[1] https://docs.fedoraproject.org/en-US/epel/epel-about-next/