### PR TITLE
Allow overriding CAPM3_VERSION and CAPI_VERSION in upgrade vars

### DIFF
--- a/scripts/feature_tests/upgrade/upgrade_vars.sh
+++ b/scripts/feature_tests/upgrade/upgrade_vars.sh
@@ -6,12 +6,10 @@ set -eux
 
 export CAPIRELEASE_HARDCODED="v1.0.99"
 
-export CAPI_VERSION="v1alpha4"
-export CAPIRELEASE="v0.4.5"
+export CAPI_VERSION="${CAPI_VERSION:-v1alpha4}"
 export CAPI_REL_TO_VERSION="v1.0.1"
 
-export CAPM3_VERSION="v1alpha5"
-export CAPM3RELEASE="v0.5.3"
+export CAPM3_VERSION="${CAPM3_VERSION:-v1alpha5}"
 export CAPM3_REL_TO_VERSION="v1.0.0"
 export UPGRADED_CAPM3_VERSION="v1beta1"
 


### PR DESCRIPTION
Also remove hard coded releases for CAPI and CAPM3. The latest release
for the chosen API version will be set automatically as seen [here](https://github.com/metal3-io/metal3-dev-env/blob/c9ac2d8082e2cc46e39dee9a81aa82172c9ae741/lib/releases.sh#L35-L55) (and can be overridden).

The idea is to make it possible to test multiple scenarios with the
upgrade test. For example, upgrading just a patch (v1.0.0 -> v1.0.1).
The default is to upgrade from the latest CAPI v1alpha4 release to the
latest v1beta1 release.