### PR TITLE
Ensure that machines are provisioned and running before repivot

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -26,7 +26,7 @@
         with_items:
           - "{{ ironic_containers }}"
           - "{{ general_containers }}"
-          
+
       - name: Fetch container logs before pivoting (kind cluster)
         shell: "sudo {{ CONTAINER_RUNTIME }} logs {{ item }} > /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stdout.log 2> /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stderr.log"
         with_items:
@@ -41,7 +41,7 @@
 
     when: EPHEMERAL_CLUSTER == "kind"
     become: yes
-    become_user: root 
+    become_user: root
 
   - name: Fetch container logs (minikube cluster)
     block:
@@ -55,7 +55,7 @@
       - name: Fetch container logs before pivoting (minikube cluster)
         shell: "sudo {{ CONTAINER_RUNTIME }} logs {{ item }} > /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stdout.log 2> /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stderr.log"
         with_items: "{{ general_containers }}"
-  
+
     become: yes
     become_user: root
     when: EPHEMERAL_CLUSTER == "minikube"
@@ -73,7 +73,7 @@
     with_items:
        - clusterctl.cluster.x-k8s.io=""
     when: CAPM3_VERSION != "v1alpha4"
-       
+
   - name: Obtain target cluster kubeconfig
     kubernetes.core.k8s_info:
       kind: secrets
@@ -170,43 +170,13 @@
   - name: Pivot objects to target cluster
     shell: "clusterctl move --to-kubeconfig /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml -n {{ NAMESPACE }} -v 10"
 
-  - name: Check if machines become running.
-    kubernetes.core.k8s_info:
-      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
-      kind: machines
+  - name: Verify that all machines are provisioned and running.
+    include_tasks: verify_resources_states.yml
+    vars:
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    register: provisioned_machines
-    retries: 50
-    delay: 20
-    until: (provisioned_machines is succeeded) and
-           (provisioned_machines.resources | filter_phase("running") | length == (NUMBER_OF_BMH | int))
-
-  - name: Check if metal3machines become ready.
-    kubernetes.core.k8s_info:
-      api_version: infrastructure.cluster.x-k8s.io/{{ CAPM3_VERSION }}
-      kind: metal3machine
-      namespace: "{{ NAMESPACE }}"
-      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    register: m3m_machines
-    retries: 10
-    delay: 20
-    until: (m3m_machines is succeeded) and
-           (m3m_machines.resources | filter_ready | length == (NUMBER_OF_BMH | int))
-
-  - name: Check if bmh is in provisioned state
-    kubernetes.core.k8s_info:
-      api_version: metal3.io/v1alpha1
-      kind: BareMetalHost
-      namespace: "{{ NAMESPACE }}"
-      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    register: bmh
-    retries: 10
-    delay: 20
-    until: (bmh is succeeded) and
-           (bmh.resources | filter_provisioning("provisioned") | length == (NUMBER_OF_BMH | int))
 
   # Normally as non authenticated user we should
-  # fail here(get 401) to reach Ironic.       
+  # fail here(get 401) to reach Ironic.
   - name: Expect 401 from /v1/nodes ednpoint
     uri:
       url: "{{ IRONIC_URL }}nodes"

--- a/vm-setup/roles/v1aX_integration_test/tasks/node_reuse.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/node_reuse.yml
@@ -2,7 +2,6 @@
   - set_fact:
       NUMBER_OF_BMH_KCP: "{{ NUM_OF_CONTROLPLANE_REPLICAS|int }}"
       NUMBER_OF_BMH_MD: "{{ NUM_OF_WORKER_REPLICAS|int }}"
-      NUMBER_OF_ALL_BMH: "{{ NUM_OF_WORKER_REPLICAS|int + NUM_OF_CONTROLPLANE_REPLICAS|int }}"
 
   - name: Untaint all nodes.
     shell: |
@@ -144,7 +143,7 @@
     until:
       - bmhs is succeeded
       - bmhs.resources | filter_provisioning("provisioning") | length == 1
-      - saved_bmhs.resources | filter_provisioning("deprovisioning") | first | json_query('metadata.name') == 
+      - saved_bmhs.resources | filter_provisioning("deprovisioning") | first | json_query('metadata.name') ==
         bmhs.resources | filter_provisioning("provisioning") | first | json_query('metadata.name')
 
   - name: Wait until two machines become running and updated with new "{{ UPGRADED_K8S_VERSION }}" k8s version.
@@ -395,7 +394,7 @@
     until:
       - bmhs is succeeded
       - bmhs.resources | filter_provisioning("provisioning") | length == 1
-      - saved_bmhs.resources | filter_provisioning("deprovisioning") | first | json_query('metadata.name') == 
+      - saved_bmhs.resources | filter_provisioning("deprovisioning") | first | json_query('metadata.name') ==
         bmhs.resources | filter_provisioning("provisioning") | first | json_query('metadata.name')
 
   - name: Wait until worker machine becomes running and updated with new "{{ UPGRADED_K8S_VERSION }}" k8s version.
@@ -441,28 +440,7 @@
         spec:
           replicas: 3
 
-  - name: Wait until all "{{ NUMBER_OF_ALL_BMH }}" BMHs' are provisioned.
-    k8s_info:
-      api_version: metal3.io/v1alpha1
-      kind: BareMetalHost
-      namespace: "{{ NAMESPACE }}"
+  - name: Verify that all machines are provisioned and running.
+    include_tasks: verify_resources_states.yml
+    vars:
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    register: bmhs
-    retries: 200
-    delay: 20
-    until:
-      - bmhs is succeeded
-      - bmhs.resources | filter_provisioning("provisioned") | length == (NUMBER_OF_ALL_BMH | int)
-
-  - name: Wait until all "{{ NUMBER_OF_ALL_BMH }}" machines become running.
-    k8s_info:
-      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
-      kind: machines
-      namespace: "{{ NAMESPACE }}"
-      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    register: machines
-    retries: 200
-    delay: 20
-    until:
-      - machines is succeeded
-      - machines.resources | filter_phase("running") | length == (NUMBER_OF_ALL_BMH | int)

--- a/vm-setup/roles/v1aX_integration_test/tasks/remediation.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/remediation.yml
@@ -142,7 +142,7 @@
         spec:
           replicas: 1
 
-    # we use shell instead of k8s_info module here because the CP may not respond to requests 
+    # we use shell instead of k8s_info module here because the CP may not respond to requests
     # while it is scaling down - k8s_info has no request timeout, which can hang the build
   - name: Wait until KCP is scaled down and two hosts are available
     shell: kubectl get bmh -n "{{ NAMESPACE }}" | egrep -c '\b(available)|(ready)\b'
@@ -245,29 +245,10 @@
           annotations:
             capi.metal3.io/unhealthy: null
 
-  - name: Wait until all "{{ NUMBER_OF_BMH }}" BMH are provisioned
-    k8s_info:
-      api_version: metal3.io/v1alpha1
-      kind: BareMetalHost
-      namespace: "{{ NAMESPACE }}"
-    register: bmhs
-    retries: 200
-    delay: 20
-    until:
-      - bmhs is succeeded
-      - bmhs.resources | filter_provisioning("provisioned") | length == (NUMBER_OF_BMH | int)
-
-  - name: Wait until "{{ NUMBER_OF_BMH }}"  machines become running.
-    k8s_info:
-      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
-      kind: machines
-      namespace: "{{ NAMESPACE }}"
-    register: machines
-    retries: 200
-    delay: 20
-    until:
-      - machines is succeeded
-      - machines.resources | filter_phase("running") | length == (NUMBER_OF_BMH | int)
+  - name: Verify that all machines are provisioned and running.
+    include_tasks: verify_resources_states.yml
+    vars:
+      kubeconfig: "{{ HOME }}/.kube/config"
 
   - name: Scale down the machinedeployment
     k8s:
@@ -382,26 +363,7 @@
         spec:
           replicas: 3
 
-  - name: Wait until "{{ NUMBER_OF_BMH }}" BMH are provisioned
-    k8s_info:
-      api_version: metal3.io/v1alpha1
-      kind: BareMetalHost
-      namespace: "{{ NAMESPACE }}"
-    register: bmhs
-    retries: 200
-    delay: 20
-    until:
-      - bmhs is succeeded
-      - bmhs.resources | filter_provisioning("provisioned") | length == (NUMBER_OF_BMH | int)
-
-  - name: Wait until all "{{ NUMBER_OF_BMH }}" machines become running.
-    k8s_info:
-      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
-      kind: machines
-      namespace: "{{ NAMESPACE }}"
-    register: machines
-    retries: 200
-    delay: 20
-    until:
-      - machines is succeeded
-      - machines.resources | filter_phase("running") | length == (NUMBER_OF_BMH | int)
+  - name: Verify that all machines are provisioned and running.
+    include_tasks: verify_resources_states.yml
+    vars:
+      kubeconfig: "{{ HOME }}/.kube/config"

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -542,3 +542,9 @@
     register: machines
     failed_when: (machines.resources | map(attribute='spec.version') | unique | length != 1) or
                  (machines.resources | map(attribute='spec.version') | first != "{{ UPGRADED_K8S_VERSION }}")
+
+# Before pivoting back we must ensure all machines are provisioned and running.
+  - name: Verify that all machines are provisioned and running.
+    include_tasks: verify_resources_states.yml
+    vars:
+      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"

--- a/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify.yml
@@ -1,47 +1,8 @@
 ---
-  - name: Define number of BMH's
-    set_fact:
-      NUMBER_OF_BMH: "{{ NUM_OF_CONTROLPLANE_REPLICAS|int +  NUM_OF_WORKER_REPLICAS|int }}"
-
-  - name: Wait until cluster becomes provisioned.
-    k8s_info:
-      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
-      kind: Cluster
-      namespace: "{{ NAMESPACE }}"
-    register: provisioned_cluster
-    retries: 100
-    delay: 20
-    until: (provisioned_cluster is succeeded) and
-           (provisioned_cluster.resources | length > 0) and
-           (provisioned_cluster.resources[0].status.phase | default("none") | lower == "provisioned")
-
-  - name: Wait until "{{ NUMBER_OF_BMH }}" BMHs become provisioned.
-    kubernetes.core.k8s_info:
-      api_version: metal3.io/v1alpha1
-      kind: BareMetalHost
-      namespace: "{{ NAMESPACE }}"
-    register: provisioned_bmh
-    retries: 200
-    delay: 30
+  - name: Verify that all machines are provisioned and running.
+    include_tasks: verify_resources_states.yml
     vars:
-      query: "[? status.provisioning.state=='provisioned']"
-    until: (provisioned_bmh is succeeded) and
-           (provisioned_bmh.resources | length > 0) and
-           (provisioned_bmh.resources | json_query(query) | length ==  (NUMBER_OF_BMH | int))
-
-  - name: Wait until "{{ NUMBER_OF_BMH }}" machines become running.
-    k8s_info:
-      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
-      kind: Machine
-      namespace: "{{ NAMESPACE }}"
-    register: provisioned_machines
-    retries: 150
-    delay: 20
-    vars:
-      query: "[? status.phase=='running' || status.phase=='Running']"
-    until: (provisioned_machines is succeeded) and
-           (provisioned_machines.resources | length > 0) and
-           (provisioned_machines.resources | json_query(query) | length == (NUMBER_OF_BMH | int))
+      kubeconfig: "{{ HOME }}/.kube/config"
 
   - name: Fetch target cluster kubeconfig
     kubernetes.core.k8s_info:

--- a/vm-setup/roles/v1aX_integration_test/tasks/verify_resources_states.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/verify_resources_states.yml
@@ -1,0 +1,63 @@
+---
+  - name: Define number of BMH's
+    set_fact:
+      NUMBER_OF_BMH: "{{ NUM_OF_CONTROLPLANE_REPLICAS|int +  NUM_OF_WORKER_REPLICAS|int }}"
+
+  - name: Wait until cluster becomes provisioned.
+    k8s_info:
+      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
+      kind: Cluster
+      namespace: "{{ NAMESPACE }}"
+      kubeconfig: "{{ kubeconfig }}"
+    register: cluster
+    retries: 100
+    delay: 20
+    until: (cluster is succeeded) and
+           (cluster.resources | length > 0) and
+           (cluster.resources[0].status.phase | default("none") | lower == "provisioned")
+
+  - name: Wait until "{{ NUMBER_OF_BMH }}" BMHs become provisioned.
+    kubernetes.core.k8s_info:
+      api_version: metal3.io/v1alpha1
+      kind: BareMetalHost
+      namespace: "{{ NAMESPACE }}"
+      kubeconfig: "{{ kubeconfig }}"
+    register: bmh
+    retries: 200
+    delay: 30
+    vars:
+      query: "[? status.provisioning.state=='provisioned']"
+    until: (bmh is succeeded) and
+           (bmh.resources | length > 0) and
+           (bmh.resources | json_query(query) | length ==  (NUMBER_OF_BMH | int))
+
+  - name: Wait until "{{ NUMBER_OF_BMH }}" metal3machines become ready.
+    kubernetes.core.k8s_info:
+      api_version: infrastructure.cluster.x-k8s.io/{{ CAPM3_VERSION }}
+      kind: Metal3Machine
+      namespace: "{{ NAMESPACE }}"
+      kubeconfig: "{{ kubeconfig }}"
+    register: m3m
+    retries: 10
+    delay: 20
+    vars:
+      # Note: the 'ready' field is a boolean (not a string)
+      query: "[? status.ready]"
+    until: (m3m is succeeded) and
+           (m3m.resources | length > 0) and
+           (m3m.resources | json_query(query) | length == (NUMBER_OF_BMH | int))
+
+  - name: Wait until "{{ NUMBER_OF_BMH }}" machines become running.
+    k8s_info:
+      api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
+      kind: Machine
+      namespace: "{{ NAMESPACE }}"
+      kubeconfig: "{{ kubeconfig }}"
+    register: machines
+    retries: 150
+    delay: 20
+    vars:
+      query: "[? status.phase=='running' || status.phase=='Running']"
+    until: (machines is succeeded) and
+           (machines.resources | length > 0) and
+           (machines.resources | json_query(query) | length == (NUMBER_OF_BMH | int))


### PR DESCRIPTION
Since we are doing this check in multiple places, I decided to factor
out the steps into a separate file that can be included where needed.
When doing this we must ensure that the correct kubeconfig is used by
passing it as a variable.