### PR TITLE
move maelk to emeritus_approvers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
  - hardys
- - maelk
  - fmuyassarov
  - furkatgofurov7
  - kashifest
@@ -14,3 +13,6 @@ reviewers:
  - namnx228
  - macaptain
  - mboukhalfa
+
+emeritus_approvers:
+ - maelk


### PR DESCRIPTION
Maël's focus has shifted from this project to other tasks thus the
OWNERS list has to be modified accordingly.