### PR TITLE
🌱 Add logic to verify passwordless sudo

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -2,6 +2,12 @@
 
 [[ ":$PATH:" != *":/usr/local/go/bin:"* ]] && PATH="$PATH:/usr/local/go/bin"
 
+# Verify that passwordless sudo is configured correctly
+if ! sudo -nl | grep -q '(ALL) NOPASSWD: ALL';then
+    echo "ERROR: metal3-dev-env requires passwordless sudo configuration!"
+    exit 1
+fi
+
 eval "$(go env)"
 export GOPATH
 


### PR DESCRIPTION
This fix is implemented because on a freshly cloned or fully cleaned metal3-dev-env
it is possible to bootstrap a cluster without the passwordless sudo
configuration but at subsequent executions the script will stop running
and one of the components will throw an error to notify the user that it needs
passwordless sudo.

In order to avoid running the dev-env with incorrect sudo configuration this
commit implements a verification step that will stop the execution in case
the sudo configuratio is incorrect.