### PR TITLE
Use the virt-rhel8.2.0 machine type in case of arm64

### DIFF
--- a/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
+++ b/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
@@ -5,6 +5,7 @@
 
   {{baremetal_vm_xml|default('')}}
 
+{% if libvirt_arch != 'aarch64' %}
   <os>
     <type arch='{{ libvirt_arch }}' machine='q35'>hvm</type>
 {% if libvirt_firmware  == 'uefi' %}
@@ -18,6 +19,12 @@
     <boot dev='network'/>
     <bootmenu enable='no'/>
   </os>
+{% else %}
+<os firmware='efi'>
+  <type arch='aarch64' machine='virt-rhel8.2.0'>hvm</type>
+</os>
+{% endif %}
+
   <features>
     <acpi/>
     <apic/>


### PR DESCRIPTION
The q35 machine isn't valid for arm64. Instead, use virt-rhel8.2.0. Also
rely on automatic UEFI firmware and secure boot settings instead of
manually configuring this which would need to be done in an architecure
specific manner.

Signed-off-by: Balazs Nemeth <bnemeth@redhat.com>