### PR TITLE
Remove checking ironic-api, ironic-conductor, mariadb containers

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -9,13 +9,10 @@
           - vbmc
       ironic_containers:
           - ironic
-          - ironic-api
-          - ironic-conductor
           - ironic-inspector
           - ironic-endpoint-keepalived
           - ironic-log-watch
           - dnsmasq
-          - mariadb
 
   - name: Fetch container logs (kind cluster)
     block:
@@ -30,9 +27,6 @@
 
       - name: Fetch container logs before pivoting (kind cluster)
         shell: "sudo {{ CONTAINER_RUNTIME }} logs {{ item }} > /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stdout.log 2> /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stderr.log"
-        # FIXME(dtantsur): remove ignore_errors after the transition period
-        # from ironic-api+conductor to just ironic
-        ignore_errors: yes
         with_items:
           - "{{ ironic_containers }}"
           - "{{ general_containers }}"
@@ -41,9 +35,6 @@
         docker_container:
           name: "{{ item }}"
           state: absent
-        # FIXME(dtantsur): remove ignore_errors after the transition period
-        # from ironic-api+conductor to just ironic
-        ignore_errors: yes
         with_items: "{{ ironic_containers }}"
 
     when: EPHEMERAL_CLUSTER == "kind"


### PR DESCRIPTION
Remove checking ironic-api, ironic-conductor, mariadb existence since these containers are not deployed anymore while deploying ironic locally.