### PR TITLE
Revert "Temporary fix for cert-manager URL change"

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -358,13 +358,6 @@ function patch_clusterctl(){
   mkdir -p "${HOME}"/.cluster-api
   touch "${HOME}"/.cluster-api/clusterctl.yaml
 
-  ## Cert-manager has changed the organization on github.
-  ## This is a temporary fix until CAPI has updated the URL.
-  cat <<EOF > "${HOME}"/.cluster-api/clusterctl.yaml
-cert-manager:
-  url: "https://github.com/cert-manager/cert-manager/releases/latest/cert-manager.yaml"
-EOF
-
   # At this point the images variables have been updated with update_images
   # Reflect the change in components files
   if [ -n "${CAPM3_LOCAL_IMAGE}" ]; then

--- a/vm-setup/roles/v1aX_integration_test/templates/clusterctl-upgrade-test.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/clusterctl-upgrade-test.yaml
@@ -1,10 +1,5 @@
 # Cluster API config used for upgrade testing.
 
-## Cert-manager has changed the organization on github.
-## This is a temporary fix until CAPI has updated the URL.
-cert-manager:
-  url: "https://github.com/cert-manager/cert-manager/releases/latest/cert-manager.yaml"
-
 # Image is overriden in provider/container_name format
 # list of providers
 # cluster.x-k8s.io/provider: bootstrap-kubeadm

--- a/vm-setup/roles/v1aX_integration_test/templates/clusterctl-vars.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/clusterctl-vars.yaml
@@ -2,11 +2,6 @@
 # For deployment to ~/.cluster-api/
 ## Note these settings are overridden by environment variables.
 
-## Cert-manager has changed the organization on github.
-## This is a temporary fix until CAPI has updated the URL.
-cert-manager:
-  url: "https://github.com/cert-manager/cert-manager/releases/latest/cert-manager.yaml"
-
 # Cluster settings
 KUBERNETES_VERSION: {{ KUBERNETES_VERSION }}
 NAMESPACE: {{ NAMESPACE }}


### PR DESCRIPTION
Reverts metal3-io/metal3-dev-env#927

There are new releases of CAPI now with a fix so we should be able to revert this.