### PR TITLE
Add install ca-certificates before update

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -12,6 +12,7 @@ if [[ $(id -u) == 0 ]]; then
 fi
 
 if [[ $OS == ubuntu ]]; then
+  sudo apt install ca-certificates
   sudo apt-get update
   sudo apt -y install python3-pip
 


### PR DESCRIPTION
Ubuntu based CI is failing with  `Certificate verification failed: The certificate is NOT trusted. The received OCSP status response is invalid.  Could not handshake: Error in the certificate verification.`

This PR is adding the installation of ca-certificate