### PR TITLE
📖 Remove v1a4 main job CI badges from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ This repository includes scripts to set up a Metal³ development environment.
 
 ## Build Status
 
-[![Ubuntu V1alpha4 build status](https://jenkins.nordix.org/view/Metal3/job/metal3_main_v1a4_integration_test_ubuntu/badge/icon?subject=Ubuntu%20E2E%20V1alpha4)](https://jenkins.nordix.org/view/Metal3/job/metal3_main_v1a4_integration_test_ubuntu)
-[![CentOS V1alpha4 build status](https://jenkins.nordix.org/view/Metal3/job/metal3_main_v1a4_integration_test_centos/badge/icon?subject=CentOS%20E2E%20V1alpha4)](https://jenkins.nordix.org/view/Metal3/job/metal3_main_v1a4_integration_test_centos)
 [![Ubuntu V1alpha5 build status](https://jenkins.nordix.org/view/Metal3/job/metal3_main_v1a5_integration_test_ubuntu/badge/icon?subject=Ubuntu%20E2E%20V1alpha5)](https://jenkins.nordix.org/view/Metal3/job/metal3_main_v1a5_integration_test_ubuntu)
 [![CentOS V1alpha5 build status](https://jenkins.nordix.org/view/Metal3/job/metal3_main_v1a5_integration_test_centos/badge/icon?subject=CentOS%20E2E%20V1alpha5)](https://jenkins.nordix.org/view/Metal3/job/metal3_main_v1a5_integration_test_centos)
 [![Ubuntu V1beta1 build status](https://jenkins.nordix.org/view/Metal3/job/metal3_main_v1b1_integration_test_ubuntu/badge/icon?subject=Ubuntu%20E2E%20V1beta1)](https://jenkins.nordix.org/view/Metal3/job/metal3_main_v1b1_integration_test_ubuntu)


### PR DESCRIPTION
Depends on:

- https://gerrit.nordix.org/c/infra/cicd/+/12300
- https://github.com/metal3-io/cluster-api-provider-metal3/pull/509

The idea is, we won't be running v1a4 main jobs daily, but we still do run v1a4 integration tests on PRs per need basis.