### PR TITLE
Always chown the working dir to the current user

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -324,9 +324,9 @@ esac
 if [ ! -d "$WORKING_DIR" ]; then
   echo "Creating Working Dir"
   sudo mkdir "$WORKING_DIR"
-  sudo chown "${USER}:${USER}" "$WORKING_DIR"
   chmod 755 "$WORKING_DIR"
 fi
+sudo chown "${USER}:${USER}" "$WORKING_DIR"
 
 function list_nodes() {
     # Includes -machine and -machine-namespace


### PR DESCRIPTION
If the working dir (/opt/metal3-dev-env) is created, but owned by another user, we hit a failure later when trying to create the certs directory.