### PR TITLE
Restructure EL packages for CentOS Stream 9

### DIFF
--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -54,8 +54,8 @@ packages:
      - jmespath
      - passlib
   centos:
-    rhel8:
-        packages:
+    common:
+      packages:
          - curl
          - dnsmasq
          - edk2-ovmf
@@ -68,7 +68,6 @@ packages:
          - bind-utils
          - jq
          - libguestfs-tools
-         - redhat-lsb-core
          - unzip
          - genisoimage
          - qemu-kvm
@@ -81,15 +80,20 @@ packages:
          - polkit-pkla-compat
          - python3-netaddr
          - virt-install
-         - network-scripts
          - firewalld
          - python3-six
          - httpd-tools
-         - python3-passlib
          - python3-bcrypt
-        pip3:
-          - jmespath
-          - kubernetes==17.17.0
+    el8:
+      packages:
+         - redhat-lsb-core
+         - network-scripts
+    el9:
+      packages: []
+    pip3:
+      - jmespath
+      - kubernetes==17.17.0
+      - passlib
 DAEMON_JSON_PATH: "{{ metal3_dir }}/vm-setup/roles/packages_installation/files"
 CONTAINER_RUNTIME: "{{ lookup('env', 'CONTAINER_RUNTIME') }}"
 OS_VERSION_ID: "{{ lookup('env', 'OS_VERSION_ID') }}"

--- a/vm-setup/roles/packages_installation/tasks/main.yml
+++ b/vm-setup/roles/packages_installation/tasks/main.yml
@@ -48,16 +48,26 @@
 
 - name: Install packages on CentOS/RHEL8
   block:
-    - name: Install packages on CentOS/RHEL8
+    - name: Install packages on CentOS/RHEL
       package:
-          name: "{{ packages.centos.rhel8.packages }}"
+          name: "{{ packages.centos.common.packages }}"
           state: present
+    - name: Install packages on CentOS8/RHEL8
+      package:
+          name: "{{ packages.centos.el8.packages }}"
+          state: present
+      when: ansible_distribution_version == "8"
+    - name: Install packages on CentOS9/RHEL9
+      package:
+          name: "{{ packages.centos.el9.packages }}"
+          state: present
+      when: ansible_distribution_version == "9"
     - name: Perform CentOS/RHEL8 required configurations
       include_tasks: centos_required_packages.yml
     - name: Install packages using pip3
       pip:
         executable: "pip3"
-        name: "{{ packages.centos.rhel8.pip3 }}"
+        name: "{{ packages.centos.pip3 }}"
         state: present
     - name: Install TPM emulator packages
       when: tpm_emulator|default(false)|bool


### PR DESCRIPTION
Add CentOS Stream support to the packages_installation ansible
role by splitting out the centos/rhel packages into common,
el8 and el9. No CS9 version of passlib seems to be available so
move it to be installed by pip.