### PR TITLE
Ensure working dir files are owned by the current user

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -326,7 +326,9 @@ if [ ! -d "$WORKING_DIR" ]; then
   sudo mkdir "$WORKING_DIR"
   sudo chmod 755 "$WORKING_DIR"
 fi
-sudo chown "${USER}:${USER}" "$WORKING_DIR"
+
+# Ensure all files in the working directory are owned by the current user
+sudo chown -R "${USER}:${USER}" "$WORKING_DIR"
 
 function list_nodes() {
     # Includes -machine and -machine-namespace


### PR DESCRIPTION
Fix for the e2e tests while we're migrating from airshipci user to metal3ci user.