### PR TITLE
Make IMAGE_OS value lower case

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,19 +67,19 @@ export CAPI_VERSION=v1beta1
 The following environment variables need to be set for **Centos**:
 
 ```sh
-export IMAGE_OS=Centos
+export IMAGE_OS=centos
 ```
 
 And the following environment variables need to be set for **Ubuntu**:
 
 ```sh
-export IMAGE_OS=Ubuntu
+export IMAGE_OS=ubuntu
 ```
 
 And the following environment variables need to be set for **Flatcar**:
 
 ```sh
-export IMAGE_OS=Flatcar
+export IMAGE_OS=flatcar
 ```
 
 You can check a list of all the environment variables [here](vars.md)

--- a/config_example.sh
+++ b/config_example.sh
@@ -42,7 +42,7 @@
 # This variable defines if controlplane should scale-in or scale-out during upgrade
 # The field values can be 0 or 1. Default is 1. When set to 1 controlplane scale-out
 # When set to 0 controlplane scale-in. In case of scale-in NUM_OF_CONTROLPLANE_REPLICAS must be >=3.
-# 
+#
 # In case of worker, this variable defines maximum number of machines that can be scheduled
 # above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage
 # of desired machines (ex: 10%). This can not be 0 if MAX_UNAVAILABLE_VALUE is 0. Absolute number
@@ -145,7 +145,7 @@
 
 # Image OS (can be "Cirros", "Ubuntu", "Centos", overriden by IMAGE_* if set)
 # Default: Centos
-#export IMAGE_OS="Centos"
+#export IMAGE_OS="centos"
 
 # Image for target hosts deployment
 #
@@ -200,10 +200,9 @@
 # Secure Ironic deployment with TLS ("true" or "false")
 #export IRONIC_TLS_SETUP="true"
 
-# Set nodeDrainTimeout for controlplane and worker template, otherwise default value will be  '0s'. 
+# Set nodeDrainTimeout for controlplane and worker template, otherwise default value will be  '0s'.
 #
 #export NODE_DRAIN_TIMEOUT=${NODE_DRAIN_TIMEOUT:-"0s"}
 
 # Uncomment the line below to build ironic-image from source
 # export IRONIC_FROM_SOURCE="true"
-

--- a/lib/images.sh
+++ b/lib/images.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 # Image name and location
-IMAGE_OS=${IMAGE_OS:-Centos}
-if [[ "${IMAGE_OS}" == "Ubuntu" ]]; then
+IMAGE_OS=${IMAGE_OS:-centos}
+# NOTE: ${VAR,,} is making the varable lower case.
+# This is temporary and will be removed once we have changed IMAGE_OS to be
+# lower case in the CI.
+if [[ "${IMAGE_OS,,}" == "ubuntu" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-UBUNTU_20.04_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://artifactory.nordix.org/artifactory/metal3/images/k8s_${KUBERNETES_VERSION}}
 elif [[ "${IMAGE_OS}" == "FCOS" ]]; then
@@ -11,10 +14,10 @@ elif [[ "${IMAGE_OS}" == "FCOS" ]]; then
 elif [[ "${IMAGE_OS}" == "FCOS-ISO" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-fedora-coreos-33.20201201.2.1-live.x86_64.iso}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201201.2.1/x86_64}
-elif [[ "${IMAGE_OS}" == "Centos" ]]; then
+elif [[ "${IMAGE_OS,,}" == "centos" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-CENTOS_8_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://artifactory.nordix.org/artifactory/metal3/images/k8s_${KUBERNETES_VERSION}}
-elif [[ "${IMAGE_OS}" == "Flatcar" ]]; then
+elif [[ "${IMAGE_OS,,}" == "flatcar" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-flatcar_production_qemu_image.img.bz2}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://stable.release.flatcar-linux.net/amd64-usr/current/}
 else

--- a/scripts/feature_tests/README.md
+++ b/scripts/feature_tests/README.md
@@ -107,7 +107,7 @@ Currently the test-framework uses the following environment variables
 by default for feature/upgrade tests, in case of **Ubuntu** setup:
 
 ```bash
-export IMAGE_OS=Ubuntu
+export IMAGE_OS=ubuntu
 export EPHEMERAL_CLUSTER=kind
 export CONTAINER_RUNTIME=docker
 export NUM_NODES=4
@@ -116,7 +116,7 @@ export NUM_NODES=4
 while **Centos** uses:
 
 ```bash
-export IMAGE_OS=Centos
+export IMAGE_OS=centos
 export EPHEMERAL_CLUSTER=minikube
 export CONTAINER_RUNTIME=podman
 export NUM_NODES=4

--- a/scripts/feature_tests/node_reuse/node_reuse_vars.sh
+++ b/scripts/feature_tests/node_reuse/node_reuse_vars.sh
@@ -2,7 +2,10 @@
 
 export UPGRADED_K8S_VERSION="v1.23.3"
 
-if [[ "${IMAGE_OS}" == "Ubuntu" ]]; then
+# NOTE: ${VAR,,} is making the varable lower case.
+# This is temporary and will be removed once we have changed IMAGE_OS to be
+# lower case in the CI.
+if [[ "${IMAGE_OS,,}" == "ubuntu" ]]; then
   export UPGRADED_IMAGE_NAME="UBUNTU_20.04_NODE_IMAGE_K8S_${UPGRADED_K8S_VERSION}.qcow2"
   export UPGRADED_RAW_IMAGE_NAME="UBUNTU_20.04_NODE_IMAGE_K8S_${UPGRADED_K8S_VERSION}-raw.img"
 else

--- a/scripts/feature_tests/upgrade/upgrade_vars.sh
+++ b/scripts/feature_tests/upgrade/upgrade_vars.sh
@@ -14,7 +14,7 @@ export CAPM3_REL_TO_VERSION="v1.0.0"
 export UPGRADED_CAPM3_VERSION="v1beta1"
 
 # Ubuntu is hard coded in the upgrade tests. Make sure we use it throughout.
-export IMAGE_OS="Ubuntu"
+export IMAGE_OS="ubuntu"
 export FROM_K8S_VERSION="v1.23.2"
 export KUBERNETES_VERSION=${FROM_K8S_VERSION}
 export UPGRADED_K8S_VERSION="v1.23.3"

--- a/vars.md
+++ b/vars.md
@@ -33,7 +33,7 @@ assured that they are persisted.
 | TEST_MAX_TIME | Number of maximum verification or test retries | | 120 |
 | BMC_DRIVER | Set the BMC driver | "ipmi", "redfish", "redfish-virtualmedia" | "mixed" |
 | BOOT_MODE  | Set libvirt firmware and BMH bootMode | "legacy", "UEFI", "UEFISecureBoot" | "legacy" |
-| IMAGE_OS | OS of the image to boot the nodes from, overriden by IMAGE\_\* if set | "Centos", "Cirros", "FCOS", "Ubuntu" | "Centos" |
+| IMAGE_OS | OS of the image to boot the nodes from, overriden by IMAGE\_\* if set | "centos", "cirros", "FCOS", "ubuntu", "flatcar" | "centos" |
 | IMAGE_NAME | Image for target hosts deployment | | "CENTOS_8_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2" |
 | IMAGE_LOCATION | Location of the image to download | | https://artifactory.nordix.org/artifactory/metal3/images/${KUBERNETES_VERSION} |
 | IMAGE_USERNAME | Image username for ssh | | "metal3" |

--- a/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
@@ -10,7 +10,7 @@
     with_items:
       - controlplane_ubuntu
       - workers_ubuntu
-    when: IMAGE_OS == "Ubuntu"
+    when: IMAGE_OS|lower == "ubuntu"
 
   - name: Remove temporary CentOS crs
     file:
@@ -19,7 +19,7 @@
     with_items:
       - controlplane_centos
       - workers_centos
-    when: (IMAGE_OS == "Centos") or
+    when: (IMAGE_OS|lower == "centos") or
           (IMAGE_OS == "")
 
   - name: Check if cluster deprovisioning started.

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -59,8 +59,8 @@ CALICO_MINOR_RELEASE: "{{ lookup('env', 'CALICO_MINOR_RELEASE') | default('v3.21
 CALICO_PATCH_RELEASE: "{{ lookup('env', 'CALICO_PATCH_RELEASE') | default('v3.21.0', true) }}"
 DOCKER_HUB_PROXY: "{{ lookup('env', 'DOCKER_HUB_PROXY') }}"
 
-# Environment variables for deployment. IMAGE_OS can be Centos or Ubuntu, change accordingly to your needs.
-IMAGE_OS: "{{ lookup('env', 'IMAGE_OS') | default('Centos', true) }}"
+# Environment variables for deployment. IMAGE_OS can be centos or ubuntu, change accordingly to your needs.
+IMAGE_OS: "{{ lookup('env', 'IMAGE_OS') | default('centos', true) }}"
 CONTAINER_RUNTIME: "{{ lookup('env', 'CONTAINER_RUNTIME') | default('podman', true) }}"
 DEFAULT_HOSTS_MEMORY: "{{ lookup('env', 'DEFAULT_HOSTS_MEMORY') | default('4096', true) }}"
 CAPI_VERSION: "{{ lookup('env', 'CAPI_VERSION') | default('v1beta1', true) }}"


### PR DESCRIPTION
IMAGE_OS used to take values like "Ubuntu" or "Centos". This commit
changes it to "ubuntu" or "centos". This makes the variable useful in
places were it would be awkward to have a capitalized value. It will
allow us to remove some logic and extra variables from CI since we can
use IMAGE_OS directly.

Note that both capitalized and lower case values will be supported while
we work on changing the CI to use lower case values.