### PR TITLE
Make IMAGE_OS case sensitive again

### DIFF
--- a/lib/images.sh
+++ b/lib/images.sh
@@ -2,10 +2,7 @@
 
 # Image name and location
 IMAGE_OS=${IMAGE_OS:-centos}
-# NOTE: ${VAR,,} is making the varable lower case.
-# This is temporary and will be removed once we have changed IMAGE_OS to be
-# lower case in the CI.
-if [[ "${IMAGE_OS,,}" == "ubuntu" ]]; then
+if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-UBUNTU_20.04_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://artifactory.nordix.org/artifactory/metal3/images/k8s_${KUBERNETES_VERSION}}
 elif [[ "${IMAGE_OS}" == "FCOS" ]]; then
@@ -14,10 +11,10 @@ elif [[ "${IMAGE_OS}" == "FCOS" ]]; then
 elif [[ "${IMAGE_OS}" == "FCOS-ISO" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-fedora-coreos-33.20201201.2.1-live.x86_64.iso}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201201.2.1/x86_64}
-elif [[ "${IMAGE_OS,,}" == "centos" ]]; then
+elif [[ "${IMAGE_OS}" == "centos" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-CENTOS_8_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://artifactory.nordix.org/artifactory/metal3/images/k8s_${KUBERNETES_VERSION}}
-elif [[ "${IMAGE_OS,,}" == "flatcar" ]]; then
+elif [[ "${IMAGE_OS}" == "flatcar" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-flatcar_production_qemu_image.img.bz2}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://stable.release.flatcar-linux.net/amd64-usr/current/}
 else

--- a/scripts/feature_tests/node_reuse/node_reuse_vars.sh
+++ b/scripts/feature_tests/node_reuse/node_reuse_vars.sh
@@ -2,10 +2,7 @@
 
 export UPGRADED_K8S_VERSION="v1.23.3"
 
-# NOTE: ${VAR,,} is making the varable lower case.
-# This is temporary and will be removed once we have changed IMAGE_OS to be
-# lower case in the CI.
-if [[ "${IMAGE_OS,,}" == "ubuntu" ]]; then
+if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
   export UPGRADED_IMAGE_NAME="UBUNTU_20.04_NODE_IMAGE_K8S_${UPGRADED_K8S_VERSION}.qcow2"
   export UPGRADED_RAW_IMAGE_NAME="UBUNTU_20.04_NODE_IMAGE_K8S_${UPGRADED_K8S_VERSION}-raw.img"
 else

--- a/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
@@ -10,7 +10,7 @@
     with_items:
       - controlplane_ubuntu
       - workers_ubuntu
-    when: IMAGE_OS|lower == "ubuntu"
+    when: IMAGE_OS == "ubuntu"
 
   - name: Remove temporary CentOS crs
     file:
@@ -19,7 +19,7 @@
     with_items:
       - controlplane_centos
       - workers_centos
-    when: (IMAGE_OS|lower == "centos") or
+    when: (IMAGE_OS == "centos") or
           (IMAGE_OS == "")
 
   - name: Check if cluster deprovisioning started.

--- a/vm-setup/roles/v1aX_integration_test/tasks/generate_templates.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/generate_templates.yml
@@ -40,7 +40,7 @@
       --kubernetes-version {{ KUBERNETES_VERSION }}
       --control-plane-machine-count={{ NUM_OF_CONTROLPLANE_REPLICAS }}
       --worker-machine-count={{ NUM_OF_WORKER_REPLICAS }}
-      --target-namespace={{ NAMESPACE }} > {{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_{{ item }}_{{ IMAGE_OS|lower }}.yaml
+      --target-namespace={{ NAMESPACE }} > {{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_{{ item }}_{{ IMAGE_OS }}.yaml
     with_items:
       - cluster
       - controlplane

--- a/vm-setup/roles/v1aX_integration_test/tasks/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/main.yml
@@ -12,19 +12,19 @@
   when: v1aX_integration_test_action in inspection_action
 
 - name: Provision cluster
-  shell: kubectl apply -f "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_cluster_{{ IMAGE_OS|lower }}.yaml" -n "{{ NAMESPACE }}"
+  shell: kubectl apply -f "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_cluster_{{ IMAGE_OS }}.yaml" -n "{{ NAMESPACE }}"
   register: kubectl_apply_cluster
   changed_when: "'configured' in kubectl_apply_cluster.stdout"
   when: v1aX_integration_test_action in provision_cluster_actions
 
 - name: Create control plane
-  shell: kubectl apply -f "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_controlplane_{{ IMAGE_OS|lower }}.yaml" -n "{{ NAMESPACE }}"
+  shell: kubectl apply -f "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_controlplane_{{ IMAGE_OS }}.yaml" -n "{{ NAMESPACE }}"
   register: kubectl_apply_controlplane
   changed_when: "'configured' in kubectl_apply_controlplane.stdout"
   when: v1aX_integration_test_action in provision_controlplane_actions
 
 - name: Create worker nodes
-  shell: kubectl apply -f "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_workers_{{ IMAGE_OS|lower }}.yaml" -n "{{ NAMESPACE }}"
+  shell: kubectl apply -f "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_workers_{{ IMAGE_OS }}.yaml" -n "{{ NAMESPACE }}"
   register: kubectl_apply_workers
   changed_when: "'configured' in kubectl_apply_workers.stdout"
   when: v1aX_integration_test_action in provision_workers_actions
@@ -48,7 +48,7 @@
 - name: Deprovision worker nodes
   kubernetes.core.k8s:
     state: absent
-    src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_workers_{{ IMAGE_OS|lower }}.yaml"
+    src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_workers_{{ IMAGE_OS }}.yaml"
     namespace: "{{ NAMESPACE }}"
   ignore_errors: yes
   when: v1aX_integration_test_action in deprovision_workers_actions
@@ -56,7 +56,7 @@
 - name: Deprovision control plane
   kubernetes.core.k8s:
     state: absent
-    src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_controlplane_{{ IMAGE_OS|lower }}.yaml"
+    src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_controlplane_{{ IMAGE_OS }}.yaml"
     namespace: "{{ NAMESPACE }}"
   ignore_errors: yes
   when: v1aX_integration_test_action in deprovision_controlplane_actions
@@ -64,7 +64,7 @@
 - name: Deprovision cluster
   kubernetes.core.k8s:
     state: absent
-    src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_cluster_{{ IMAGE_OS|lower }}.yaml"
+    src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_cluster_{{ IMAGE_OS }}.yaml"
     namespace: "{{ NAMESPACE }}"
   ignore_errors: yes
   when: v1aX_integration_test_action in deprovision_cluster_actions

--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane.yaml
@@ -54,7 +54,7 @@ spec:
       sshAuthorizedKeys:
       - {{ SSH_PUB_KEY_CONTENT }}
 {% filter indent(width=4, first=True) %}
-{% include "cluster-template-controlplane-kubeadm-config-%s.yaml" % (IMAGE_OS | lower) %}
+{% include "cluster-template-controlplane-kubeadm-config-%s.yaml" % IMAGE_OS %}
 {% endfilter %}
 
 ---

--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-workers.yaml
@@ -77,5 +77,5 @@ spec:
         sshAuthorizedKeys:
         - {{ SSH_PUB_KEY_CONTENT }}
 {% filter indent(width=6, first=True) %}
-{% include "cluster-template-workers-kubeadm-config-%s.yaml" % (IMAGE_OS | lower) %}
+{% include "cluster-template-workers-kubeadm-config-%s.yaml" % IMAGE_OS %}
 {% endfilter %}


### PR DESCRIPTION
This is the last step in changeing IMAGE_OS to take all lower case
values like "ubuntu" and "centos" for CI runs. As a temporary solution
while transitioning, both capitalized and lower case values were
supported. With this change only lower case values will work.