### PR TITLE
🌱 Fetch CAPM3RELEASE from the Github

### DIFF
--- a/lib/releases.sh
+++ b/lib/releases.sh
@@ -46,10 +46,7 @@ if [ "${CAPM3_VERSION}" == "v1alpha4" ]; then
 elif [ "${CAPM3_VERSION}" == "v1alpha5" ]; then
   export CAPM3RELEASE="${CAPM3RELEASE:-$(get_latest_release "${CAPM3RELEASEPATH}" "v0.5.")}"
 else
-  # workaround until we have a proper CAPM3 v1beta1 release.
-  export CAPM3RELEASE="v1.1.0"
-  # TODO(furkat) Uncomment below once we start releasing CAPM3 with v1beta1 API.
-  # export CAPM3RELEASE="${CAPM3RELEASE:-$(get_latest_release "${CAPM3RELEASEPATH}" "v1.0.")}"
+  export CAPM3RELEASE="${CAPM3RELEASE:-$(get_latest_release "${CAPM3RELEASEPATH}" "v1.1.")}"
 fi
 
 # On first iteration, jq might not be installed


### PR DESCRIPTION
This PR removes  temporary workaround of hardcoding `CAPM3RELEASE` reference, as new CAPM3 release [v1.1.0](https://github.com/metal3-io/cluster-api-provider-metal3/releases/tag/v1.1.0) supporting v1beta1 API is out on Github.