### PR TITLE
allow kubectl caching after cluster creation

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
@@ -15,6 +15,7 @@ preKubeadmCommands:
   - systemctl start monitor.keepalived.service
 postKubeadmCommands:
   - mkdir -p /home/{{ IMAGE_USERNAME }}/.kube
+  - chown {{ IMAGE_USERNAME }}:{{ IMAGE_USERNAME }} /home/{{ IMAGE_USERNAME }}/.kube
   - cp /etc/kubernetes/admin.conf /home/{{ IMAGE_USERNAME }}/.kube/config
   - chown {{ IMAGE_USERNAME }}:{{ IMAGE_USERNAME }} /home/{{ IMAGE_USERNAME }}/.kube/config
 files:

--- a/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane-kubeadm-config-ubuntu.yaml
+++ b/vm-setup/roles/v1aX_integration_test/templates/cluster-template-controlplane-kubeadm-config-ubuntu.yaml
@@ -14,6 +14,7 @@ preKubeadmCommands:
   - systemctl start monitor.keepalived.service
 postKubeadmCommands:
   - mkdir -p /home/{{ IMAGE_USERNAME }}/.kube
+  - chown {{ IMAGE_USERNAME }}:{{ IMAGE_USERNAME }} /home/{{ IMAGE_USERNAME }}/.kube
   - cp /etc/kubernetes/admin.conf /home/{{ IMAGE_USERNAME }}/.kube/config
   - systemctl enable --now keepalived
   - chown {{ IMAGE_USERNAME }}:{{ IMAGE_USERNAME }} /home/{{ IMAGE_USERNAME }}/.kube/config


### PR DESCRIPTION
The .kube directory must belong to the (non-root) user issuing kubectl.
Otherwise kubectl will not be able to cache requests and will issue warnings
due to client-side throttling taking place when requests normally hitting the
cache are directed at the server instead.

fixes: #957