### PR TITLE
🌱 Remove ironic container workarounds in upgrade and pivoting tests

### DIFF
--- a/scripts/feature_tests/README.md
+++ b/scripts/feature_tests/README.md
@@ -22,7 +22,7 @@ to ensure that new changes will not break the existing functionalities.
 
 Test-framework can be triggered by leaving
 
-- `/test-features` (Ubuntu based)
+- `/test-features-ubuntu` (Ubuntu based)
 - `/test-features-centos` (Centos based)
 
 comments for remediation/scale-in/node reuse/pivoting and
@@ -68,7 +68,7 @@ N (from the test-framework perspective N=4) number of ready BMH as an output.
 `feature_test_provisioning.sh` and `feature_test_deprovisioning.sh` are used by
 each feature test to provision/deprovision cluster and BMH.
 
-When the test-framework is triggered with `/test-features` or
+When the test-framework is triggered with `/test-features-ubuntu` or
 `/test-features-centos`, it will:
 
 - setup metal3-dev-env
@@ -153,7 +153,7 @@ Similarly two other jobs,
 [Metal3_*_feature_tests_ubuntu](https://jenkins.nordix.org/view/Metal3/job/metal3_metal3_dev_env_feature_tests_ubuntu/)
 and
 [Metal3_*_feature_tests_centos](https://jenkins.nordix.org/view/Metal3/job/metal3_metal3_dev_env_feature_tests_centos/)
-that can be run when triggered with `/test-features` and `/test-features-centos`
+that can be run when triggered with `/test-features-ubuntu` and `/test-features-centos`
 phrases for Ubuntu and Centos, accordingly on a pull request.
 
 We are running a single main job(both for Ubuntu and Centos) for the **upgrade**

--- a/scripts/feature_tests/README.md
+++ b/scripts/feature_tests/README.md
@@ -10,14 +10,15 @@ Feature tests framework is made to run a set of scripts for testing pivoting,
 remediation, scale-in, node reuse and upgrade functionalities of Metal3 project.
 The framework relies on already existing test scripts of each
 feature in Metal3-dev-env. The motivation behind the framework is to be able to
-test pivoting/remediation/scale-in/node reuse/upgrade features in Metal3-dev-env
-environment and detect breaking changes in advance.
+test inspection/remediation/healthcheck/pivoting/scale-in/node reuse/repivoting/upgrade
+features in Metal3-dev-env environment and detect breaking changes in advance.
 
 Test-framework CI can be triggered from a pull request in CAPM3, BMO,
 metal3-dev-env, project-infra, ironic-image, and
 ironic-ipa-downloader repositories.
 It is recommended to run test-framework CI especially when
-introducing a commit related to pivoting/remediation/scale-in/node reuse/upgrade,
+introducing a commit related to
+inspection/remediation/healthcheck/pivoting/scale-in/node reuse/repivoting/upgrade
 to ensure that new changes will not break the existing functionalities.
 
 Test-framework can be triggered by leaving
@@ -25,7 +26,8 @@ Test-framework can be triggered by leaving
 - `/test-features-ubuntu` (Ubuntu based)
 - `/test-features-centos` (Centos based)
 
-comments for remediation/scale-in/node reuse/pivoting and
+comments for inspection/remediation/healthcheck/pivoting/scale-in/node reuse/repivoting
+and
 
 - `/test-upgrade-features`
 
@@ -40,10 +42,14 @@ feature_tests/
 ├── feature_test_deprovisioning.sh
 ├── feature_test_provisioning.sh
 ├── feature_test_vars.sh
+├── healthcheck
+│   ├── healthcheck.sh
+│   └── Makefile
 ├── inspection_test.sh
 ├── node_reuse
 │   ├── Makefile
-│   └── node_reuse.sh
+│   ├── node_reuse.sh
+│   └── node_reuse_vars.sh
 ├── OWNERS
 ├── pivoting
 │   ├── Makefile
@@ -77,6 +83,10 @@ When the test-framework is triggered with `/test-features-ubuntu` or
   - provision cluster and BMH
   - run remediation tests
   - deprovision cluster and BMH
+- run healthcheck tests
+  - provision cluster and BMH
+  - run healthcheck tests
+  - deprovision cluster and BMH
 - clean up the environment
   - run `cleanup_env.sh`
 - run pivoting tests
@@ -85,8 +95,8 @@ When the test-framework is triggered with `/test-features-ubuntu` or
 - run scale-in and node reuse tests
   - run scale-in and node reuse tests for KubeadmControlPlane scenario
   - run node reuse tests for MachineDeployment scenario
-- run re-pivoting tests
-  - run re-pivoting tests
+- run repivoting tests
+  - run repivoting tests
   - deprovision cluster and BMH
 - clean up the environment
   - run `cleanup_env.sh`
@@ -128,6 +138,7 @@ Both **Ubuntu** and **Centos** setups for feature tests use:
 export CAPM3_VERSION=v1beta1
 export CAPI_VERSION=v1beta1
 ```
+
 while upgrade tests use:
 
 ```bash
@@ -135,7 +146,7 @@ export CAPM3_VERSION=v1alpha5
 export CAPI_VERSION=v1alpha4
 ```
 
-in order to perform an upgrade from old API versions of CAPM3/CAPI exported above 
+in order to perform an upgrade from old API versions of CAPM3/CAPI exported above
 to newer versions of CAPM3/CAPI which is v1beta.
 
 Recommended resource requirements for the host machine are: 8C CPUs, 32 GB RAM,
@@ -148,7 +159,9 @@ We are running two main jobs for the feature framework testing:
 
 - inspection
 - remediation
+- healthcheck
 - pivoting
+- scale-in
 - node reuse
 - repivoting
 

--- a/scripts/feature_tests/README.md
+++ b/scripts/feature_tests/README.md
@@ -122,12 +122,21 @@ export CONTAINER_RUNTIME=podman
 export NUM_NODES=4
 ```
 
-Both **Ubuntu** and **Centos** setups for feature/upgrade tests use:
+Both **Ubuntu** and **Centos** setups for feature tests use:
 
 ```bash
 export CAPM3_VERSION=v1beta1
 export CAPI_VERSION=v1beta1
 ```
+while upgrade tests use:
+
+```bash
+export CAPM3_VERSION=v1alpha5
+export CAPI_VERSION=v1alpha4
+```
+
+in order to perform an upgrade from old API versions of CAPM3/CAPI exported above 
+to newer versions of CAPM3/CAPI which is v1beta.
 
 Recommended resource requirements for the host machine are: 8C CPUs, 32 GB RAM,
 300 GB disk space.

--- a/vm-setup/roles/v1aX_integration_test/tasks/move.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/move.yml
@@ -9,13 +9,10 @@
           - vbmc
       ironic_containers:
           - ironic
-          - ironic-api
-          - ironic-conductor
           - ironic-inspector
           - ironic-endpoint-keepalived
           - ironic-log-watch
           - dnsmasq
-          - mariadb
 
   - name: Fetch container logs (kind cluster)
     block:
@@ -30,9 +27,6 @@
 
       - name: Fetch container logs before pivoting (kind cluster)
         shell: "sudo {{ CONTAINER_RUNTIME }} logs {{ item }} > /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stdout.log 2> /tmp/{{ CONTAINER_RUNTIME }}/{{ item }}/stderr.log"
-        # FIXME(dtantsur): remove ignore_errors after the transition period
-        # from ironic-api+conductor to just ironic
-        ignore_errors: yes
         with_items:
           - "{{ ironic_containers }}"
           - "{{ general_containers }}"
@@ -41,9 +35,6 @@
         docker_container:
           name: "{{ item }}"
           state: absent
-        # FIXME(dtantsur): remove ignore_errors after the transition period
-        # from ironic-api+conductor to just ironic
-        ignore_errors: yes
         with_items: "{{ ironic_containers }}"
 
     when: EPHEMERAL_CLUSTER == "kind"

--- a/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml
@@ -265,33 +265,6 @@
 #                       Upgrade Ironic                                                  |
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
 
-# NOTE(dtantsur): the logic to determine the currently used containers can be
-# removed once we finally switch to the combined ironic executable
-  - name: Get the current deployment
-    kubernetes.core.k8s_info:
-      api_version: v1
-      kind: Deployment
-      name: "{{ NAMEPREFIX }}-ironic"
-      namespace: "{{ IRONIC_NAMESPACE }}"
-      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-    register: ironic_deployment
-
-  - name: Determine if the new ironic executable is used
-    set_fact:
-      has_combined_ironic: >
-        {{ "ironic" in (ironic_deployment.resources[0].spec.template.spec.containers
-                        | map(attribute="name")) }}
-
-  - name: Set expected ironic image based containers (old version)
-    set_fact:
-      ironic_image_containers:
-        - ironic-api
-        - ironic-dnsmasq
-        - ironic-conductor
-        - ironic-log-watch
-        - ironic-inspector
-    when: not has_combined_ironic | bool
-
   - name: Set expected ironic image based containers
     set_fact:
       ironic_image_containers:
@@ -303,7 +276,6 @@
         # There is also a keepalived container in the pods, but it is using a
         # different image than the rest and therefore not included in the list.
         # - ironic-endpoint-keepalived
-    when: has_combined_ironic | bool
 
   - name: Upgrade ironic image based containers
     kubernetes.core.k8s:


### PR DESCRIPTION
After https://github.com/metal3-io/baremetal-operator/pull/1091/commits/623b65594be21c02e3a15117cdd6588d8352f0b9 upgrade tests started failing since we introduced some workarounds to tests in #891  but now we are using all in one container - ironic, instead of ironic-api+ironic-conductor). This removes those workarounds both in pivoting and upgrade tests

Also updates notes in feature tests README a bit.  