### PR TITLE
Convert IMAGE_OS string to lowercase before proceeding

### DIFF
--- a/lib/images.sh
+++ b/lib/images.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Image name and location
-IMAGE_OS=${IMAGE_OS:-centos}
+IMAGE_OS="$(echo "${IMAGE_OS:-centos}" | tr '[:upper:]' '[:lower:]')"
+export "${IMAGE_OS?}"
 if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-UBUNTU_20.04_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://artifactory.nordix.org/artifactory/metal3/images/k8s_${KUBERNETES_VERSION}}


### PR DESCRIPTION
User can accidentally set  `IMAGE_OS=Ubuntu`, and scripts will proceed
without warning or stopping. As such, running make will complete,
but when starting to provision, via provisioning scripts, cluster
creation will fail because template generation has created a template
with incorrect naming: cluster-template-workers-kubeadm-config-Ubuntu.yaml.
This patch, ensures that we convert image os string to lowercase,
to avoid such issues during provisioning.

Example run where I forgot to set `IMAGE_OS` to `ubuntu` instead of `Ubuntu`:
```
TASK [v1aX_integration_test : Generate clusterctl cluster template] ************
ok: [localhost] => (item=cluster) => {"ansible_loop_var": "item", "changed": false, "checksum": "ea6c9b080a8d37e9747980d9c9396adb0eb5ebc1", "dest": "/home/ubuntu/.cluster-api/overrides/infrastructure-metal3/v0.5.5/cluster-template-cluster.yaml", "gid": 1001, "group": "ubuntu", "item": "cluster", "mode": "0664", "owner": "ubuntu", "path": "/home/ubuntu/.cluster-api/overrides/infrastructure-metal3/v0.5.5/cluster-template-cluster.yaml", "size": 1472, "state": "file", "uid": 1001}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: jinja2.exceptions.TemplateNotFound: cluster-template-controlplane-kubeadm-config-Ubuntu.yaml
failed: [localhost] (item=controlplane) => {"ansible_loop_var": "item", "changed": false, "item": "controlplane", "msg": "TemplateNotFound: cluster-template-controlplane-kubeadm-config-Ubuntu.yaml"}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: jinja2.exceptions.TemplateNotFound: cluster-template-workers-kubeadm-config-Ubuntu.yaml
failed: [localhost] (item=workers) => {"ansible_loop_var": "item", "changed": false, "item": "workers", "msg": "TemplateNotFound: cluster-template-workers-kubeadm-config-Ubuntu.yaml"}

PLAY RECAP *********************************************************************
localhost                  : ok=6    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   


```