### PR TITLE
let Tilt handle image tag changing process.

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -73,6 +73,7 @@ function launch_baremetal_operator() {
 
   # Deploy BMO using deploy.sh script
 
+if [ "${EPHEMERAL_CLUSTER}" != "tilt" ]; then
   # Update container images to use local ones
   cp "${BMOPATH}/config/default/kustomization.yaml" "${BMOPATH}/config/default/kustomization.yaml.orig"
   if [ -n "${BAREMETAL_OPERATOR_LOCAL_IMAGE}" ]; then
@@ -80,6 +81,7 @@ function launch_baremetal_operator() {
   else
     update_component_image BMO "${BAREMETAL_OPERATOR_IMAGE}"
   fi
+fi
 
   # Update Configmap parameters with correct urls
   cp "${BMOPATH}/config/default/ironic.env" "${BMOPATH}/config/default/ironic.env.orig"


### PR DESCRIPTION
When using tilt, the bmo image tag is changing twice. 
1. When deploying bmo to` 192.168.111.1:5000/localimages/baremetal-operator`
2. When code changes and tilt rebuilds the image. 

(1) is not necessary and is causing for the tilt environment setup to fail due to missing image, even tough the image is in the local registry. Loading the image to the kind cluster did not help either. 

This PR lets tilt handle the tagging process.