### PR TITLE
Ensure python3-libselinux is installed for centos/rhel

### DIFF
--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -84,6 +84,7 @@ packages:
          - python3-six
          - httpd-tools
          - python3-bcrypt
+         - python3-libselinux
     el8:
       packages:
          - redhat-lsb-core


### PR DESCRIPTION
This is a requirement for the ansible.posix.selinux module