### PR TITLE
Make sure jq is installed before common.sh is sourced

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -17,7 +17,7 @@ export OS="${ID}"
 
 if [[ $OS == ubuntu ]]; then
   sudo apt-get update
-  sudo apt -y install python3-pip
+  sudo apt -y install python3-pip jq curl
 
   # Set update-alternatives to python3
   if [[ ${DISTRO} == "ubuntu18" ]]; then
@@ -29,7 +29,7 @@ elif [[ $OS == "centos" || $OS == "rhel" ]]; then
   sudo dnf upgrade -y
   sudo dnf config-manager --set-enabled powertools
   sudo dnf install -y epel-release epel-next-release
-  sudo dnf -y install python3-pip
+  sudo dnf -y install python3-pip jq curl
   sudo alternatives --set python /usr/bin/python3
 fi
 


### PR DESCRIPTION
I somehow missed this in the last PR, even though I added a comment on line 41 about it... It wasn't caught by CI since there we already have jq and curl installed. However, in other places this can be a real problem.