### PR TITLE
Add missing directory in Ubuntu

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -239,6 +239,7 @@ function init_minikube() {
         sudo systemctl restart libvirtd.service
         configure_minikube
         #NOTE(elfosardo): workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2057769
+        mkdir -p /etc/qemu/firmware
         sudo touch /etc/qemu/firmware/50-edk2-ovmf-amdsev.json
         sudo su -l -c "minikube start --insecure-registry ${REGISTRY}"  "${USER}" || minikube_error=1
         if [[ $minikube_error -eq 0 ]]; then

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,3 @@
-
 {
   "extends":[
     "config:base"


### PR DESCRIPTION
In Ubuntu, there is no `firmware` directory in /etc/qemu. However, it is needed when minikube is used as ephemeral cluster. This PR fixes this issue.