### PR TITLE
Fix unversioned python on CentOS

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -31,18 +31,17 @@ elif [[ $OS == "centos" || $OS == "rhel" ]]; then
     8)
       sudo dnf config-manager --set-enabled powertools
       sudo dnf install -y epel-release
-      sudo alternatives --set python /usr/bin/python3
       ;;
     9)
       sudo dnf config-manager --set-enabled crb
       sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-      sudo ln -s /usr/bin/python3 /usr/bin/python || true
       ;;
     *)
       echo -n "CentOS or RHEL version not supported"
       exit 1
       ;;
   esac
+  sudo ln -s /usr/bin/python3 /usr/bin/python || true
   sudo dnf -y install python3-pip jq curl
 fi
 


### PR DESCRIPTION
CentOS does not have preconfigured alternatives for python anymore it
seems. It only has the "no-python" alternative even when python3 is
installed. To solve this we can simply create the link manually (same
solution as for CentOS Stream 9).

I tried first to use `alternatives --install /usr/bin/python python /usr/bin/python3 1` to add python3 as an alternative. However, it does not allow me to do so, saying that `/usr/bin/python` is not allowed, it must be `/usr/bin/unversioned-python`. But then we don't get `python`, we get `unversioned-python` which is not helpful... So then I reverted to creating the link manually which is the same as for CentOS Stream 9 a few lines below.