### PR TITLE
Revert "Set BMO and Ironic tags based on CAPM3 release"

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -3,17 +3,13 @@ set -xe
 
 # shellcheck disable=SC1091
 source lib/logging.sh
+# shellcheck disable=SC1091
+source lib/common.sh
 
 if [[ $(id -u) == 0 ]]; then
   echo "Please run 'make' as a non-root user"
   exit 1
 fi
-
-# Check OS type and version
-# shellcheck disable=SC1091
-source /etc/os-release
-export DISTRO="${ID}${VERSION_ID%.*}"
-export OS="${ID}"
 
 if [[ $OS == ubuntu ]]; then
   sudo apt-get update
@@ -45,14 +41,8 @@ elif [[ $OS == "centos" || $OS == "rhel" ]]; then
   sudo dnf -y install python3-pip jq curl
 fi
 
-# Ansible version
-export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"4.10.0"}
 sudo python -m pip install ansible=="${ANSIBLE_VERSION}"
 
-# Now that the basics are installed, we can source common.sh.
-# common.sh cannot be sourced before things like curl and jq are installed.
-# shellcheck disable=SC1091
-source lib/common.sh
 # NOTE(fmuyassarov) Make sure to source before runnig install-package-playbook.yml
 # because there are some vars exported in network.sh and used by
 # install-package-playbook.yml.
@@ -82,6 +72,9 @@ if [[ ":$PATH:" != *":$GOBINARY:"* ]]; then
   # shellcheck disable=SC1090
   source ~/.bashrc
 fi
+
+# shellcheck disable=SC1091
+source lib/releases.sh
 
 ## Install krew
 if ! kubectl krew > /dev/null 2>&1; then

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -6,6 +6,8 @@ source lib/logging.sh
 # shellcheck disable=SC1091
 source lib/common.sh
 # shellcheck disable=SC1091
+source lib/releases.sh
+# shellcheck disable=SC1091
 source lib/network.sh
 
 export IRONIC_HOST="${CLUSTER_URL_HOST}"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -114,10 +114,6 @@ else
   exit 1
 fi
 
-# Based on CAPM3_VERSION and CAPI_VERSION, set CAPM3RELEASE and CAPIRELEASE
-# (unless they are already specified)
-source "${SCRIPTDIR}/lib/releases.sh"
-
 export M3PATH="${M3PATH:-${GOPATH}/src/github.com/metal3-io}"
 export BMOPATH="${BMOPATH:-${M3PATH}/baremetal-operator}"
 # shellcheck disable=SC2034
@@ -193,6 +189,7 @@ export SUSHY_TOOLS_IMAGE=${SUSHY_TOOLS_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/s
 export IRONIC_TLS_SETUP=${IRONIC_TLS_SETUP:-"true"}
 export IRONIC_BASIC_AUTH=${IRONIC_BASIC_AUTH:-"true"}
 export IPA_DOWNLOADER_IMAGE=${IPA_DOWNLOADER_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ironic-ipa-downloader"}
+export IRONIC_IMAGE=${IRONIC_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ironic"}
 export IRONIC_CLIENT_IMAGE=${IRONIC_CLIENT_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ironic-client"}
 export MARIADB_IMAGE=${MARIADB_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/mariadb"}
 export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
@@ -210,13 +207,8 @@ fi
 # Enable ironic restart feature when the TLS certificate is updated
 export RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-${IRONIC_TLS_SETUP}}
 
-# Baremetal operator and Ironic image
-# Set the tags based on the CAPM3RELEASE. Both BMO and Ironic has tags with the
-# following format: capm3-vX.Y.Z, where vX.Y.Z is the CAPM3 release.
-bmo_tag="capm3-${CAPM3RELEASE}"
-ironic_tag="capm3-${CAPM3RELEASE}"
-export BAREMETAL_OPERATOR_IMAGE=${BAREMETAL_OPERATOR_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/baremetal-operator:${bmo_tag}"}
-export IRONIC_IMAGE=${IRONIC_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ironic:${ironic_tag}"}
+# Baremetal operator image
+export BAREMETAL_OPERATOR_IMAGE=${BAREMETAL_OPERATOR_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/baremetal-operator"}
 
 # Config for OpenStack CLI
 export OPENSTACK_CONFIG=$HOME/.config/openstack/clouds.yaml
@@ -267,6 +259,9 @@ else
   export MINIKUBE_VERSION=${MINIKUBE_VERSION:-"v1.25.2"}
 fi
 export KIND_NODE_IMAGE=${KIND_NODE_IMAGE:-"${DOCKER_HUB_PROXY}/kindest/node:${KIND_NODE_IMAGE_VERSION}"}
+
+# Ansible version
+export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"4.10.0"}
 
 # Test and verification related variables
 SKIP_RETRIES="${SKIP_RETRIES:-false}"

--- a/renovate.json
+++ b/renovate.json
@@ -52,7 +52,7 @@
        "datasourceTemplate": "github-releases"
      },
      {
-       "fileMatch": ["^01_prepare_hosts.sh$"],
+       "fileMatch": ["^lib/common.sh$"],
        "matchStrings": ["ANSIBLE_VERSION:-\"(?<currentValue>.*?)\"}"],
        "depNameTemplate": "ansible",
        "datasourceTemplate": "pypi"

--- a/scripts/feature_tests/cleanup_env.sh
+++ b/scripts/feature_tests/cleanup_env.sh
@@ -10,6 +10,8 @@ source "${ROOTPATH}/lib/logging.sh"
 # shellcheck disable=SC1091
 source "${ROOTPATH}/lib/common.sh"
 # shellcheck disable=SC1091
+source "${ROOTPATH}/lib/releases.sh"
+# shellcheck disable=SC1091
 source "${ROOTPATH}/lib/network.sh"
 # shellcheck disable=SC1091
 source "${ROOTPATH}/lib/ironic_tls_setup.sh"
@@ -22,7 +24,7 @@ ssh-keygen -f /home/"${USER}"/.ssh/known_hosts -R "${CLUSTER_APIENDPOINT_IP}"
 if [ "${EPHEMERAL_CLUSTER}" == "kind" ]; then
   # Kill and remove the running ironic containers
   "$BMOPATH"/tools/remove_local_ironic.sh
-else
+else 
   # Scale down ironic
   kubectl scale deploy -n "${IRONIC_NAMESPACE}" "${NAMEPREFIX}-ironic" --replicas=0
 fi
@@ -63,11 +65,11 @@ done
 delete_finalizers
 
 if [ "${EPHEMERAL_CLUSTER}" == "kind" ]; then
-  # Re-create ironic containers and BMH
+  # Re-create ironic containers and BMH 
   pushd "${BMOPATH}" || exit
   ./tools/run_local_ironic.sh
   popd || exit
-else
+else 
   # Scale up ironic
   kubectl scale deploy -n "${IRONIC_NAMESPACE}" "${NAMEPREFIX}-ironic" --replicas=1
 fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -13,6 +13,9 @@ source "${METAL3_DIR}/lib/logging.sh"
 source "${METAL3_DIR}/lib/common.sh"
 # shellcheck disable=SC1090
 # shellcheck disable=SC1091
+source "${METAL3_DIR}/lib/releases.sh"
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
 source "${METAL3_DIR}/lib/network.sh"
 # shellcheck disable=SC1090
 # shellcheck disable=SC1091
@@ -27,7 +30,7 @@ source "${METAL3_DIR}/lib/ironic_basic_auth.sh"
 # Disable SSH strong authentication
 export ANSIBLE_HOST_KEY_CHECKING=False
 
-# Ansible config file
+# Ansible config file 
 export ANSIBLE_CONFIG=${METAL3_DIR}/ansible.cfg
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \

--- a/scripts/run_command.sh
+++ b/scripts/run_command.sh
@@ -14,6 +14,9 @@ source "${METAL3_DIR}/lib/logging.sh"
 source "${METAL3_DIR}/lib/common.sh"
 # shellcheck disable=SC1090
 # shellcheck disable=SC1091
+source "${METAL3_DIR}/lib/releases.sh"
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
 source "${METAL3_DIR}/lib/network.sh"
 # shellcheck disable=SC1090
 # shellcheck disable=SC1091


### PR DESCRIPTION
This reverts commit de72620a2befaa6441d411ad5b747a38fe65e5e2.

It had the uninstended consequence of not testing the latest code of Ironic and BMO in the main jobs.