### PR TITLE
Ensure python3 is installed before linking to it

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -41,8 +41,8 @@ elif [[ $OS == "centos" || $OS == "rhel" ]]; then
       exit 1
       ;;
   esac
-  sudo ln -s /usr/bin/python3 /usr/bin/python || true
   sudo dnf -y install python3-pip jq curl
+  sudo ln -s /usr/bin/python3 /usr/bin/python || true
 fi
 
 # Ansible version


### PR DESCRIPTION
Apparently python3 is not always installed at this point, so we need to make sure that it is installed before trying to link to it. By installing python3-pip we ensure that it is there.

This problem can be seen in the image building job [here](https://jenkins.nordix.org/view/Metal3%20Main/job/metal3_openstack_image_building/100/consoleFull)
```
openstack: + export ANSIBLE_VERSION=4.10.0
openstack: + ANSIBLE_VERSION=4.10.0
openstack: + sudo python -m pip install ansible==4.10.0
openstack: sudo: python: command not found
openstack: make: *** [Makefile:4: install_requirements] Error 1
```