### PR TITLE
FIx permission denied error in BML

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -231,7 +231,7 @@ function init_minikube() {
         sudo systemctl restart libvirtd.service
         configure_minikube
         #NOTE(elfosardo): workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2057769
-        mkdir -p /etc/qemu/firmware
+        sudo mkdir -p /etc/qemu/firmware
         sudo touch /etc/qemu/firmware/50-edk2-ovmf-amdsev.json
         sudo su -l -c "minikube start --insecure-registry ${REGISTRY}"  "${USER}" || minikube_error=1
         if [[ $minikube_error -eq 0 ]]; then


### PR DESCRIPTION
This PR fixes the permission denied error when creating a directory in /etc/qemu/
