### PR TITLE
Add missing sudo for 'mkdir -p /etc/qemu/firmware'

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -231,7 +231,7 @@ function init_minikube() {
         sudo systemctl restart libvirtd.service
         configure_minikube
         #NOTE(elfosardo): workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2057769
-        mkdir -p /etc/qemu/firmware
+        sudo mkdir -p /etc/qemu/firmware
         sudo touch /etc/qemu/firmware/50-edk2-ovmf-amdsev.json
         sudo su -l -c "minikube start --insecure-registry ${REGISTRY}"  "${USER}" || minikube_error=1
         if [[ $minikube_error -eq 0 ]]; then


### PR DESCRIPTION
I can't create a cluster anymore as a non root user, it fails with `mkdir: cannot create directory ‘/etc/qemu’: Permission denied`. Seems to be caused by https://github.com/metal3-io/metal3-dev-env/pull/977. This PR adds the missing `sudo`.

