### PR TITLE
Delete host as part of cluster clean up

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -246,11 +246,12 @@ function make_bm_hosts() {
 # Apply the BMH CRs
 #
 function apply_bm_hosts() {
+  NAMESPACE=$1
   pushd "${BMOPATH}"
   list_nodes | make_bm_hosts > "${WORKING_DIR}/bmhosts_crs.yaml"
   if [[ -n "$(list_nodes)" ]]; then
     echo "bmhosts_crs.yaml is applying"
-    while ! kubectl apply -f "${WORKING_DIR}/bmhosts_crs.yaml" -n metal3 &>/dev/null; do
+    while ! kubectl apply -f "${WORKING_DIR}/bmhosts_crs.yaml" -n "$NAMESPACE" &>/dev/null; do
 	    sleep 3
     done
     echo "bmhosts_crs.yaml is successfully applied"
@@ -515,7 +516,7 @@ if [ "${EPHEMERAL_CLUSTER}" != "tilt" ]; then
     # Thus we are deleting validatingwebhookconfiguration resource if exists to let BMO is working properly on local runs.
     kubectl delete validatingwebhookconfiguration/"${BMO_NAME_PREFIX}"-validating-webhook-configuration --ignore-not-found=true
   fi
-  apply_bm_hosts
+  apply_bm_hosts "$NAMESPACE"
 elif [ "${EPHEMERAL_CLUSTER}" == "tilt" ]; then
 
 source scripts/deploy_tilt_env.sh

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -36,5 +36,6 @@ export ANSIBLE_CONFIG=${METAL3_DIR}/ansible.cfg
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
    -e "metal3_dir=$SCRIPTDIR" \
    -e "v1aX_integration_test_action=${ACTION}" \
+   -e "working_dir=$WORKING_DIR" \
    -i "${METAL3_DIR}/vm-setup/inventory.ini" \
    -b -v "${METAL3_DIR}/vm-setup/v1aX_integration_test.yml"

--- a/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
@@ -91,3 +91,21 @@
     delay: 3
     until: (deprovisioned_cluster is succeeded) and
            (deprovisioned_cluster.resources | length ==  0)
+
+  - name: Delete baremetalhosts
+    kubernetes.core.k8s:
+      state: absent
+      src: "{{ WORKING_DIR }}/bmhosts_crs.yaml"
+      namespace: "{{ NAMESPACE }}"
+    ignore_errors: yes
+
+  - name: Wait until no baremetalhost is remaining
+    kubernetes.core.k8s_info:
+      api_version: metal3.io/v1alpha1
+      kind: BareMetalHost
+      namespace: "{{ NAMESPACE }}"
+    register: dedeleted_baremetalhost
+    retries: 100
+    delay: 3
+    until: (dedeleted_baremetalhost is succeeded) and
+           (dedeleted_baremetalhost.resources | length ==  0)

--- a/vm-setup/roles/v1aX_integration_test/vars/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/vars/main.yml
@@ -58,6 +58,7 @@ REGISTRY: "{{ lookup('env', 'REGISTRY') | default('192.168.111.1:5000', true) }}
 CALICO_MINOR_RELEASE: "{{ lookup('env', 'CALICO_MINOR_RELEASE') | default('v3.21', true) }}"
 CALICO_PATCH_RELEASE: "{{ lookup('env', 'CALICO_PATCH_RELEASE') | default('v3.21.0', true) }}"
 DOCKER_HUB_PROXY: "{{ lookup('env', 'DOCKER_HUB_PROXY') }}"
+WORKING_DIR: "{{ lookup('env', 'WORKING_DIR') | default('/opt/metal3-dev-env', true) }}"
 
 # Environment variables for deployment. IMAGE_OS can be centos or ubuntu, change accordingly to your needs.
 IMAGE_OS: "{{ lookup('env', 'IMAGE_OS') | default('centos', true) }}"


### PR DESCRIPTION
Delete host as part of clean up script. We already wait for BMH deprovisioning, as such adding a task to delete the host should not increase overall test run time much (usually ~2-3 mins). This will ensure that we don't miss a bug in BMO code that would break deletion workflow like it was missed in https://github.com/metal3-io/baremetal-operator/issues/1113.