### PR TITLE
Avoid overiding working dir in playbooks

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -30,12 +30,11 @@ source "${METAL3_DIR}/lib/ironic_basic_auth.sh"
 # Disable SSH strong authentication
 export ANSIBLE_HOST_KEY_CHECKING=False
 
-# Ansible config file 
+# Ansible config file
 export ANSIBLE_CONFIG=${METAL3_DIR}/ansible.cfg
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
    -e "metal3_dir=$SCRIPTDIR" \
    -e "v1aX_integration_test_action=${ACTION}" \
-   -e "working_dir=$WORKING_DIR" \
    -i "${METAL3_DIR}/vm-setup/inventory.ini" \
    -b -v "${METAL3_DIR}/vm-setup/v1aX_integration_test.yml"


### PR DESCRIPTION
Ansible overrides all variables in tasks when passing them as extra
vars (e.g. -e my_var=my_val). The working_dir variable is already picked
up from the environment and can be overridden in some tasks, so we
should not set working_dir as extra var.

After https://github.com/metal3-io/metal3-dev-env/pull/991 the upgrade test started failing with
```
Could not find or access '/opt/metal3-dev-env/dev-repository/cluster-api/v1.1.99/core-components.yaml
```
This is because the `working_dir` variable was overridden by the extra var. (See [ansible docs](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#understanding-variable-precedence).)
This PR removes the extra var, but the working_dir still get the same default value from the environment variable.