### PR TITLE
Uplift CentOS node images to use stream 9 and install additional CentOS packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Instructions can be found here: <https://metal3.io/try-it.html>
 Versions v1alpha4, v1alpha5 or v1beta1 are later referred as **v1alphaX**/**v1betaX**.
 
 The v1alphaX or v1betaX deployment can be done with Ubuntu 18.04, 20.04 or
-Centos 8 Stream target host images. By default, for Ubuntu based target hosts
+Centos 9 Stream target host images. By default, for Ubuntu based target hosts
 we are using Ubuntu 20.04
 
 ### Requirements

--- a/lib/images.sh
+++ b/lib/images.sh
@@ -13,7 +13,7 @@ elif [[ "${IMAGE_OS}" == "FCOS-ISO" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-fedora-coreos-33.20201201.2.1-live.x86_64.iso}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201201.2.1/x86_64}
 elif [[ "${IMAGE_OS}" == "centos" ]]; then
-  export IMAGE_NAME=${IMAGE_NAME:-CENTOS_8_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2}
+  export IMAGE_NAME=${IMAGE_NAME:-CENTOS_9_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://artifactory.nordix.org/artifactory/metal3/images/k8s_${KUBERNETES_VERSION}}
 elif [[ "${IMAGE_OS}" == "flatcar" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-flatcar_production_qemu_image.img.bz2}

--- a/vars.md
+++ b/vars.md
@@ -34,7 +34,7 @@ assured that they are persisted.
 | BMC_DRIVER | Set the BMC driver | "ipmi", "redfish", "redfish-virtualmedia" | "mixed" |
 | BOOT_MODE  | Set libvirt firmware and BMH bootMode | "legacy", "UEFI", "UEFISecureBoot" | "legacy" |
 | IMAGE_OS | OS of the image to boot the nodes from, overriden by IMAGE\_\* if set | "centos", "cirros", "FCOS", "ubuntu", "flatcar" | "centos" |
-| IMAGE_NAME | Image for target hosts deployment | | "CENTOS_8_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2" |
+| IMAGE_NAME | Image for target hosts deployment | | "CENTOS_9_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2" |
 | IMAGE_LOCATION | Location of the image to download | | https://artifactory.nordix.org/artifactory/metal3/images/${KUBERNETES_VERSION} |
 | IMAGE_USERNAME | Image username for ssh | | "metal3" |
 | CONTAINER_REGISTRY | Registry to pull metal3 container images from | | "quay.io" |

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -91,10 +91,12 @@ packages:
     el9:
       packages:
         - NetworkManager-initscripts-updown
+        - python3-requests-oauthlib
     pip3:
       - jmespath
-      - kubernetes==17.17.0
+      - kubernetes==23.3.0
       - passlib
+      - flask_oauthlib==0.9.6
 DAEMON_JSON_PATH: "{{ metal3_dir }}/vm-setup/roles/packages_installation/files"
 CONTAINER_RUNTIME: "{{ lookup('env', 'CONTAINER_RUNTIME') }}"
 OS_VERSION_ID: "{{ lookup('env', 'OS_VERSION_ID') }}"


### PR DESCRIPTION
This PR Uplifts CentOS node images to use stream 9 and installs/updates additional CentOS packages namely:

- kubernetes==23.3.0 
- flask_oauthlib==0.9.6 and 
- python3-requests-oauthlib