### PR TITLE
Move BMH cleanup tasks to main.yaml

### DIFF
--- a/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/cleanup.yml
@@ -91,21 +91,3 @@
     delay: 3
     until: (deprovisioned_cluster is succeeded) and
            (deprovisioned_cluster.resources | length ==  0)
-
-  - name: Delete baremetalhosts
-    kubernetes.core.k8s:
-      state: absent
-      src: "{{ WORKING_DIR }}/bmhosts_crs.yaml"
-      namespace: "{{ NAMESPACE }}"
-    ignore_errors: yes
-
-  - name: Wait until no baremetalhost is remaining
-    kubernetes.core.k8s_info:
-      api_version: metal3.io/v1alpha1
-      kind: BareMetalHost
-      namespace: "{{ NAMESPACE }}"
-    register: dedeleted_baremetalhost
-    retries: 100
-    delay: 3
-    until: (dedeleted_baremetalhost is succeeded) and
-           (dedeleted_baremetalhost.resources | length ==  0)

--- a/vm-setup/roles/v1aX_integration_test/tasks/main.yml
+++ b/vm-setup/roles/v1aX_integration_test/tasks/main.yml
@@ -73,6 +73,27 @@
   include_tasks: cleanup.yml
   when: v1aX_integration_test_action in cleanup_actions
 
+- name: Delete BareMetalHosts
+  block:
+    - name: Delete BareMetalHosts CRs
+      kubernetes.core.k8s:
+        state: absent
+        src: "{{ WORKING_DIR }}/bmhosts_crs.yaml"
+        namespace: "{{ NAMESPACE }}"
+      ignore_errors: yes
+  
+    - name: Wait until no BareMetalHost is remaining
+      kubernetes.core.k8s_info:
+        api_version: metal3.io/v1alpha1
+        kind: BareMetalHost
+        namespace: "{{ NAMESPACE }}"
+      register: dedeleted_baremetalhost
+      retries: 100
+      delay: 3
+      until: (dedeleted_baremetalhost is succeeded) and
+            (dedeleted_baremetalhost.resources | length ==  0)
+  when: v1aX_integration_test_action == "ci_test_deprovision"
+
 - name: Node remediation
   include_tasks: remediation.yml
   when: v1aX_integration_test_action == "remediation"


### PR DESCRIPTION
We don't want the BMH CRs to be deleted for every types of the tests like integration, features, upgrade. Deletion check is only needed in integration tests which we run on every single PR in most of the repos. This patch is just moving around the deletion Ansible task so that deletion takes places only for the integration tests.
/cc @kashifest 