### PR TITLE
Pin node image to be used in BML to CentOS8 Stream k8s v1.23.3

### DIFF
--- a/lib/images.sh
+++ b/lib/images.sh
@@ -13,8 +13,14 @@ elif [[ "${IMAGE_OS}" == "FCOS-ISO" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-fedora-coreos-33.20201201.2.1-live.x86_64.iso}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201201.2.1/x86_64}
 elif [[ "${IMAGE_OS}" == "centos" ]]; then
-  export IMAGE_NAME=${IMAGE_NAME:-CENTOS_9_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2}
-  export IMAGE_LOCATION=${IMAGE_LOCATION:-https://artifactory.nordix.org/artifactory/metal3/images/k8s_${KUBERNETES_VERSION}}
+  if [[ -z "${EXTERNAL_VLAN_ID}" ]]; then
+    export IMAGE_NAME=${IMAGE_NAME:-CENTOS_9_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2}
+    export IMAGE_LOCATION=${IMAGE_LOCATION:-https://artifactory.nordix.org/artifactory/metal3/images/k8s_${KUBERNETES_VERSION}}
+  else
+    # Pin node image to be used in BML to CENTOS_8_NODE_IMAGE_K8S_v1.23.3.qcow2
+    export IMAGE_NAME=${IMAGE_NAME:-CENTOS_8_NODE_IMAGE_K8S_v1.23.3.qcow2}
+    export IMAGE_LOCATION=${IMAGE_LOCATION:-https://artifactory.nordix.org/artifactory/metal3/images/k8s_v1.23.3}
+  fi
 elif [[ "${IMAGE_OS}" == "flatcar" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-flatcar_production_qemu_image.img.bz2}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://stable.release.flatcar-linux.net/amd64-usr/current/}


### PR DESCRIPTION
[BML tests](https://jenkins.nordix.org/view/Metal3%20Main/job/metal3_main_bml_integration_tests_centos/) in CI have been failing for some time and the tests we have done show that either introduction of CentOS9 stream: https://github.com/Nordix/metal3-dev-tools/commit/0d3e5cc313999e95e6a8e71842aafcd942ee0b48 or cloud-init changes: https://github.com/Nordix/metal3-dev-tools/commit/c5213dcd4582c6cb15d1873df70d8494a7a2c59f related to centos node image buildings, OR a combination of both, might have broken it. See the list of different tests run using different node images here: https://github.com/metal3-io/project-infra/pull/377#issuecomment-1128135511. For now, we can pin the node images used in BML to get the CI going.