### PR TITLE
🐛 Pass ns to apply_bm_hosts func in tilt to avoid creating BMHs in default ns

### DIFF
--- a/scripts/deploy_tilt_env.sh
+++ b/scripts/deploy_tilt_env.sh
@@ -34,7 +34,7 @@ sleep 120
 launch_ironic
 # deploy bmo in order to generate ironic credentials and tls
 launch_baremetal_operator
-apply_bm_hosts
+apply_bm_hosts "${NAMESPACE}"
 # remove bmo, so that is deployed and monitored by Tilt
 kubectl delete deployments.apps -n "${IRONIC_NAMESPACE}" baremetal-operator-controller-manager
 


### PR DESCRIPTION
Without this, BMHs will be created in the default namespace when tilt is used as an ephemeral cluster. In normal m3-dev-env deployment (using kind/minikube) namespace is passed to apply_bm_hosts func properly: https://github.com/metal3-io/metal3-dev-env/blob/main/03_launch_mgmt_cluster.sh#L519 so this went in unnoticed