### PR TITLE
Fix minikube error creating bridge interface virbr0: File exists

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -240,6 +240,8 @@ function init_minikube() {
           break
         fi
         sudo su -l -c 'minikube delete --all --purge' "${USER}"
+        # NOTE (Mohammed): workaround for https://github.com/kubernetes/minikube/issues/9878
+        sudo ip link delete virbr0
       done
       sudo su -l -c "minikube stop" "$USER"
     fi


### PR DESCRIPTION
Recently a flaky issue raised in centos 9, while minikube tries to start default libvirt network it fails with ` error creating bridge interface virbr0: File exists` example logs [here](https://jenkins.nordix.org/view/Metal3%20Main/job/metal3_main_v1b1_e2e_test_centos/160/console). 
[This issue](https://github.com/kubernetes/minikube/issues/9878 ) suggests to delete the bridge which seems resolving the problem https://github.com/kubernetes/minikube/issues/9878 