### PR TITLE
Use firewalld with all centos distros

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -298,7 +298,7 @@ fi
 
 # Use firewalld on CentOS/RHEL, iptables everywhere else
 export USE_FIREWALLD=False
-if [[ $DISTRO == "rhel8" || $DISTRO == "centos8" ]]; then
+if [[ $DISTRO == "rhel"* || $DISTRO == "centos"* ]]; then
   export USE_FIREWALLD=True
 fi
 


### PR DESCRIPTION
Dev-env is using firewalld only with centos8 this PR makes dev-env uses firewalld with all centos versions