### PR TITLE
Make wget less verbose

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -104,20 +104,20 @@ fi
 
 if [ "${EPHEMERAL_CLUSTER}" == "minikube" ]; then
   if ! command -v minikube 2>/dev/null || [[ "$(minikube version --short)" != "${MINIKUBE_VERSION}" ]]; then
-      wget -O minikube https://storage.googleapis.com/minikube/releases/"${MINIKUBE_VERSION}"/minikube-linux-amd64
+      wget --no-verbose -O minikube https://storage.googleapis.com/minikube/releases/"${MINIKUBE_VERSION}"/minikube-linux-amd64
       chmod +x minikube
       sudo mv minikube /usr/local/bin/.
   fi
 
   if ! command -v docker-machine-driver-kvm2 2>/dev/null ; then
-      wget -O docker-machine-driver-kvm2 https://storage.googleapis.com/minikube/releases/"${MINIKUBE_VERSION}"/docker-machine-driver-kvm2
+      wget --no-verbose -O docker-machine-driver-kvm2 https://storage.googleapis.com/minikube/releases/"${MINIKUBE_VERSION}"/docker-machine-driver-kvm2
       chmod +x docker-machine-driver-kvm2
       sudo mv docker-machine-driver-kvm2 /usr/local/bin/.
   fi
 # Install Kind for both Kind and tilt
 else
   if ! command -v kind 2>/dev/null || [[ "v$(kind version -q)" != "$KIND_VERSION" ]]; then
-      wget -O ./kind https://github.com/kubernetes-sigs/kind/releases/download/"${KIND_VERSION}"/kind-"$(uname)"-amd64
+      wget --no-verbose -O ./kind https://github.com/kubernetes-sigs/kind/releases/download/"${KIND_VERSION}"/kind-"$(uname)"-amd64
       chmod +x ./kind
       sudo mv kind /usr/local/bin/.
   fi
@@ -127,18 +127,18 @@ else
 fi
 
 KUBECTL_LATEST=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
-KUBECTL_LOCAL=$(kubectl version --client --short | cut -d ":" -f2 | sed 's/[[:space:]]//g' 2> /dev/null)
+KUBECTL_LOCAL=$(kubectl version --client -o json | jq -r '.clientVersion.gitVersion' 2> /dev/null)
 KUBECTL_PATH=$(whereis -b kubectl | cut -d ":" -f2 | awk '{print $1}')
 
 if [ "$KUBECTL_LOCAL" != "$KUBECTL_LATEST" ]; then
-    wget -O kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_LATEST}/bin/linux/amd64/kubectl"
+    wget --no-verbose -O kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_LATEST}/bin/linux/amd64/kubectl"
     chmod +x kubectl
     KUBECTL_PATH="${KUBECTL_PATH:-/usr/local/bin/kubectl}"
     sudo mv kubectl "${KUBECTL_PATH}"
 fi
 
 if ! command -v kustomize 2>/dev/null ; then
-    wget "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+    wget --no-verbose "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
     tar -xzvf "kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
     chmod +x kustomize
     sudo mv kustomize /usr/local/bin/.
@@ -147,7 +147,7 @@ fi
 
 # Install clusterctl client
 function install_clusterctl() {
-  wget -O clusterctl https://github.com/kubernetes-sigs/cluster-api/releases/download/"${CAPIRELEASE}"/clusterctl-linux-amd64
+  wget --no-verbose -O clusterctl https://github.com/kubernetes-sigs/cluster-api/releases/download/"${CAPIRELEASE}"/clusterctl-linux-amd64
   chmod +x ./clusterctl
   sudo mv ./clusterctl /usr/local/bin/clusterctl
 }


### PR DESCRIPTION
This turns off the progress log for wget but will still show errors and a message when the download is completed. For example like this:

```console
❯ wget --no-verbose -O kubectl https://storage.googleapis.com/kubernetes-release/release/v1.24.2/bin/linux/amd64/kubectl
2022-07-01 08:44:25 URL:https://storage.googleapis.com/kubernetes-release/release/v1.24.2/bin/linux/amd64/kubectl [45711360/45711360] -> "kubectl" [1]
```