### PR TITLE
🐛 Fix test scripts paths used in v1alpha5 e2e

### DIFF
--- a/tests/scripts/generate-template.sh
+++ b/tests/scripts/generate-template.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-METAL3_DIR="$(dirname "$(readlink -f "${0}")")/.."
+METAL3_DIR="$(dirname "$(readlink -f "${0}")")/../.."
 
 export ACTION="generate_template"
 

--- a/tests/scripts/run_command.sh
+++ b/tests/scripts/run_command.sh
@@ -4,7 +4,7 @@
 
 set -xe
 
-METAL3_DIR="$(dirname "$(readlink -f "${0}")")/.."
+METAL3_DIR="$(dirname "$(readlink -f "${0}")")/../.."
 
 # shellcheck disable=SC1090
 # shellcheck disable=SC1091


### PR DESCRIPTION
What this PR does / why we need it:
Fixes main ci e2e tests for ubuntu and centos.