### PR TITLE
Clean defaut connection before adding ironicendpoint

### DIFF
--- a/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
@@ -1,6 +1,7 @@
 # CentOS specific controlplane kubeadm config
 preKubeadmCommands:
   - systemctl restart NetworkManager.service
+  - nmcli connection delete "System eth0"
   - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
   - nmcli connection up eth0
   - nmcli connection load /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection

--- a/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-centos.yaml
@@ -1,6 +1,7 @@
 # CentOS specific worker kubeadm config
 preKubeadmCommands:
   - systemctl restart NetworkManager.service
+  - nmcli connection delete "System eth0"
   - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
   - nmcli connection up eth0
   - nmcli connection load /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection


### PR DESCRIPTION
The "System eth0" connection is automatically created and "blocks" the ironicendpoint. This deletes the default connection before we create the ironicendpoint.