### PR TITLE
Add autoconnect priority to centos target node network config

### DIFF
--- a/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
@@ -104,6 +104,8 @@ files:
       interface-name=eth0
       master={{ IRONIC_ENDPOINT_BRIDGE }}
       slave-type=bridge
+      autoconnect=yes
+      autoconnect-priority=999
   - path: /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
     owner: root:root
     permissions: '0600'

--- a/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-centos.yaml
@@ -35,6 +35,8 @@ files:
       interface-name=eth0
       master={{ IRONIC_ENDPOINT_BRIDGE }}
       slave-type=bridge
+      autoconnect=yes
+      autoconnect-priority=999
   - path: /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
     owner: root:root
     permissions: '0600'


### PR DESCRIPTION
This PR solves issue of two connection profiles competing for eth0 interface. We set higher priority to eth0.nmconnection profile.
The dev-tools part  of the solution is [here](https://github.com/Nordix/metal3-dev-tools/pull/587)