### PR TITLE
Fix cert-manager version to v1.9.1 and also fix clusterctl.yaml templating

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -341,6 +341,13 @@ function patch_clusterctl(){
   mkdir -p "${HOME}"/.cluster-api
   touch "${HOME}"/.cluster-api/clusterctl.yaml
 
+  ## Remove these lines
+  ## This is hard-coded until we fix the issue with v1.9.1
+  cat << EOF | sudo tee "${HOME}/.cluster-api/clusterctl.yaml"
+cert-manager:
+  version: "v1.9.1" 
+EOF
+
   # At this point the images variables have been updated with update_images
   # Reflect the change in components files
   if [ -n "${CAPM3_LOCAL_IMAGE}" ]; then

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -342,7 +342,7 @@ function patch_clusterctl(){
   touch "${HOME}"/.cluster-api/clusterctl.yaml
 
   ## Remove these lines
-  ## This is hard-coded until we fix the issue with v1.9.1
+  ## This is hard-coded until we use clusterctl with cert-manager v1.9.1
   cat << EOF | sudo tee "${HOME}/.cluster-api/clusterctl.yaml"
 cert-manager:
   version: "v1.9.1" 

--- a/tests/roles/run_tests/tasks/generate_templates.yml
+++ b/tests/roles/run_tests/tasks/generate_templates.yml
@@ -18,9 +18,11 @@
       mode: '0755'
 
   - name: Deploy clusterctl variables to clusterctl config
-    template:
-      src: clusterctl-vars.yaml
-      dest: "{{ HOME }}/.cluster-api/clusterctl.yaml"
+    ansible.builtin.blockinfile:
+      block: "{{lookup('ansible.builtin.template', '{{ CRS_PATH }}/clusterctl-vars.yaml')}}"
+      path: "{{ HOME }}/.cluster-api/clusterctl.yaml"
+      create: yes 
+      state: present
 
   - name: Generate clusterctl cluster template
     template:


### PR DESCRIPTION
This PR fixes cert-manager version to v1.9.1. This will be removed once clusterctl used in dev-env also uses the same version of cert manager. This PR also fixes clusterctl.yaml templating to make sure the content is always appended instead of overriden. 