### PR TITLE
Upgrade k8s from v1.23.8 instead of v1.24.0

### DIFF
--- a/tests/feature_tests/feature_test_vars.sh
+++ b/tests/feature_tests/feature_test_vars.sh
@@ -6,6 +6,6 @@ if [ "${CAPM3RELEASEBRANCH}" == "release-0.5" ];
 then
   export FROM_K8S_VERSION="v1.23.5"
 else
-  export FROM_K8S_VERSION="v1.24.0"
+  export FROM_K8S_VERSION="v1.23.8"
 fi
 export KUBERNETES_VERSION="${FROM_K8S_VERSION}"


### PR DESCRIPTION
Instead of testing k8s upgrade between patch version we want to test upgrade between minor versions i.e:
instead of upgrade from v1.24.0 to v1.24.1 if should be from v1.23.8 to v1.24.1 