### PR TITLE
Remove overriding cert manager version

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -341,13 +341,6 @@ function patch_clusterctl(){
   mkdir -p "${HOME}"/.cluster-api
   touch "${HOME}"/.cluster-api/clusterctl.yaml
 
-  ## Remove these lines
-  ## This is hard-coded until we use clusterctl with cert-manager v1.9.1
-  cat << EOF | sudo tee "${HOME}/.cluster-api/clusterctl.yaml"
-cert-manager:
-  version: "v1.9.1" 
-EOF
-
   # At this point the images variables have been updated with update_images
   # Reflect the change in components files
   if [ -n "${CAPM3_LOCAL_IMAGE}" ]; then


### PR DESCRIPTION
CAPI has uplifted cert manager version to v1.9.1 https://github.com/kubernetes-sigs/cluster-api/pull/7187 . We do not need to pin it anymore.