### PR TITLE
Add BMORELEASE as the default BMOBRANCH

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -96,7 +96,7 @@ FILESYSTEM=${FILESYSTEM:="/"}
 # CAPIPATH : Path to clone the Cluster API repository
 #
 # BMOREPO : Baremetal Operator repository URL
-# BMOBRANCH : Baremetal Operator repository branch to checkout
+# BMOBRANCH : Baremetal Operator repository branch to checkout (its set it lib/releases.sh)
 # CAPM3REPO : Cluster API Provider Metal3 repository URL
 # CAPM3BRANCH : Cluster API Provider Metal3 repository branch to checkout
 # FORCE_REPO_UPDATE : discard existing directories
@@ -149,7 +149,7 @@ CAPI_BASE_URL="${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}"
 CAPIREPO="${CAPIREPO:-https://github.com/${CAPI_BASE_URL}}"
 
 BMOREPO="${BMOREPO:-https://github.com/metal3-io/baremetal-operator.git}"
-BMOBRANCH="${BMOBRANCH:-${BMORELEASE}}"
+export BMO_BASE_URL="${BMO_BASE_URL:-metal3-io/baremetal-operator}"
 FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-true}"
 BMOCOMMIT="${BMOCOMMIT:-HEAD}"
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -149,7 +149,7 @@ CAPI_BASE_URL="${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}"
 CAPIREPO="${CAPIREPO:-https://github.com/${CAPI_BASE_URL}}"
 
 BMOREPO="${BMOREPO:-https://github.com/metal3-io/baremetal-operator.git}"
-BMOBRANCH="${BMOBRANCH:-main}"
+BMOBRANCH="${BMOBRANCH:-${BMORELEASE}}"
 FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-true}"
 BMOCOMMIT="${BMOCOMMIT:-HEAD}"
 

--- a/lib/releases.sh
+++ b/lib/releases.sh
@@ -27,9 +27,9 @@ function get_latest_release() {
 }
 
 # CAPM3, CAPI and BMO release path
-CAPM3RELEASEPATH="${CAPM3RELEASEPATH:-https://api.github.com/repos/${CAPM3_BASE_URL:-metal3-io/cluster-api-provider-metal3}/releases}"
-CAPIRELEASEPATH="${CAPIRELEASEPATH:-https://api.github.com/repos/${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}/releases}"
-BMORELEASEPATH="${https://api.github.com/repos/${BMO_BASE_URL:-metal3-io/baremetal-operator}/releases}"
+CAPM3RELEASEPATH="{https://api.github.com/repos/${CAPM3_BASE_URL:-metal3-io/cluster-api-provider-metal3}/releases}"
+CAPIRELEASEPATH="{https://api.github.com/repos/${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}/releases}"
+BMORELEASEPATH="{https://api.github.com/repos/${BMO_BASE_URL:-metal3-io/baremetal-operator}/releases}"
 
 # CAPM3, CAPI and BMO releases
 if [ "${CAPM3RELEASEBRANCH}" == "release-0.5" ] || [ "${CAPM3_VERSION}" == "v1alpha5" ]; then

--- a/lib/releases.sh
+++ b/lib/releases.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 function get_latest_release() {
   set +x
   if [ -z "${GITHUB_TOKEN:-}" ]; then
@@ -28,12 +26,12 @@ function get_latest_release() {
   echo "$release_tag"
 }
 
-# CAPM3 , CAPI and BMO release path
+# CAPM3, CAPI and BMO release path
 CAPM3RELEASEPATH="${CAPM3RELEASEPATH:-https://api.github.com/repos/${CAPM3_BASE_URL:-metal3-io/cluster-api-provider-metal3}/releases}"
 CAPIRELEASEPATH="${CAPIRELEASEPATH:-https://api.github.com/repos/${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}/releases}"
-BMORELEASEPATH="${https://api.github.com/repos/${CAPM3_BASE_URL:-metal3-io/baremetal-operator}/releases}"
+BMORELEASEPATH="${https://api.github.com/repos/${BMO_BASE_URL:-metal3-io/baremetal-operator}/releases}"
 
-# CAPM3 CAPI and BMO releases
+# CAPM3, CAPI and BMO releases
 if [ "${CAPM3RELEASEBRANCH}" == "release-0.5" ] || [ "${CAPM3_VERSION}" == "v1alpha5" ]; then
   export CAPM3RELEASE="${CAPM3RELEASE:-$(get_latest_release "${CAPM3RELEASEPATH}" "v0.5.")}"
   export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v0.4.")}"
@@ -48,6 +46,7 @@ fi
 export BMORELEASE="${BMORELEASE:-$(get_latest_release "${BMORELEASEPATH}" "v0.1.")}"
 
 CAPIBRANCH="${CAPIBRANCH:-${CAPIRELEASE}}"
+BMOBRANCH="${BMOBRANCH:-${BMORELEASE}}"
 
 # On first iteration, jq might not be installed
 if [[ "$CAPIRELEASE" == "" ]]; then

--- a/lib/releases.sh
+++ b/lib/releases.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 function get_latest_release() {
   set +x
   if [ -z "${GITHUB_TOKEN:-}" ]; then
@@ -26,11 +28,12 @@ function get_latest_release() {
   echo "$release_tag"
 }
 
-# CAPM3 and CAPI release path
+# CAPM3 , CAPI and BMO release path
 CAPM3RELEASEPATH="${CAPM3RELEASEPATH:-https://api.github.com/repos/${CAPM3_BASE_URL:-metal3-io/cluster-api-provider-metal3}/releases}"
 CAPIRELEASEPATH="${CAPIRELEASEPATH:-https://api.github.com/repos/${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}/releases}"
+BMORELEASEPATH="${https://api.github.com/repos/${CAPM3_BASE_URL:-metal3-io/baremetal-operator}/releases}"
 
-# CAPM3 and CAPI releases
+# CAPM3 CAPI and BMO releases
 if [ "${CAPM3RELEASEBRANCH}" == "release-0.5" ] || [ "${CAPM3_VERSION}" == "v1alpha5" ]; then
   export CAPM3RELEASE="${CAPM3RELEASE:-$(get_latest_release "${CAPM3RELEASEPATH}" "v0.5.")}"
   export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v0.4.")}"
@@ -42,6 +45,8 @@ else
   export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v1.2.")}"
 fi
 
+export BMORELEASE="${BMORELEASE:-$(get_latest_release "${BMORELEASEPATH}" "v0.1.")}"
+
 CAPIBRANCH="${CAPIBRANCH:-${CAPIRELEASE}}"
 
 # On first iteration, jq might not be installed
@@ -51,4 +56,8 @@ fi
 
 if [[ "$CAPM3RELEASE" == "" ]]; then
   command -v jq &> /dev/null && echo "Failed to fetch CAPM3 release from Github" && exit 1
+fi
+
+if [[ "$BMORELEASE" == "" ]]; then
+  command -v jq &> /dev/null && echo "Failed to fetch BMO release from Github" && exit 1
 fi

--- a/vars.md
+++ b/vars.md
@@ -19,7 +19,7 @@ assured that they are persisted.
 | SSH_PUB_KEY | This SSH key will be automatically injected into the provisioned host by the clusterctl environment template files. | | ~/.ssh/id_rsa.pub |
 | CONTAINER_RUNTIME | Select the Container Runtime | "docker", "podman" | "docker" on ubuntu, "podman" otherwise |
 | BMOREPO | Set the Baremetal Operator repository to clone | | https://github.com/metal3-io/baremetal-operator.git |
-| BMOBRANCH | Set the Baremetal Operator branch to checkout | | main |
+| BMOBRANCH | Set the Baremetal Operator branch to checkout | branch name or latest release tag | v0.1.0 |
 | CAPM3REPO | Set the Cluster Api Metal3 provider repository to clone | | https://github.com/metal3-io/cluster-api-provider-metal3.git |
 | CAPM3BRANCH | Set the Cluster Api Metal3 provider branch to checkout | | main |
 | FORCE_REPO_UPDATE | Force deletion of the BMO, CAPM3 and IPAM repositories before cloning them again | "true", "false" | "true" |


### PR DESCRIPTION
This PR ensures that BMO is always checked out at the latest release. Only for main periodic test, BMOBRANCH will be set to main branch from Project Infra.

It also removes assuming that users will be providing different releasepaths because there arent any different releasepaths other than one only. 