### PR TITLE
Fix commands for running keepalived monitor

### DIFF
--- a/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
@@ -12,9 +12,7 @@ preKubeadmCommands:
   - mount /dev/vda1 {{ VM_EXTRADISKS_MOUNT_DIR }}
 {% endif %}
   - systemctl enable --now crio keepalived kubelet
-  - systemctl link /lib/systemd/system/monitor.keepalived.service
-  - systemctl enable monitor.keepalived.service
-  - systemctl start monitor.keepalived.service
+  - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
 postKubeadmCommands:
   - mkdir -p /home/{{ IMAGE_USERNAME }}/.kube
   - chown {{ IMAGE_USERNAME }}:{{ IMAGE_USERNAME }} /home/{{ IMAGE_USERNAME }}/.kube

--- a/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-ubuntu.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-ubuntu.yaml
@@ -9,9 +9,7 @@ preKubeadmCommands:
   - netplan apply
   - systemctl enable --now crio kubelet
   - if (curl -sk --max-time 10 https://{{ CLUSTER_APIENDPOINT_HOST }}:{{ CLUSTER_APIENDPOINT_PORT }}/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
-  - systemctl link /lib/systemd/system/monitor.keepalived.service
-  - systemctl enable monitor.keepalived.service
-  - systemctl start monitor.keepalived.service
+  - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
 postKubeadmCommands:
   - mkdir -p /home/{{ IMAGE_USERNAME }}/.kube
   - chown {{ IMAGE_USERNAME }}:{{ IMAGE_USERNAME }} /home/{{ IMAGE_USERNAME }}/.kube


### PR DESCRIPTION
Systemd has changed so that it is no longer possible to first link a unit and then enable it by its name. Instead we use the full path for enabling. Enabling also creates a link so linkin is not necessary.