### PR TITLE
Export BMOBRANCH to fix release-0.5 e2e

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -3,6 +3,10 @@ set -xe
 
 # shellcheck disable=SC1091
 source lib/logging.sh
+
+# shellcheck disable=SC1091
+source lib/releases.sh
+
 # shellcheck disable=SC1091
 source lib/common.sh
 
@@ -79,9 +83,6 @@ if [[ ":$PATH:" != *":$GOBINARY:"* ]]; then
   # shellcheck disable=SC1090
   source ~/.bashrc
 fi
-
-# shellcheck disable=SC1091
-source lib/releases.sh
 
 ## Install krew
 if ! kubectl krew > /dev/null 2>&1; then

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -150,6 +150,7 @@ CAPIREPO="${CAPIREPO:-https://github.com/${CAPI_BASE_URL}}"
 
 BMOREPO="${BMOREPO:-https://github.com/metal3-io/baremetal-operator.git}"
 export BMO_BASE_URL="${BMO_BASE_URL:-metal3-io/baremetal-operator}"
+export BMOBRANCH="${BMOBRANCH:-${BMORELEASE}}"
 FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-true}"
 BMOCOMMIT="${BMOCOMMIT:-HEAD}"
 

--- a/lib/releases.sh
+++ b/lib/releases.sh
@@ -46,7 +46,7 @@ fi
 export BMORELEASE="${BMORELEASE:-$(get_latest_release "${BMORELEASEPATH}" "v0.1.")}"
 
 CAPIBRANCH="${CAPIBRANCH:-${CAPIRELEASE}}"
-BMOBRANCH="${BMOBRANCH:-${BMORELEASE}}"
+export BMOBRANCH="${BMOBRANCH:-${BMORELEASE}}"
 
 # On first iteration, jq might not be installed
 if [[ "$CAPIRELEASE" == "" ]]; then


### PR DESCRIPTION
Release-0.5 branch of CAPM3 doesnt have this commit https://github.com/metal3-io/cluster-api-provider-metal3/pull/550. So, it depends on dev-env vars. Adding an export on dev-env BMOBRANCH hopefully would make it reache e2e script in release-0.5