### PR TITLE
Improve the local image branch config

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -223,14 +223,11 @@ for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
   # Is it a git repo?
   if [[ "$IMAGE" =~ "://" ]] ; then
     REPOPATH=~/${IMAGE##*/}
-    # Clone to ~ if not there already
-    if [ -e "${REPOPATH}" ]; then
-       cd "${REPOPATH}" || exit
-    else
-      git clone "${IMAGE}" "${REPOPATH}"
-      cd "${REPOPATH}" || exit
-      [ "${BRANCH}" = "main" ] || git checkout "${BRANCH}"
-    fi
+    # Clone to ~
+    # Clean the directory if it already exists
+    rm --recursive --force "${REPOPATH}"
+    git clone --branch "${BRANCH}" "${IMAGE}" "${REPOPATH}"
+    cd "${REPOPATH}" || exit
   # Assume it is a path
   else
     cd "${IMAGE}" || exit

--- a/vars.md
+++ b/vars.md
@@ -89,6 +89,23 @@ assured that they are persisted.
 | MARIADB_CAKEY_FILE | Path to the CA key of MariaDB | | /opt/metal3-dev-env/certs/ironic-ca.key |
 | MARIADB_CACERT_FILE | Path to the CA certificate of MariaDB | | /opt/metal3-dev-env/certs/ironic-ca.pem |
 
+## Local images
+
+Environment variables with `_LOCAL_IMAGE` in their name are used to specify either git repositories or directories that contain the code that is used to build the components locally e.g. `CAPM3_LOCAL_IMAGE`.
+
+Branches can be specified for the aforementioned repositories by following the same naming convention
+e.g. `CAPM3_LOCAL_IMAGE_BRANCH`.
+
+In case a git repository is specified instead of a local path the repository will be pulled and
+controlled by dev-env thus all manual changes done in the related directory will be disregarded by
+the build process.
+
+The intended use of git repository adresses for local image building is to stay synced with
+a branch of the component's upstream repository.
+
+In case there is a need to specify a directory that will keep local changes during the image building
+process just use local path instead of a git repository address.
+
 ## Additional networks
 
 By default two libvirt networks are created `baremetal` and `provisioning`


### PR DESCRIPTION
The configuration logic that is changed in this
commit is used when container images are built
locally in metal3-dev-env.