### PR TITLE
bug host_cleanup.sh: Make baremetal net deletion in Centos optional

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -57,9 +57,10 @@ if [[ $OS == "centos" || $OS == "rhel" ]]; then
   if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
       sudo nmcli con delete provisioning
   fi
-  # Leaving this around causes issues when the host is rebooted
+  # Baremetal net should have been cleaned already at this stage, but we double
+  # check as leaving it around causes issues when the host is rebooted
   if [ "$MANAGE_BR_BRIDGE" == "y" ]; then
-      sudo nmcli con delete baremetal
+      sudo nmcli con delete baremetal || true
   fi
 fi
 


### PR DESCRIPTION
This network should be cleaned up by the "Delete libvirt networks" ansible job, so this step is likely redundant. For now keeping it as an optional step.

Fixes #1079 