### PR TITLE
Delete only the Cluster when cleaning up

### DIFF
--- a/tests/roles/run_tests/tasks/main.yml
+++ b/tests/roles/run_tests/tasks/main.yml
@@ -45,27 +45,13 @@
   include_tasks: move_back.yml
   when: v1aX_integration_test_action in repivot_actions
 
-- name: Deprovision worker nodes
-  kubernetes.core.k8s:
-    state: absent
-    src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_workers_{{ IMAGE_OS }}.yaml"
-    namespace: "{{ NAMESPACE }}"
-  ignore_errors: yes
-  when: v1aX_integration_test_action in deprovision_workers_actions
-
-- name: Deprovision control plane
-  kubernetes.core.k8s:
-    state: absent
-    src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_controlplane_{{ IMAGE_OS }}.yaml"
-    namespace: "{{ NAMESPACE }}"
-  ignore_errors: yes
-  when: v1aX_integration_test_action in deprovision_controlplane_actions
-
 - name: Deprovision cluster
   kubernetes.core.k8s:
     state: absent
-    src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_cluster_{{ IMAGE_OS }}.yaml"
+    api_version: cluster.x-k8s.io/{{ CAPI_VERSION }}
+    kind: Cluster
     namespace: "{{ NAMESPACE }}"
+    name: "{{ CLUSTER_NAME }}"
   ignore_errors: yes
   when: v1aX_integration_test_action in deprovision_cluster_actions
 
@@ -81,7 +67,7 @@
         src: "{{ WORKING_DIR }}/bmhosts_crs.yaml"
         namespace: "{{ NAMESPACE }}"
       ignore_errors: yes
-  
+
     - name: Wait until no BareMetalHost is remaining
       kubernetes.core.k8s_info:
         api_version: metal3.io/v1alpha1

--- a/tests/roles/run_tests/vars/main.yml
+++ b/tests/roles/run_tests/vars/main.yml
@@ -140,16 +140,6 @@ deprovision_cluster_actions:
     - "deprovision_cluster"
     - "feature_test_deprovisioning"
     - "upgrading"
-deprovision_controlplane_actions:
-    - "ci_test_deprovision"
-    - "deprovision_controlplane"
-    - "feature_test_deprovisioning"
-    - "upgrading"
-deprovision_workers_actions:
-    - "ci_test_deprovision"
-    - "deprovision_worker"
-    - "feature_test_deprovisioning"
-    - "upgrading"
 verify_actions:
     - "ci_test_provision"
     - "feature_test_provisioning"


### PR DESCRIPTION
We used to delete the complete manifests, including MachineDeployment, KubeadmControlPlane, Metal3Cluster, etc. Deleting the Cluster is enough as all other resources will follow from the owner chain. This should avoid any issues with things deleted in the wrong order also.
This is also the recommended way to clean up in the CAPI book: https://cluster-api.sigs.k8s.io/user/quick-start.html#clean-up