### PR TITLE
Improve metal3-dev-env repository cloning

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -7,6 +7,8 @@ source lib/logging.sh
 source lib/common.sh
 # shellcheck disable=SC1091
 source lib/network.sh
+# shellcheck disable=SC1091
+source lib/releases.sh
 
 # Root needs a private key to talk to libvirt
 # See tripleo-quickstart-config/roles/virtbmc/tasks/configure-vbmc.yml
@@ -197,6 +199,15 @@ elif [[ "$reg_state" != "running" ]]; then
   sudo "${CONTAINER_RUNTIME}" run -d -p "${REGISTRY_PORT}":5000 --name registry "$DOCKER_REGISTRY_IMAGE"
 fi
 sleep 5
+
+
+# Clone all needed repositories (CAPI, CAPM3, BMO, IPAM)
+mkdir -p "${M3PATH}"
+clone_repo "${BMOREPO}" "${BMOBRANCH}" "${BMOPATH}" "${BMOCOMMIT}"
+clone_repo "${CAPM3REPO}" "${CAPM3BRANCH}" "${CAPM3PATH}" "${CAPM3COMMIT}"
+clone_repo "${IPAMREPO}" "${IPAMBRANCH}" "${IPAMPATH}" "${IPAMCOMMIT}"
+clone_repo "${CAPIREPO}" "${CAPIBRANCH}" "${CAPIPATH}" "${CAPICOMMIT}"
+
 
 # Pushing images to local registry
 for IMAGE_VAR in $(env | grep -v "_LOCAL_IMAGE=" | grep "_IMAGE=" | grep -o "^[^=]*") ; do

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -22,45 +22,6 @@ source lib/ironic_tls_setup.sh
 # shellcheck disable=SC1091
 source lib/ironic_basic_auth.sh
 
-# -----------------------
-# Repositories management
-# -----------------------
-
-#
-# Clone and checkout a repo
-#
-function clone_repo() {
-  local REPO_URL="$1"
-  local REPO_BRANCH="$2"
-  local REPO_PATH="$3"
-  local REPO_COMMIT="${4:-HEAD}"
-
-  if [[ -d "${REPO_PATH}" && "${FORCE_REPO_UPDATE}" == "true" ]]; then
-    rm -rf "${REPO_PATH}"
-  fi
-  if [ ! -d "${REPO_PATH}" ] ; then
-    pushd "${M3PATH}"
-    git clone "${REPO_URL}" "${REPO_PATH}"
-    popd
-    pushd "${REPO_PATH}"
-    git checkout "${REPO_BRANCH}"
-    git checkout "${REPO_COMMIT}"
-    git pull -r || true
-    popd
-  fi
-}
-
-#
-# Clone all needed repositories
-#
-function clone_repos() {
-  mkdir -p "${M3PATH}"
-  clone_repo "${BMOREPO}" "${BMOBRANCH}" "${BMOPATH}" "${BMOCOMMIT}"
-  clone_repo "${CAPM3REPO}" "${CAPM3BRANCH}" "${CAPM3PATH}"
-  clone_repo "${IPAMREPO}" "${IPAMBRANCH}" "${IPAMPATH}"
-  clone_repo "${CAPIREPO}" "${CAPIBRANCH}" "${CAPIPATH}"
-}
-
 # ------------------------------------
 # BMO and Ironic deployment functions
 # ------------------------------------
@@ -450,8 +411,6 @@ function start_management_cluster () {
 # -----------------------------
 # Deploy the management cluster
 # -----------------------------
-
-clone_repos
 
 # Kill and remove the running ironic containers
 "$BMOPATH"/tools/remove_local_ironic.sh

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -89,21 +89,29 @@ export SSH_PUB_KEY_CONTENT
 
 FILESYSTEM=${FILESYSTEM:="/"}
 
-# Environment variables
-# M3PATH : Path to clone the Metal3 Development Environment repository
-# BMOPATH : Path to clone the Bare Metal Operator repository
-# CAPM3PATH : Path to clone the Cluster API Provider Metal3 repository
-# CAPIPATH : Path to clone the Cluster API repository
-#
-# BMOREPO : Baremetal Operator repository URL
-# BMOBRANCH : Baremetal Operator repository branch to checkout (its set it lib/releases.sh)
-# CAPM3REPO : Cluster API Provider Metal3 repository URL
-# CAPM3BRANCH : Cluster API Provider Metal3 repository branch to checkout
-# FORCE_REPO_UPDATE : discard existing directories
-#
-# BMO_RUN_LOCAL : run the Baremetal Operator locally (not in Kubernetes cluster)
-# CAPM3_RUN_LOCAL : run the Cluster API Provider Metal3 locally
+# Reusable repository cloning function
+function clone_repo() {
+  local REPO_URL="$1"
+  local REPO_BRANCH="$2"
+  local REPO_PATH="$3"
+  local REPO_COMMIT="${4:-HEAD}"
 
+  if [[ -d "${REPO_PATH}" && "${FORCE_REPO_UPDATE}" == "true" ]]; then
+    rm -rf "${REPO_PATH}"
+  fi
+  if [ ! -d "${REPO_PATH}" ] ; then
+    pushd "${M3PATH}" || exit
+    git clone "${REPO_URL}" "${REPO_PATH}"
+    popd || exit
+    pushd "${REPO_PATH}" || exit
+    git checkout "${REPO_BRANCH}"
+    git checkout "${REPO_COMMIT}"
+    git pull -r || true
+    popd || exit
+  fi
+}
+
+# Configure common environment variables
 CAPM3_VERSION_LIST="v1alpha5 v1beta1"
 export CAPM3_VERSION="${CAPM3_VERSION:-"v1beta1"}"
 
@@ -155,6 +163,9 @@ BMOREPO="${BMOREPO:-https://github.com/metal3-io/baremetal-operator.git}"
 export BMO_BASE_URL="${BMO_BASE_URL:-metal3-io/baremetal-operator}"
 FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-true}"
 BMOCOMMIT="${BMOCOMMIT:-HEAD}"
+CAPM3COMMIT="${CAPM3COMMIT:-HEAD}"
+IPAMCOMMIT="${IPAMCOMMIT:-HEAD}"
+CAPICOMMIT="${CAPICOMMIT:-HEAD}"
 
 BMO_RUN_LOCAL="${BMO_RUN_LOCAL:-false}"
 CAPM3_RUN_LOCAL="${CAPM3_RUN_LOCAL:-false}"

--- a/vars.md
+++ b/vars.md
@@ -18,11 +18,6 @@ assured that they are persisted.
 | PROVISIONING_IPV6 | Configure provisioning network for single-stack ipv6 | "true", "false" | false |
 | SSH_PUB_KEY | This SSH key will be automatically injected into the provisioned host by the clusterctl environment template files. | | ~/.ssh/id_rsa.pub |
 | CONTAINER_RUNTIME | Select the Container Runtime | "docker", "podman" | "docker" on ubuntu, "podman" otherwise |
-| BMOREPO | Set the Baremetal Operator repository to clone | | https://github.com/metal3-io/baremetal-operator.git |
-| BMOBRANCH | Set the Baremetal Operator branch to checkout | branch name or latest release tag | v0.1.0 |
-| CAPM3REPO | Set the Cluster Api Metal3 provider repository to clone | | https://github.com/metal3-io/cluster-api-provider-metal3.git |
-| CAPM3BRANCH | Set the Cluster Api Metal3 provider branch to checkout | | main |
-| FORCE_REPO_UPDATE | Force deletion of the BMO, CAPM3 and IPAM repositories before cloning them again | "true", "false" | "true" |
 | IPA_DOWNLOAD_ENABLED | Enables the use of the Ironic Python Agent Downloader container to download IPA archive| "true", "false | "true" |
 | USE_LOCAL_IPA | Enables the use of locally supplied IPA archive. This condition is handled by BMO and this has effect only when IPA_DOWNLOAD_ENABLED is "false", otherwise IPA_DOWNLOAD_ENABLED takes precedence. | "true", "false" | "false" |
 | LOCAL_IPA_PATH | This has effect only when USE_LOCAL_IPA is set to "true", points to the directory where the IPA archive is located. This variable is handled by BMO. | "arbitrary directory path" | "" |
@@ -88,6 +83,24 @@ assured that they are persisted.
 | MARIADB_CERT_FILE | Path to the cert of MariaDB | | /opt/metal3-dev-env/certs/mariadb.crt |
 | MARIADB_CAKEY_FILE | Path to the CA key of MariaDB | | /opt/metal3-dev-env/certs/ironic-ca.key |
 | MARIADB_CACERT_FILE | Path to the CA certificate of MariaDB | | /opt/metal3-dev-env/certs/ironic-ca.pem |
+| M3PATH | Path to clone the Metal3 Development Environment repository | | $HOME/go/src/github.com/metal3-io
+| BMOPATH | Path to clone the Bare Metal Operator repository | | $HOME/go/src/github.com/metal3-io/baremetal-operator
+| CAPM3PATH | Path to clone the Cluster API Provider Metal3 repository | | $HOME/go/src/github.com/metal3-io/cluster-api-provider-metal3
+| CAPIPATH | Path to clone the Cluster API repository | | $HOME/go/src/github.com/metal3-io/cluster-api
+| IPAMPATH | Path to clone IP Address Manager repository | | $HOME/go/src/github.com/metal3-io/ip-address-manager |
+| CAPIREPO | Cluster API git repository URL | | https://github.com/kubernetes-sigs/cluster-api |
+| CAPIBRANCH | Cluster API git repository branch to checkout | | main |
+| CAPICOMMIT | Cluster API git commit to checkout on CAPIBRANCH | | HEAD |
+| BMOREPO | Baremetal Operator git repository URL | | https://github.com/metal3-io/baremetal-operator.git |
+| BMOBRANCH | Baremetal Operator git repository branch to checkout (set in lib/releases.sh) | | main |
+| BMOCOMMIT | BMO git commit to checkout on BMOBRANCH | | HEAD |
+| CAPM3REPO | Cluster API Provider Metal3 git repository URL | | https://github.com/metal3-io/cluster-api-provider-metal3 |
+| CAPM3BRANCH | Cluster API Provider Metal3 git repository branch to checkout | | main |
+| CAPM3COMMIT | Cluster API Provicer Metal3 git commit to checkout on CAPM3BRANCH | | HEAD |
+| IPAMREPO | IP Address Manager git repository URL | | https://github.com/metal3-io/ip-address-manageri/ |
+| IPAMBRANCH | IP Address Manager git repository branch to checkout | | main |
+| IPAMCOMMIT | IP Address Manager git commit to checkout on IPAMBRANCH | | HEAD |
+| FORCE_REPO_UPDATE | discard existing directories | "true","false" | "true" |
 
 ## Local images
 


### PR DESCRIPTION
Two issues are being fixed by this commit.

1. Currently the dev-env have 2 independent repo
cloning functionality. One for building local images
and one for customizing CRDs.

The two cloning process is incompatible because the cloning
used for CRD customization happens after the images
specified with _LOCAL_IMAGE postfix have been
built so a clean environment where the repositories
are not yet cloned to $HOME/go/src/github.com/metal3-io/
would not support the local image building based on the same repos
that were used for CRD customization.

2. The clone_repo bash function now have support cloning
specific commits from branches of CAPI, CAPM3 and IPAM.

NOTE: With the changes in this commit the git repo support
implemented exclusively for _LOCAL_IMAGE variables will become redundant
because the _LOCAL_IMAGEs can use the same repositories that are
now cloned by the clone_repo functions thus the redundant functionality
should be removed in later commits in order to keep the scope of this
commit manageable.