### PR TITLE
improve local build of CAPI,CAPM3,IPAM,BMO

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -227,22 +227,8 @@ done
 
 # Support for building local images
 for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
-  BRANCH_IMAGE_VAR="${IMAGE_VAR}_BRANCH"
   IMAGE="${!IMAGE_VAR}"
-  BRANCH="${!BRANCH_IMAGE_VAR:-main}"
-
-  # Is it a git repo?
-  if [[ "$IMAGE" =~ "://" ]] ; then
-    REPOPATH=~/${IMAGE##*/}
-    # Clone to ~
-    # Clean the directory if it already exists
-    rm --recursive --force "${REPOPATH}"
-    git clone --branch "${BRANCH}" "${IMAGE}" "${REPOPATH}"
-    cd "${REPOPATH}" || exit
-  # Assume it is a path
-  else
-    cd "${IMAGE}" || exit
-  fi
+  cd "${IMAGE}" || exit
 
   #shellcheck disable=SC2086
   export $IMAGE_VAR="${IMAGE##*/}"
@@ -252,6 +238,12 @@ for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
   # Support building ironic-image from source
   if [[ "${IMAGE}" =~ "ironic" ]] && [[ ${IRONIC_FROM_SOURCE:-} == "true" ]]; then
     sudo "${CONTAINER_RUNTIME}" build --build-arg INSTALL_TYPE=source -t "${!IMAGE_VAR}" . -f ./Dockerfile
+  elif [[ "${IMAGE}" =~ "cluster-api" ]]; then
+    CAPI_GO_VERSION=$(grep "GO_VERSION ?= [0-9].*" Makefile | sed -e 's/GO_VERSION ?= //g')
+    #shellcheck disable=SC2016
+    CAPI_BASEIMAGE=$(grep "GO_CONTAINER_IMAGE ?=" Makefile | sed -e 's/GO_CONTAINER_IMAGE ?= //g' -e 's/$(GO_VERSION)//g')
+    CAPI_TAGGED_BASE_IMAGE="$CAPI_BASEIMAGE$CAPI_GO_VERSION"
+    sudo DOCKER_BUILDKIT=1 "${CONTAINER_RUNTIME}" build --build-arg builder_image="$CAPI_TAGGED_BASE_IMAGE" --build-arg ARCH="amd64" -t "${!IMAGE_VAR}" . -f ./Dockerfile
   else
     sudo "${CONTAINER_RUNTIME}" build -t "${!IMAGE_VAR}" . -f ./Dockerfile
   fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -136,43 +136,61 @@ export CAPM3REPO="${CAPM3REPO:-https://github.com/${CAPM3_BASE_URL}}"
 export CAPM3RELEASEBRANCH=${CAPM3RELEASEBRANCH:-main}
 
 if [ "${CAPM3RELEASEBRANCH}" == "release-0.5" ] || [ "${CAPM3_VERSION}" == "v1alpha5" ]; then
-  CAPM3BRANCH="${CAPM3BRANCH:-release-0.5}"
-  IPAMBRANCH="${IPAMBRANCH:-release-0.1}"
+  export CAPM3BRANCH="${CAPM3BRANCH:-release-0.5}"
+  export IPAMBRANCH="${IPAMBRANCH:-release-0.1}"
 elif [ "${CAPM3RELEASEBRANCH}" == "release-1.1" ]; then
-  CAPM3BRANCH="${CAPM3BRANCH:-release-1.1}"
-  IPAMBRANCH="${IPAMBRANCH:-release-1.1}"
+  export CAPM3BRANCH="${CAPM3BRANCH:-release-1.1}"
+  export IPAMBRANCH="${IPAMBRANCH:-release-1.1}"
 elif [ "${CAPM3RELEASEBRANCH}" == "release-1.2" ]; then
-  CAPM3BRANCH="${CAPM3BRANCH:-release-1.2}"
-  IPAMBRANCH="${IPAMBRANCH:-release-1.2}"
+  export CAPM3BRANCH="${CAPM3BRANCH:-release-1.2}"
+  export IPAMBRANCH="${IPAMBRANCH:-release-1.2}"
 else
-  CAPM3BRANCH="${CAPM3BRANCH:-main}"
-  IPAMBRANCH="${IPAMBRANCH:-main}"
+  export CAPM3BRANCH="${CAPM3BRANCH:-main}"
+  export IPAMBRANCH="${IPAMBRANCH:-main}"
 fi
 
 export IPAMPATH="${IPAMPATH:-${M3PATH}/ip-address-manager}"
 export IPAM_BASE_URL="${IPAM_BASE_URL:-metal3-io/ip-address-manager}"
 export IPAMREPO="${IPAMREPO:-https://github.com/${IPAM_BASE_URL}}"
 
-IPA_DOWNLOAD_ENABLED="${IPA_DOWNLOAD_ENABLED:-true}"
+export IPA_DOWNLOAD_ENABLED="${IPA_DOWNLOAD_ENABLED:-true}"
 
-CAPIPATH="${CAPIPATH:-${M3PATH}/cluster-api}"
-CAPI_BASE_URL="${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}"
-CAPIREPO="${CAPIREPO:-https://github.com/${CAPI_BASE_URL}}"
+export CAPIPATH="${CAPIPATH:-${M3PATH}/cluster-api}"
+export CAPI_BASE_URL="${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}"
+export CAPIREPO="${CAPIREPO:-https://github.com/${CAPI_BASE_URL}}"
 
-BMOREPO="${BMOREPO:-https://github.com/metal3-io/baremetal-operator.git}"
+export BMOREPO="${BMOREPO:-https://github.com/metal3-io/baremetal-operator.git}"
 export BMO_BASE_URL="${BMO_BASE_URL:-metal3-io/baremetal-operator}"
-FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-true}"
-BMOCOMMIT="${BMOCOMMIT:-HEAD}"
-CAPM3COMMIT="${CAPM3COMMIT:-HEAD}"
-IPAMCOMMIT="${IPAMCOMMIT:-HEAD}"
-CAPICOMMIT="${CAPICOMMIT:-HEAD}"
+export FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-true}"
+export BMOCOMMIT="${BMOCOMMIT:-HEAD}"
+export CAPM3COMMIT="${CAPM3COMMIT:-HEAD}"
+export IPAMCOMMIT="${IPAMCOMMIT:-HEAD}"
+export CAPICOMMIT="${CAPICOMMIT:-HEAD}"
 
-BMO_RUN_LOCAL="${BMO_RUN_LOCAL:-false}"
-CAPM3_RUN_LOCAL="${CAPM3_RUN_LOCAL:-false}"
+export BUILD_CAPM3_LOCALLY="${BUILD_CAPM3_LOCALLY=-false}"
+export BUILD_IPAM_LOCALLY="${BUILD_IPAM_LOCALLY=-false}"
+export BUILD_BMO_LOCALLY="${BUILD_BMO_LOCALLY=-false}"
+export BUILD_CAPI_LOCALLY="${BUILD_CAPI_LOCALLY=-false}"
 
-WORKING_DIR=${WORKING_DIR:-"/opt/metal3-dev-env"}
-NODES_FILE=${NODES_FILE:-"${WORKING_DIR}/ironic_nodes.json"}
-NODES_PLATFORM=${NODES_PLATFORM:-"libvirt"}
+if [ "${BUILD_CAPM3_LOCALLY}" == "true" ]; then
+  export CAPM3_LOCAL_IMAGE="${CAPM3PATH}"
+fi
+if [ "${BUILD_IPAM_LOCALLY}" == "true" ]; then
+  export IPAM_LOCAL_IMAGE="${IPAMPATH}"
+fi
+if [ "${BUILD_BMO_LOCALLY}" == "true" ]; then
+  export BMO_LOCAL_IMAGE="${BMOPATH}"
+fi
+if [ "${BUILD_CAPI_LOCALLY}" == "true" ]; then
+  export CAPI_LOCAL_IMAGE="${CAPIPATH}"
+fi
+
+export BMO_RUN_LOCAL="${BMO_RUN_LOCAL:-false}"
+export CAPM3_RUN_LOCAL="${CAPM3_RUN_LOCAL:-false}"
+
+export WORKING_DIR=${WORKING_DIR:-"/opt/metal3-dev-env"}
+export NODES_FILE=${NODES_FILE:-"${WORKING_DIR}/ironic_nodes.json"}
+export NODES_PLATFORM=${NODES_PLATFORM:-"libvirt"}
 
 # Metal3
 export NAMESPACE=${NAMESPACE:-"metal3"}
@@ -285,7 +303,7 @@ FAILS=0
 RESULT_STR=""
 
 # Avoid printing skipped Ansible tasks
-export ANSIBLE_DISPLAY_SKIPPED_HOSTS=no
+export ANSIBLE_DISPLAY_SKIPPED_HOSTS="no"
 
 # Sanity check for number of nodes
 if [ "${NUM_NODES}" -lt "$((NUM_OF_CONTROLPLANE_REPLICAS + NUM_OF_WORKER_REPLICAS))" ]; then

--- a/vars.md
+++ b/vars.md
@@ -92,32 +92,27 @@ assured that they are persisted.
 | CAPIBRANCH | Cluster API git repository branch to checkout | | main |
 | CAPICOMMIT | Cluster API git commit to checkout on CAPIBRANCH | | HEAD |
 | BMOREPO | Baremetal Operator git repository URL | | https://github.com/metal3-io/baremetal-operator.git |
-| BMOBRANCH | Baremetal Operator git repository branch to checkout (set in lib/releases.sh) | | main |
+| BMOBRANCH | Baremetal Operator git repository branch to checkout | | main |
 | BMOCOMMIT | BMO git commit to checkout on BMOBRANCH | | HEAD |
 | CAPM3REPO | Cluster API Provider Metal3 git repository URL | | https://github.com/metal3-io/cluster-api-provider-metal3 |
 | CAPM3BRANCH | Cluster API Provider Metal3 git repository branch to checkout | | main |
-| CAPM3COMMIT | Cluster API Provicer Metal3 git commit to checkout on CAPM3BRANCH | | HEAD |
+| CAPM3COMMIT | Cluster API Provider Metal3 git commit to checkout on CAPM3BRANCH | | HEAD |
 | IPAMREPO | IP Address Manager git repository URL | | https://github.com/metal3-io/ip-address-manageri/ |
 | IPAMBRANCH | IP Address Manager git repository branch to checkout | | main |
 | IPAMCOMMIT | IP Address Manager git commit to checkout on IPAMBRANCH | | HEAD |
 | FORCE_REPO_UPDATE | discard existing directories | "true","false" | "true" |
+| BUILD_CAPM3_LOCALLY | build Cluster API Provider Metal3 based on CAPM3PATH | "true","false" | "false" |
+| BUILD_IPAM_LOCALLY | build IP Address Manager based on IPAMPATH | "true","false" | "false" |
+| BUILD_BMO_LOCALLY | build Baremetal Operator based on BMOPATH | "true","false" | "false" |
+| BUILD_CAPI_LOCALLY | build Cluster API based on CAPIPATH | "true","false" | "false" |
+
+**NOTE** `(BMO/CAPI/CAPM3/IPAM)RELEASE` variables are also affecting the `BRANCH` variables so make sure that
+RELEASE and BRANCH variables are not conflicting.
 
 ## Local images
 
-Environment variables with `_LOCAL_IMAGE` in their name are used to specify either git repositories or directories that contain the code that is used to build the components locally e.g. `CAPM3_LOCAL_IMAGE`.
-
-Branches can be specified for the aforementioned repositories by following the same naming convention
-e.g. `CAPM3_LOCAL_IMAGE_BRANCH`.
-
-In case a git repository is specified instead of a local path the repository will be pulled and
-controlled by dev-env thus all manual changes done in the related directory will be disregarded by
-the build process.
-
-The intended use of git repository adresses for local image building is to stay synced with
-a branch of the component's upstream repository.
-
-In case there is a need to specify a directory that will keep local changes during the image building
-process just use local path instead of a git repository address.
+Environment variables with `_LOCAL_IMAGE` in their name are used to specify directories that contain the code to build the
+components locally e.g. `CAPM3_LOCAL_IMAGE`.
 
 ## Additional networks
 


### PR DESCRIPTION
This commit improves 3 different things.

1. Add default build option for CAPI,CAPM3,IPAM,BMO.
If the default build option is set to true for any of the
aforementioned repositories then the dev-env will build
the container images based on the same directory that is used
for CRD customization.

2. In order to unify the local container image build process
with the CRD customization process this commit removes the git
repository supoort feature from 02 script because that was exclusively
wirrten to support the local image building thus duplicating the
repository cloning process and by default separating the directories
used for CRD customization and image building.

3. Fix CAPI build options for local image building.

This PR is the continuation of #1083