### PR TITLE
Remove CAPM3 release-0.5 branch check from _vars.sh scripts

### DIFF
--- a/tests/feature_tests/feature_test_vars.sh
+++ b/tests/feature_tests/feature_test_vars.sh
@@ -2,10 +2,5 @@
 
 export CONTROL_PLANE_MACHINE_COUNT="3"
 export WORKER_MACHINE_COUNT="1"
-if [ "${CAPM3RELEASEBRANCH}" == "release-0.5" ];
-then
-  export FROM_K8S_VERSION="v1.23.5"
-else
-  export FROM_K8S_VERSION="v1.24.1"
-fi
+export FROM_K8S_VERSION="v1.24.1"
 export KUBERNETES_VERSION="${FROM_K8S_VERSION}"

--- a/tests/feature_tests/node_reuse/node_reuse_vars.sh
+++ b/tests/feature_tests/node_reuse/node_reuse_vars.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-if [[ "$CAPM3RELEASEBRANCH" == "release-0.5" ]];
-then
-  export UPGRADED_K8S_VERSION="v1.23.8"
-else
-  export UPGRADED_K8S_VERSION="v1.25.2"
-fi
+export UPGRADED_K8S_VERSION="v1.25.2"
 
 if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
   export UPGRADED_IMAGE_NAME="UBUNTU_22.04_NODE_IMAGE_K8S_${UPGRADED_K8S_VERSION}.qcow2"


### PR DESCRIPTION
Support for CAPM3 e2e tests running on the release-0.5 branch is being dropped so no need to check the vars being set in _vars.sh scripts

related code: https://github.com/metal3-io/cluster-api-provider-metal3/blob/release-0.5/hack/e2e/environment.sh#L53-L56