### PR TITLE
Use SQlite for Ironic

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -121,6 +121,10 @@ function update_images(){
 function launch_ironic() {
   pushd "${BMOPATH}"
 
+    # TODO(lentzi90): When the Ironic kustomizations support running without mariadb
+    # adapt this so that we run with/without mariadb based on IRONIC_USE_MARIADB.
+    # Currently we leave mariadb there even when using sqlite.
+
     # Update Configmap parameters with correct urls
     cat << EOF | sudo tee "$IRONIC_DATA_DIR/ironic_bmo_configmap.env"
 HTTP_PORT=${HTTP_PORT}
@@ -136,6 +140,7 @@ CACHEURL=http://${PROVISIONING_URL_HOST}/images
 IRONIC_FAST_TRACK=true
 RESTART_CONTAINER_CERTIFICATE_UPDATED="${RESTART_CONTAINER_CERTIFICATE_UPDATED}"
 IRONIC_RAMDISK_SSH_KEY=${SSH_PUB_KEY_CONTENT}
+IRONIC_USE_MARIADB=${IRONIC_USE_MARIADB:-false}
 EOF
 
   if [ -n "${DEPLOY_ISO_URL}" ]; then


### PR DESCRIPTION
This explicitly configures Ironic to use SQlite instead of Mariadb. We are already using sqlite since it is [the default](https://github.com/metal3-io/ironic-image/blob/main/scripts/runironic#L5) so this is not a change in behavior, it just makes it explicit. With this change it is also possible to set IRONIC_USE_MARIADB=true in the dev-env and actually run with mariadb.  However, there is no kustomization yet for running Ironic without Mariadb, so we will always have a Mariadb container no matter what this variable is set to.

The long term plan for this is to
1. Make the ironic kustomization more flexible: https://github.com/metal3-io/baremetal-operator/pull/1172
2. Add separate sqlite and mariadb flavors
3. Adapt metal3-dev-env to make use of these flavors so that we can truly run without the mariadb container.