### PR TITLE
WIP test NATed provisioning subnet

### DIFF
--- a/ubuntu_bridge_network_configuration.sh
+++ b/ubuntu_bridge_network_configuration.sh
@@ -16,7 +16,7 @@ if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
      # Create a veth iterface peer.
      sudo ip link add ironicendpoint type veth peer name ironic-peer
      # Create provisioning bridge.
-     sudo brctl addbr provisioning
+     # sudo brctl addbr provisioning this interface is already there as NATed iface
      # sudo ifconfig provisioning 172.22.0.1 netmask 255.255.255.0 up
      # Use ip command. ifconfig commands are deprecated now.
      sudo ip link set provisioning up

--- a/vm-setup/roles/common/defaults/main.yml
+++ b/vm-setup/roles/common/defaults/main.yml
@@ -51,7 +51,24 @@ manage_baremetal: 'y'
 provisioning_network:
   - name: provisioning
     bridge: provisioning
-    forward_mode: bridge
+    forward_mode: nat
+    address_v4: "172.23.23.1"
+    netmask_v4: "255.255.255.0"
+    dhcp_range_v4:
+      - "172.23.23.20"
+      - "172.23.23.30"
+    # libvirt defaults to minutes as the unit
+    lease_expiry: 60
+    nat_port_range:
+      - 1024
+      - 65535
+    domain: "{{ cluster_domain }}"
+    dns:
+      hosts: "{{dns_extrahosts | default([])}}"
+      forwarders:
+        - domain: "apps.{{ cluster_domain }}"
+          addr: "127.0.0.1"
+      srvs: "{{dns_externalsrvs | default([])}}"
 external_network:
   - name: baremetal
     bridge: baremetal


### PR DESCRIPTION
This is not a finalized feature ATM.

I am just pushing this PR to help with the network modification discussions.
Use these environment variables during testing. 

export NUM_OF_CONTROLPLANE_REPLICAS=1
export NUM_OF_WORKER_REPLICAS=1
export NUM_NODES=2
export IPA_DOWNLOAD_ENABLED='false'
export USE_LOCAL_IPA='true'
export CLUSTER_DHCP_RANGE='0.0.0.0,0.0.0.0'
export BMC_DRIVER='redfish-virtualmedia'