### PR TITLE
Use ansible 7.0.0 only for Ubuntu 22.x

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -308,7 +308,13 @@ fi
 export KIND_NODE_IMAGE=${KIND_NODE_IMAGE:-"${DOCKER_HUB_PROXY}/kindest/node:${KIND_NODE_IMAGE_VERSION}"}
 
 # Ansible version
-export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"7.0.0"}
+# Older ubuntu version do no support 7.0.0 because of older python versions
+# Ansible 7.0.0 requires python 3.10+
+if [ "${DISTRO}" == "ubuntu22" ]; then
+    export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"7.0.0"}
+else 
+    export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"6.6.0"}
+fi
 
 # Test and verification related variables
 SKIP_RETRIES="${SKIP_RETRIES:-false}"


### PR DESCRIPTION
Recent Ansible uplift to 7.0.0 has broken ubuntu 18.x and ubuntu 20.x builds because the default python version in those distros are older than 3.10.x python version which is a requirement for ansible 7.0.0