### PR TITLE
markdown: pin mdl to 0.12.0 and fix complaints

### DIFF
--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -14,6 +14,6 @@ else
     --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \
     --workdir /workdir \
-    docker.io/pipelinecomponents/markdownlint:latest \
+    registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2 \
     /workdir/hack/markdownlint.sh "${@}"
 fi;

--- a/tests/feature_tests/README.md
+++ b/tests/feature_tests/README.md
@@ -78,38 +78,38 @@ When the test-framework is triggered with `/test-features-ubuntu` or
 `/test-features-centos`, it will:
 
 - setup metal3-dev-env
-  - run 01_\*, 02_\*, 03_\*, 04_\* scripts
+   - run 01_\*, 02_\*, 03_\*, 04_\* scripts
 - run remediation tests
-  - provision cluster and BMH
-  - run remediation tests
-  - deprovision cluster and BMH
+   - provision cluster and BMH
+   - run remediation tests
+   - deprovision cluster and BMH
 - run healthcheck tests
-  - provision cluster and BMH
-  - run healthcheck tests
-  - deprovision cluster and BMH
+   - provision cluster and BMH
+   - run healthcheck tests
+   - deprovision cluster and BMH
 - clean up the environment
-  - run `cleanup_env.sh`
+   - run `cleanup_env.sh`
 - run pivoting tests
-  - provision cluster and BMH
-  - run pivoting tests
+   - provision cluster and BMH
+   - run pivoting tests
 - run scale-in and node reuse tests
-  - run scale-in and node reuse tests for KubeadmControlPlane scenario
-  - run node reuse tests for MachineDeployment scenario
+   - run scale-in and node reuse tests for KubeadmControlPlane scenario
+   - run node reuse tests for MachineDeployment scenario
 - run repivoting tests
-  - run repivoting tests
-  - deprovision cluster and BMH
+   - run repivoting tests
+   - deprovision cluster and BMH
 - clean up the environment
-  - run `cleanup_env.sh`
+   - run `cleanup_env.sh`
 
 When the test-framework is triggered with `/test-upgrade-features`, it will:
 
 - setup metal3-dev-env
-  - run 01_\*, 02_\*, 03_\*, 04_\* scripts
+   - run 01_\*, 02_\*, 03_\*, 04_\* scripts
 - run upgrade tests
-  - provision cluster and BMH
-  - run upgrade tests
-  - deprovision cluster and BMH
-  - destroy the environment (i.e. run `make clean`)
+   - provision cluster and BMH
+   - run upgrade tests
+   - deprovision cluster and BMH
+   - destroy the environment (i.e. run `make clean`)
 
 ## Environment variables
 


### PR DESCRIPTION
mdl 0.12 moves unordered list indentation from 2 spaces to 3 spaces due Kramdown requirements.

Pin markdownlint image to 0.12 (with SHA), and fix all markdown comply with mdl 0.12.