### PR TITLE
Update dependency ansible to v7.1.0

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -311,7 +311,7 @@ export KIND_NODE_IMAGE=${KIND_NODE_IMAGE:-"${DOCKER_HUB_PROXY}/kindest/node:${KI
 # Older ubuntu version do no support 7.0.0 because of older python versions
 # Ansible 7.0.0 requires python 3.10+
 if [ "${DISTRO}" == "ubuntu22" ]; then
-    export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"7.0.0"}
+    export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"7.1.0"}
 else 
     export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"6.6.0"}
 fi


### PR DESCRIPTION
Fixes this renovate PR: https://github.com/metal3-io/metal3-dev-env/pull/1122
Renovate PR was updating ansible version also for older Ubuntu versions which is not going to work.