### PR TITLE
shellcheck: pin shellcheck to v0.9.0

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -249,7 +249,7 @@ if ${IPA_DOWNLOAD_ENABLED} || [ ! -f "${IRONIC_DATA_DIR}/html/images/ironic-pyth
           -v "$IRONIC_DATA_DIR":/shared "${IPA_DOWNLOADER_IMAGE}" \
           /bin/bash -c "/usr/local/bin/get-resource.sh &> /dev/null" && s=0 && break || s=$?
     done
-    (exit $s)
+    (exit "${s}")
 fi
 
 function configure_minikube() {

--- a/04_verify.sh
+++ b/04_verify.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# ignore shellcheck v0.9.0 introduced SC2317 about unreachable code
+# that doesn't understand traps, variables, functions etc causing all
+# code called via iterate() to false trigger SC2317
+# shellcheck disable=SC2317
 
 set -u
 
@@ -293,4 +297,3 @@ echo ""
 
 echo -e "\nNumber of failures : $FAILS"
 exit "${FAILS}"
-

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -15,6 +15,6 @@ else
     --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \
     --workdir /workdir \
-    docker.io/koalaman/shellcheck-alpine:stable \
+    docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7 \
     /workdir/hack/shellcheck.sh "${@}"
 fi;


### PR DESCRIPTION
Pin shellcheck to v0.9.0 with digest, and fix the new complaints introduced in this version. Previous stable tag was pointing to v0.8.0 until this morning's release of v0.9.0.