### PR TITLE
bind registry to EXTERNAL_SUBNET_V4_HOST

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -196,7 +196,7 @@ if [[ "$reg_state" == "exited" ]]; then
   sudo "${CONTAINER_RUNTIME}" start registry
 elif [[ "$reg_state" != "running" ]]; then
   sudo "${CONTAINER_RUNTIME}" rm registry -f || true
-  sudo "${CONTAINER_RUNTIME}" run -d -p "${REGISTRY_PORT}":5000 --name registry "$DOCKER_REGISTRY_IMAGE"
+  sudo "${CONTAINER_RUNTIME}" run -d -p "${REGISTRY}":5000 --name registry "$DOCKER_REGISTRY_IMAGE"
 fi
 sleep 5
 


### PR DESCRIPTION
Registry should be binding to an IP by default. In case dev-env is ran on a machine that has internet connectivity, binding to all interfaces exposes unauthenticated registry to anyone. This would allow anyone to replace images with arbitrary code, or perform DOS by filling the machine's disk, etc.

Here we replace binding "$REGISTRY_PORT":5000 with $REGISTRY:5000 as $REGISTRY is defined as $EXTERNAL_SUBNET_V4_HOST:$REGISTRY_PORT and by default that is 192.168.11.1:5000