### PR TITLE
Support deploying Ironic with/without MariaDB

### DIFF
--- a/tests/roles/run_tests/tasks/move.yml
+++ b/tests/roles/run_tests/tasks/move.yml
@@ -115,7 +115,7 @@
 
   # Install BMO
   - name: Install Baremetal Operator
-    shell: "{{ BMOPATH }}/tools/deploy.sh true false {{ IRONIC_TLS_SETUP }} {{ IRONIC_BASIC_AUTH }} true"
+    shell: "{{ BMOPATH }}/tools/deploy.sh -b {{ BMO_IRONIC_ARGS }}"
     environment:
       IRONIC_HOST: "{{ IRONIC_HOST }}"
       IRONIC_HOST_IP: "{{ IRONIC_HOST_IP }}"
@@ -125,7 +125,7 @@
 
   # Install Ironic
   - name: Install Ironic
-    shell: "{{ BMOPATH }}/tools/deploy.sh false true {{ IRONIC_TLS_SETUP }} {{ IRONIC_BASIC_AUTH }} true"
+    shell: "{{ BMOPATH }}/tools/deploy.sh -i {{ BMO_IRONIC_ARGS }}"
     environment:
       IRONIC_HOST: "{{ IRONIC_HOST }}"
       IRONIC_HOST_IP: "{{ IRONIC_HOST_IP }}"

--- a/tests/roles/run_tests/tasks/move_back.yml
+++ b/tests/roles/run_tests/tasks/move_back.yml
@@ -16,7 +16,7 @@
     when: EPHEMERAL_CLUSTER == "kind"
 
   - name: Install Ironic in Source cluster (Ephemeral Cluster is minikube)
-    shell: "{{ BMOPATH }}/tools/deploy.sh false true {{ IRONIC_TLS_SETUP }} {{ IRONIC_BASIC_AUTH }} true"
+    shell: "{{ BMOPATH }}/tools/deploy.sh -i {{ BMO_IRONIC_ARGS }}"
     environment:
       IRONIC_HOST: "{{ IRONIC_HOST }}"
       IRONIC_HOST_IP: "{{ IRONIC_HOST_IP }}"

--- a/tests/roles/run_tests/tasks/upgrade.yml
+++ b/tests/roles/run_tests/tasks/upgrade.yml
@@ -277,7 +277,7 @@
         spec:
           template:
             spec:
-              containers: "{{ ironic_based_containers + mariadb_container }}"
+              containers: "{{ ironic_based_containers }}"
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
     vars:
       # Generate a list of name/image pairs from the ironic_image_containers.
@@ -290,10 +290,6 @@
         "{{ dict(ironic_image_containers |
               zip_longest([], fillvalue=CONTAINER_REGISTRY+'/metal3-io/ironic:'+IRONIC_IMAGE_TAG)) |
             dict2items(key_name='name', value_name='image') }}"
-      mariadb_container:
-      - name:  mariadb
-        image: "{{CONTAINER_REGISTRY+'/metal3-io/mariadb:'+MARIADB_IMAGE_TAG}}"
-
 
   - name: Wait for ironic update to rollout
     kubernetes.core.k8s_info:
@@ -336,4 +332,3 @@
     include_tasks: verify_resources_states.yml
     vars:
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
-      

--- a/tests/roles/run_tests/vars/main.yml
+++ b/tests/roles/run_tests/vars/main.yml
@@ -80,14 +80,20 @@ IMAGE_FORMAT: "{{ lookup('env', 'IMAGE_FORMAT') | default('raw', true) }}"
 IMAGE_CHECKSUM_TYPE: "{{ lookup('env', 'IMAGE_CHECKSUM_TYPE') | default('md5', true) }}"
 IMAGE_CHECKSUM: "http://{{ PROVISIONING_IP }}/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
 
-# Environment variables to install Ironic with TLS and Basic Auth
+# Environment variables to install Ironic with TLS, Basic Auth and MariaDB
 GOPATH: "{{ lookup('env', 'GOPATH')}}"
 IRONIC_TLS_SETUP: "{{ lookup('env', 'IRONIC_TLS_SETUP') | default('true', true) }}"
 IRONIC_BASIC_AUTH: "{{ lookup('env', 'IRONIC_BASIC_AUTH') | default('true', true) }}"
+IRONIC_USE_MARIADB: "{{ lookup('env', 'IRONIC_USE_MARIADB') | default('false', true) }}"
+
+# Args to pass to the deploy.sh script when deploying Ironic and BMO
+# [k]eepalived [t]ls [n]o basic auth or [m]ariadb
+BMO_IRONIC_ARGS: "-k {{ (IRONIC_TLS_SETUP == 'true') | ternary('-t', '') }}
+    {{ (IRONIC_BASIC_AUTH == 'true') | ternary('', '-n') }}
+    {{ (IRONIC_USE_MARIADB == 'true') | ternary('-m', '') }}"
 
 # Environment variables for upgrade workflow
 IRONIC_IMAGE_TAG: "main"
-MARIADB_IMAGE_TAG: "main"
 CONTAINER_REGISTRY: "{{ lookup('env', 'CONTAINER_REGISTRY') }}"
 NUM_IRONIC_IMAGES: 8
 CAPIRELEASE_HARDCODED: "{{ lookup('env', 'CAPIRELEASE_HARDCODED') }}"

--- a/vars.md
+++ b/vars.md
@@ -73,6 +73,7 @@ assured that they are persisted.
 | IRONIC_INSPECTOR_USERNAME | Username for Ironic inspector basic auth | | |
 | IRONIC_PASSWORD | Password for Ironic basic auth | | |
 | IRONIC_INSPECTOR_PASSWORD | Password for Ironic inspector basic auth | | |
+| IRONIC_USE_MARIADB | Use MariaDB instead of SQLite. Setting this to "true" does not work with v0.2.0 and older versions of BMO. MariaDB cannot be used without TLS. | "true", "false" | "false" |
 | REGISTRY_PORT | Container image registry port | | 5000 |
 | HTTP_PORT | Httpd server port | | 6180 |
 | IRONIC_INSPECTOR_PORT | Ironic Inspector port | | 5050 |


### PR DESCRIPTION
Note: We still set the mariadb container image to use even though we don't use mariadb. Not sure if it is worth it to add a check there also.
I removed mariadb from the containers we bump in the upgrade test though. This is because it would make the test more complex and upgrading a database seems a bit outside of scope. We will not anyway use mariadb in the normal tests.

Related:
- https://github.com/metal3-io/baremetal-operator/pull/1196