### PR TITLE
Configure vlan interface in centos when EXTERNAL_VLAN_ID is set 

### DIFF
--- a/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
@@ -13,6 +13,10 @@ preKubeadmCommands:
 {% endif %}
   - systemctl enable --now crio keepalived kubelet
   - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
+{% if EXTERNAL_VLAN_ID != "" %}
+  - nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+  - nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+{% endif %}
 postKubeadmCommands:
   - mkdir -p /home/{{ IMAGE_USERNAME }}/.kube
   - chown {{ IMAGE_USERNAME }}:{{ IMAGE_USERNAME }} /home/{{ IMAGE_USERNAME }}/.kube
@@ -141,3 +145,26 @@ files:
 
       [registries.insecure]
       registries = ['{{ REGISTRY }}']
+{% if EXTERNAL_VLAN_ID != "" %}
+  - path: /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+    owner: root:root
+    permissions: '0600'
+    content: |
+      [connection]
+      id=Vlan eth0.{{ EXTERNAL_VLAN_ID }}
+      type=vlan
+      autoconnect-priority=999
+      interface-name=eth0.{{ EXTERNAL_VLAN_ID }}
+
+      [vlan]
+      flags=1
+      id=3
+      parent=eth0
+
+      [ipv4]
+      method=auto
+
+      [ipv6]
+      addr-gen-mode=eui64
+      method=ignore
+{% endif %}

--- a/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-centos.yaml
@@ -6,6 +6,10 @@ preKubeadmCommands:
   - nmcli connection load /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
   - nmcli connection up {{ IRONIC_ENDPOINT_BRIDGE }}
   - systemctl enable --now crio kubelet
+{% if EXTERNAL_VLAN_ID != "" %}
+  - nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+  - nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+{% endif %}
 files:
   - path: /usr/local/bin/retrieve.configuration.files.sh
     owner: root:root
@@ -76,3 +80,26 @@ files:
 
       [registries.insecure]
       registries = ['{{ REGISTRY }}']
+{% if EXTERNAL_VLAN_ID != "" %}
+  - path: /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+    owner: root:root
+    permissions: '0600'
+    content: |
+      [connection]
+      id=Vlan eth0.{{ EXTERNAL_VLAN_ID }}
+      type=vlan
+      autoconnect-priority=999
+      interface-name=eth0.{{ EXTERNAL_VLAN_ID }}
+
+      [vlan]
+      flags=1
+      id=3
+      parent=eth0
+
+      [ipv4]
+      method=auto
+
+      [ipv6]
+      addr-gen-mode=eui64
+      method=ignore
+{% endif %}


### PR DESCRIPTION
Configure vlan interface via kubeadm config when EXTERNAL_VLAN_ID is set.