### PR TITLE
uplift golang to 1.19.4

### DIFF
--- a/vm-setup/install-package-playbook.yml
+++ b/vm-setup/install-package-playbook.yml
@@ -9,5 +9,5 @@
     - import_role:
         name: fubarhouse.golang
       vars:
-        go_version: 1.19.3
+        go_version: 1.19.4
         go_install_clean: true


### PR DESCRIPTION
Uplift golang to 1.19.4 in vm-setup playbook.