### PR TITLE
Control-plane and worker deprovision scripts are removed.

### DIFF
--- a/tests/scripts/deprovision/controlplane.sh
+++ b/tests/scripts/deprovision/controlplane.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-METAL3_DIR="$(dirname "$(readlink -f "${0}")")/../../.."
-
-export ACTION="deprovision_controlplane"
-
-"${METAL3_DIR}"/tests/run.sh

--- a/tests/scripts/deprovision/worker.sh
+++ b/tests/scripts/deprovision/worker.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-METAL3_DIR="$(dirname "$(readlink -f "${0}")")/../../.."
-
-export ACTION="deprovision_worker"
-
-"${METAL3_DIR}"/tests/run.sh


### PR DESCRIPTION
This is a follow-up of this PR: https://github.com/metal3-io/metal3-dev-env/pull/1082
Separate de-provisioning of worker and controlplane was removed in the above PR and the shell scripts were not removed. This PR is removing those orphaned shell scripts.