### PR TITLE
Adding deprovisioning of kcp and worker back.

### DIFF
--- a/tests/roles/run_tests/tasks/main.yml
+++ b/tests/roles/run_tests/tasks/main.yml
@@ -45,6 +45,22 @@
   include_tasks: move_back.yml
   when: v1aX_integration_test_action in repivot_actions
 
+- name: Deprovision worker nodes
+  kubernetes.core.k8s:
+    state: absent
+    src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_workers_{{ IMAGE_OS }}.yaml"
+    namespace: "{{ NAMESPACE }}"
+  ignore_errors: yes
+  when: v1aX_integration_test_action in deprovision_workers_actions
+
+- name: Deprovision control plane
+  kubernetes.core.k8s:
+    state: absent
+    src: "{{ TEMP_GEN_DIR }}/{{ CAPM3_VERSION }}_controlplane_{{ IMAGE_OS }}.yaml"
+    namespace: "{{ NAMESPACE }}"
+  ignore_errors: yes
+  when: v1aX_integration_test_action in deprovision_controlplane_actions
+
 - name: Deprovision cluster
   kubernetes.core.k8s:
     state: absent

--- a/tests/roles/run_tests/vars/main.yml
+++ b/tests/roles/run_tests/vars/main.yml
@@ -141,6 +141,10 @@ deprovision_cluster_actions:
     - "deprovision_cluster"
     - "feature_test_deprovisioning"
     - "upgrading"
+deprovision_controlplane_actions:
+    - "deprovision_controlplane"
+deprovision_workers_actions:
+    - "deprovision_worker"
 verify_actions:
     - "ci_test_provision"
     - "feature_test_provisioning"


### PR DESCRIPTION
Keeping deprovision scripts and adding the ansible blocks back, so if someone wants to do the deprovisioning separately they can just use these scripts. It is not included in CI, CI will use the same logic of deprovisioning just cluster.