### PR TITLE
readme: add information how to develop with Tilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,22 @@ make
 kubectl delete cluster "${CLUSTER_NAME:-"test1"}" -n metal3
 ```
 
-### Deploying with Tilt
+### Deploying and developing with Tilt
 
 It is possible to use Tilt to run the CAPI, BMO, CAPM3 and IPAM components. Tilt
 ephemeral cluster will utilize Kind and Docker, so it requires an Ubuntu host.
 For this, run:
+
+By default, Metal3 components are not built locally. To develop with Tilt, you
+must `export BUILD_[CAPM3|BMO|IPAM|CAPI]_LOCALLY=true`, and then you can edit
+the code in `~/go/src/github.com/metal3-io/...` and it will be picked up by
+Tilt. You can also specify repository URL, branch and commit with `CAPM3REPO`,
+`CAPM3BRANCH` and `CAPM3COMMIT` to make dev-env start the component with your
+development branch content. Same for IPAM, BMO and CAPI.
+See `vars.md` for more information.
+
+After specifying the components and paths to your liking, bring the cluster up
+by setting the ephemeral cluster type to Tilt and image OS to Ubuntu.
 
 ```sh
 export IMAGE_OS=ubuntu
@@ -133,6 +144,9 @@ If you are running tilt on a remote machine, you can forward the web interface
 by adding the following parameter to the ssh command `-L 10350:127.0.0.1:10350`
 
 Then you can access the Tilt dashboard locally [here](http://127.0.0.1:10350)
+
+*Note*: It is easiest if you configure all these in `config_<username>.sh` file,
+which is automatically sourced if it exists.
 
 ### Recreating local ironic containers
 


### PR DESCRIPTION
Add steps how to set up dev-env with Tilt to develop one or more component in dev-env. Earlier we had information only per component repository, and nothing on developing in dev-env where everything is present.