### PR TITLE
Allow metal3-dev-env to run on a generic ubuntu VM

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -25,6 +25,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "platform=$NODES_PLATFORM" \
     -e "libvirt_firmware=$LIBVIRT_FIRMWARE" \
     -e "libvirt_secure_boot=$LIBVIRT_SECURE_BOOT" \
+    -e "libvirt_domain_type=$LIBVIRT_DOMAIN_TYPE" \
     -e "default_memory=$DEFAULT_HOSTS_MEMORY" \
     -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
     -e "provisioning_url_host=$PROVISIONING_URL_HOST" \
@@ -173,6 +174,7 @@ fi
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "{use_firewalld: $USE_FIREWALLD}" \
     -e "external_subnet_v4: ${EXTERNAL_SUBNET_V4}" \
+    -e "provisioning_subnet: ${PROVISIONING_NETWORK}" \
     -i vm-setup/inventory.ini \
     -b vm-setup/firewall.yml
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ And the following environment variables need to be set for **Flatcar**:
 export IMAGE_OS=flatcar
 ```
 
+By default the virtualization hypervisor used is kvm. To be able to use it
+the nested virtualization needs to be enabled in the host. In case kvm or
+nested virtualization are not available it is possible to switch to qemu,
+although at this moment there are limitations in the execution and it is
+considered as experimental configuration.
+To switch to the qemu hypervisor apply the following setting:
+
+```sh
+export LIBVIRT_DOMAIN_TYPE=qemu
+```
+
 You can check a list of all the environment variables [here](vars.md)
 
 ### Deploy the metal3 Dev env

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -342,6 +342,10 @@ if [ "${NUM_NODES}" -lt "$((CONTROL_PLANE_MACHINE_COUNT + WORKER_MACHINE_COUNT))
     exit 1
 fi
 
+# Set default libvirt_domain_type to kvm
+# Accepted values are kvm or qemu
+export LIBVIRT_DOMAIN_TYPE=${LIBVIRT_DOMAIN_TYPE:-kvm}
+
 # Verify requisites/permissions
 # Connect to system libvirt
 export LIBVIRT_DEFAULT_URI=qemu:///system

--- a/vars.md
+++ b/vars.md
@@ -16,6 +16,7 @@ assured that they are persisted.
 | EXTERNAL_SUBNET_V4 | When using IPv4 stack, this is the subnet used on the "baremetal" libvirt network, created as the primary network interface for the virtual bare metalhosts. | IPv4 CIDR | 192.168.111.0/24 |
 | EXTERNAL_SUBNET_V6 | When using IPv6 stack, this is the subnet used on the "baremetal" libvirt network, created as the primary network interface for the virtual bare metalhosts. | IPv6 CIDR | fd55::/64 |
 | PROVISIONING_IPV6 | Configure provisioning network for single-stack ipv6 | "true", "false" | false |
+| PROVISIONING_NETWORK | Assign a subnet to the provisioning network. | IPv4 CIDR | 172.22.0.0/24 |
 | SSH_PUB_KEY | This SSH key will be automatically injected into the provisioned host by the clusterctl environment template files. | | ~/.ssh/id_rsa.pub |
 | CONTAINER_RUNTIME | Select the Container Runtime | "docker", "podman" | "docker" on ubuntu, "podman" otherwise |
 | IPA_DOWNLOAD_ENABLED | Enables the use of the Ironic Python Agent Downloader container to download IPA archive| "true", "false | "true" |
@@ -49,6 +50,7 @@ assured that they are persisted.
 | UPGRADED_K8S_VERSION | Upgraded Kubernetes version | "x.x.x" | "1.26.0" |
 | KUBERNETES_BINARIES_VERSION | Version of kubelet, kubeadm and kubectl | "x.x.x-xx" or "x.x.x" | same as KUBERNETES_VERSION |
 | KUBERNETES_BINARIES_CONFIG_VERSION | Version of kubelet.service and 10-kubeadm.conf files | "vx.x.x" | "v0.13.0" |
+| LIBVIRT_DOMAIN_TYPE | Which hypervisor to use for the virtual machines libvirt domain, default to kvm. It is possible to switch to qemu in case nested virtualization is not available, although it's considered experimental at this stage of development. | "kvm", "qemu" | "kvm" |
 | NUM_NODES | Set the number of virtual machines to be provisioned. This VMs will be further configured as controlplane or worker Nodes. Note that CONTROL_PLANE_MACHINE_COUNT and WORKER_MACHINE_COUNT should sum to this value. | | 2 |
 | CONTROL_PLANE_MACHINE_COUNT | Set the controlplane replica count in the target cluster. ||1|
 | WORKER_MACHINE_COUNT | Set the worker replica count in the target cluster. ||1|

--- a/vm-setup/roles/firewall/defaults/main.yml
+++ b/vm-setup/roles/firewall/defaults/main.yml
@@ -1,16 +1,21 @@
 use_firewalld: true
 baremetal_interface: baremetal
 provisioning_interface: provisioning
+cluster_provisioning_interface: "{{ lookup('env', 'CLUSTER_PROVISIONING_INTERFACE') | default('ironicendpoint', true) }}"
 external_subnet_v4: "{{ lookup('env', 'EXTERNAL_SUBNET_V4') | default('192.168.111.0/24', true) }}"
+provisioning_subnet: "{{ lookup('env', 'PROVISIONING_NETWORK') | default('172.22.0.0/24', true) }}"
+kind_subnet: '172.18.0.0/24'
 registry_port: "{{ lookup('env', 'REGISTRY_PORT') | default('5000', true) }}"
 http_port: "{{ lookup('env', 'HTTP_PORT') | default('6180', true) }}"
 ironic_inspector_port: "{{ lookup('env', 'IRONIC_INSPECTOR_PORT') | default('5050', true) }}"
 ironic_api_port: "{{ lookup('env', 'IRONIC_API_PORT') | default('6385', true) }}"
 vbmc_port_range: "6230:6235"
 sushy_port: 8000
+cluster_api_port: "{{ lookup('env', 'CLUSTER_APIENDPOINT_PORT') | default('6443', true) }}"
 firewall_rule_state: present
 ironic_ports:
   - "{{ http_port }}"
+  - "443"
   - "{{ ironic_inspector_port }}"
   - "{{ ironic_api_port }}"
   - "9999"
@@ -22,6 +27,7 @@ provisioning_host_ports:
   - "{{ registry_port }}"
   # DNS for registry naming resolution
   - "53"
+  - "443"
 pxe_udp_ports:
   # Multicast DNS
   - "5353"
@@ -38,4 +44,3 @@ ironic_keepalived_proto:
   - "icmp"
 
 EPHEMERAL_CLUSTER: "{{ lookup('env', 'EPHEMERAL_CLUSTER') | default('kind', true)}}"
-

--- a/vm-setup/roles/firewall/tasks/firewalld.yaml
+++ b/vm-setup/roles/firewall/tasks/firewalld.yaml
@@ -13,6 +13,7 @@
   loop:
     - "{{ provisioning_interface }}"
     - "{{ baremetal_interface }}"
+    - "{{ cluster_provisioning_interface }}"
 
 - name: "firewalld: Provisioning host ports"
   ansible.posix.firewalld:

--- a/vm-setup/roles/firewall/tasks/iptables.yaml
+++ b/vm-setup/roles/firewall/tasks/iptables.yaml
@@ -8,6 +8,7 @@
 - name: "iptables: VBMC Ports"
   iptables:
     chain: INPUT
+    action: insert
     in_interface: "{{ baremetal_interface }}"
     protocol: udp
     match: udp
@@ -18,6 +19,7 @@
 - name: "iptables: sushy Port"
   iptables:
     chain: INPUT
+    action: insert
     in_interface: "{{ baremetal_interface }}"
     protocol: tcp
     match: tcp
@@ -36,19 +38,29 @@
 
 - name: "iptables: Ironic Ports"
   iptables:
-    chain: FORWARD
-    in_interface: "{{ provisioning_interface }}"
+    chain: "{{ item[0].chain }}"
+    action: insert
+    in_interface: "{{ item[0].interface }}"
     protocol: tcp
     match: tcp
-    destination_port: "{{ item }}"
+    destination_port: "{{ item[1] }}"
     jump: ACCEPT
     state: "{{ firewall_rule_state }}"
-  loop: "{{ ironic_ports }}"
+  vars:
+    interfaces:
+      - chain: INPUT
+        interface: "{{ provisioning_interface }}"
+      - chain: INPUT
+        interface: "{{ cluster_provisioning_interface }}"
+      - chain: FORWARD
+        interface: "{{ provisioning_interface }}"
+  loop: "{{ interfaces | product(ironic_ports) | list }}"
 
 - name: "iptables: Provisioning host ports"
   iptables:
     chain: INPUT
-    in_interface: "{{ provisioning_interface }}"
+    action: insert
+    in_interface: "{{ baremetal_interface }}"
     protocol: tcp
     match: tcp
     destination_port: "{{ item }}"
@@ -58,14 +70,23 @@
 
 - name: "iptables: PXE Ports"
   iptables:
-    chain: FORWARD
-    in_interface: "{{ provisioning_interface }}"
+    chain: "{{ item[0].chain }}"
+    action: insert
+    in_interface: "{{ item[0].interface }}"
     protocol: udp
     match: udp
-    destination_port: "{{ item }}"
+    destination_port: "{{ item[1] }}"
     jump: ACCEPT
     state: "{{ firewall_rule_state }}"
-  loop: "{{ pxe_udp_ports }}"
+  vars:
+    interfaces:
+      - chain: INPUT
+        interface: "{{ provisioning_interface }}"
+      - chain: INPUT
+        interface: "{{ cluster_provisioning_interface }}"
+      - chain: FORWARD
+        interface: "{{ provisioning_interface }}"
+  loop: "{{ interfaces | product(pxe_udp_ports) | list }}"
 
 - name: "iptables: Ironic Endpoint Keepalived"
   iptables:
@@ -76,12 +97,48 @@
     state: "{{ firewall_rule_state }}"
   loop: "{{ ironic_keepalived_proto }}"
 
-- name: "iptables: Allow access to baremetal network from kind"
-  iptables:
-    chain: FORWARD
-    action: insert
-    out_interface: "{{ baremetal_interface }}"
-    destination: "{{ external_subnet_v4 }}"
-    jump: ACCEPT
-    state: "{{ firewall_rule_state }}"
+- block:
+    - name: "iptables: Allow access to baremetal network from kind"
+      iptables:
+        chain: INPUT
+        action: insert
+        protocol: tcp
+        match: tcp
+        destination: "{{ external_subnet_v4 }}"
+        destination_port: "{{ item }}"
+        jump: ACCEPT
+        state: "{{ firewall_rule_state }}"
+      loop: "{{ provisioning_host_ports }}"
+
+    - name: "iptables: Allow access to provisioning network from kind"
+      iptables:
+        chain: INPUT
+        action: insert
+        protocol: tcp
+        match: tcp
+        destination: "{{ provisioning_subnet }}"
+        destination_port: "{{ item }}"
+        jump: ACCEPT
+        state: "{{ firewall_rule_state }}"
+      loop: "{{ ironic_ports }}"
+
+    - name: "iptables: Allow access to Kubernetes API from kind"
+      iptables:
+        chain: INPUT
+        action: insert
+        protocol: tcp
+        match: tcp
+        destination: "{{ kind_subnet }}"
+        destination_port: "{{ cluster_api_port }}"
+        jump: ACCEPT
+        state: "{{ firewall_rule_state }}"
+
+    - name: "iptables: Allow forwarding to baremetal network from kind"
+      iptables:
+        chain: FORWARD
+        action: insert
+        out_interface: "{{ baremetal_interface }}"
+        destination: "{{ external_subnet_v4 }}"
+        jump: ACCEPT
+        state: "{{ firewall_rule_state }}"
   when: (EPHEMERAL_CLUSTER == "kind")

--- a/vm-setup/roles/libvirt/defaults/main.yml
+++ b/vm-setup/roles/libvirt/defaults/main.yml
@@ -9,7 +9,6 @@ vm_platform: libvirt
 # not require privileged access (but does require the setup performed by the
 # `environment/setup` role).
 libvirt_volume_pool: oooq_pool
-libvirt_domain_type: kvm
 libvirt_diskdev: sda
 libvirt_cdromdev: sdb
 libvirt_diskbus: scsi

--- a/vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml
@@ -9,6 +9,24 @@
     state: directory
     mode: 0755
 
+- block:
+    - name: Detect virtualization if libvirt_domain_type is not provided
+      command: systemd-detect-virt
+      ignore_errors: true
+      become: true
+      register: virt_result
+
+    - name: Default to qemu if inside a VM
+      set_fact:
+        libvirt_domain_type: qemu
+      when: virt_result is succeeded
+
+    - name: Default to kvm if a VM is not detected
+      set_fact:
+        libvirt_domain_type: kvm
+      when: virt_result is failed
+  when: libvirt_domain_type is undefined
+
 - name: Check volume pool
   command: >
     virsh pool-uuid "{{ libvirt_volume_pool }}"

--- a/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
+++ b/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
@@ -18,6 +18,7 @@
 {% endif %}
     <boot dev='network'/>
     <bootmenu enable='no'/>
+    <bios useserial='yes' rebootTimeout='10000'/>
   </os>
 {% else %}
 <os firmware='efi'>
@@ -30,7 +31,11 @@
     <apic/>
     <pae/>
   </features>
+{% if libvirt_domain_type == 'qemu' %}
+  <cpu mode='host-model'/>
+{% else %}
   <cpu mode='host-passthrough'/>
+{% endif %}
   <clock offset='utc'/>
   <on_poweroff>destroy</on_poweroff>
   <on_reboot>restart</on_reboot>

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -24,6 +24,7 @@ packages:
         - libpolkit-agent-1-0
         - libpolkit-gobject-1-0
         - apache2-utils
+        - netcat
     podman:
       packages:
         - apt-transport-https
@@ -38,6 +39,9 @@ packages:
         - python3-bcrypt
     focal_jammy:
       packages:
+        - apparmor
+        - apparmor-profiles-extra
+        - apparmor-utils
         - libvirt-daemon
         - libvirt-daemon-system
         - libssl-dev

--- a/vm-setup/roles/packages_installation/tasks/ubuntu_required_packages.yml
+++ b/vm-setup/roles/packages_installation/tasks/ubuntu_required_packages.yml
@@ -92,6 +92,13 @@
           apt: name={{ item }} state=latest update_cache=yes
           loop: [ 'docker-ce', 'docker-ce-cli', 'containerd.io' ]
 
+        - name: Create docker configuration dir
+          file:
+            path: /etc/docker
+            state: directory
+            owner: root
+            group: root
+
         - name: Template daemon.json to /etc/docker/daemon.json
           template:
             src: "{{ DAEMON_JSON_PATH }}/daemon.json"


### PR DESCRIPTION
Currently metal3-dev-env is configured to run on a preconfigured ubuntu host.
Some configuration parameters and options are given as assumed, but to run it
in a generic VM ( based on ubuntu focal or jammy), we need to update the
configuration to take into consideration a default clean OS configuration.