### PR TITLE
fix dev-env installation on ubuntu 18.04/centos 8

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -151,7 +151,7 @@ elif [ "${CAPM3RELEASEBRANCH}" == "release-1.2" ]; then
   export IPAMBRANCH="${IPAMBRANCH:-release-1.2}"
 elif [ "${CAPM3RELEASEBRANCH}" == "release-1.3" ]; then
   export CAPM3BRANCH="${CAPM3BRANCH:-release-1.3}"
-  export IPAMBRANCH="${IPAMBRANCH:-release-1.3}"  
+  export IPAMBRANCH="${IPAMBRANCH:-release-1.3}"
 else
   export CAPM3BRANCH="${CAPM3BRANCH:-main}"
   export IPAMBRANCH="${IPAMBRANCH:-main}"
@@ -262,7 +262,7 @@ elif [ "${CAPM3RELEASEBRANCH}" == "release-1.2" ]; then
   export IPAM_IMAGE=${IPAM_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ip-address-manager:release-1.2"}
 elif [ "${CAPM3RELEASEBRANCH}" == "release-1.3" ]; then
   export CAPM3_IMAGE=${CAPM3_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/cluster-api-provider-metal3:release-1.3"}
-  export IPAM_IMAGE=${IPAM_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ip-address-manager:release-1.3"}  
+  export IPAM_IMAGE=${IPAM_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ip-address-manager:release-1.3"}
 else
   export CAPM3_IMAGE=${CAPM3_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/cluster-api-provider-metal3:main"}
   export IPAM_IMAGE=${IPAM_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ip-address-manager:main"}
@@ -315,10 +315,13 @@ export KIND_NODE_IMAGE=${KIND_NODE_IMAGE:-"${DOCKER_HUB_PROXY}/kindest/node:${KI
 
 # Ansible version
 # Older ubuntu version do no support 7.0.0 because of older python versions
+# Ubuntu 18/Centos8 have 4.10.0 as latest ansible
 # Ansible 7.0.0 requires python 3.10+
-if [ "${DISTRO}" == "ubuntu22" ]; then
+if [ "${DISTRO}" = "ubuntu22" ]; then
     export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"7.1.0"}
-else 
+elif [ "${DISTRO}" = "ubuntu18" ] || [ "${DISTRO}" = "centos8" ]; then
+    export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"4.10.0"}
+else
     export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"6.7.0"}
 fi
 

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -35,6 +35,7 @@ packages:
         - libvirt-bin
         - libpolkit-backend-1-0
         - libssl1.0-dev
+        - python3-bcrypt
     focal_jammy:
       packages:
         - libvirt-daemon


### PR DESCRIPTION
Ubuntu 18.04/Centos8 cannot install Ansible newer than 4.x as they have
only Python 3.6.

Ubuntu 18.04 needs python3-bcrypt as well. It must be installed as
system package as bcrypt bugs out pip's older than 19.3, but pip
upgrade breaks other module installations.
