### PR TITLE
Fetch target cluster logs before re-pivot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ pivoting_test:
 	make -C ./tests/feature_tests/pivoting/
 
 repivoting_test:
+	make -C ./tests/feature_tests/pivoting/ fetch_target_logs
 	make -C ./tests/feature_tests/pivoting/ repivoting
 	make -C ./tests//feature_tests/pivoting/ deprovision
 

--- a/tests/feature_tests/pivoting/Makefile
+++ b/tests/feature_tests/pivoting/Makefile
@@ -13,6 +13,9 @@ fetch_manifests:
 pivoting:
 	./pivot.sh
 
+fetch_target_logs:
+	./../../scripts/fetch_target_logs.sh
+
 repivoting:
 	./repivot.sh
 

--- a/tests/roles/run_tests/vars/main.yml
+++ b/tests/roles/run_tests/vars/main.yml
@@ -162,7 +162,6 @@ pivot_actions:
     - "pivoting"
     - "upgrading"
 repivot_actions:
-    - "ci_test_provision"
     - "repivoting"
     - "upgrading"
 cleanup_actions:

--- a/tests/scripts/fetch_target_logs.sh
+++ b/tests/scripts/fetch_target_logs.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -x
+
+KUBE_CONFIG="$(sudo find /tmp/ -type f -name "kubeconfig*")"
+DIR_NAME="/tmp/target_cluster_logs"
+NAMESPACES="$(kubectl --kubeconfig="${KUBE_CONFIG}" get namespace -o json | jq -r '.items[].metadata.name')"
+mkdir -p "${DIR_NAME}"
+for NAMESPACE in ${NAMESPACES}
+do
+  mkdir -p "${DIR_NAME}/${NAMESPACE}"
+# Fetch logs from target cluster according to the pods name
+  PODS="$(kubectl --kubeconfig="${KUBE_CONFIG}" get pods -n "${NAMESPACE}" -o json | jq -r '.items[].metadata.name')"
+  for POD in ${PODS}
+  do
+    mkdir -p "${DIR_NAME}/${NAMESPACE}/${POD}"
+    CONTAINERS="$(kubectl --kubeconfig="${KUBE_CONFIG}" get pods -n "${NAMESPACE}" "${POD}" -o json | jq -r '.spec.containers[].name')"
+    for CONTAINER in ${CONTAINERS}
+    do
+      LOG_DIR="${DIR_NAME}/${NAMESPACE}/${POD}/${CONTAINER}"
+      mkdir -p "${LOG_DIR}"
+      kubectl --kubeconfig="${KUBE_CONFIG}" logs -n "${NAMESPACE}" "${POD}" "${CONTAINER}" \
+        > "${LOG_DIR}/stdout.log" 2> "${LOG_DIR}/stderr.log"
+    done
+  done
+done

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -11,6 +11,12 @@ export ACTION="ci_test_provision"
 
 "${METAL3_DIR}"/tests/run.sh
 
+"${METAL3_DIR}"/tests/scripts/fetch_target_logs.sh
+
+export ACTION="repivoting"
+
+"${METAL3_DIR}"/tests/run.sh
+
 # wait until status of Metal3Machine is rebuilt
 while [ -z "${status}" ]
 do


### PR DESCRIPTION
This PR will help to fetch target cluster logs from pods and save them in tmp folder during integration and feature test.