### PR TITLE
Add optional fully NATed network configuration 

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -140,6 +140,9 @@ function launch_ironic() {
   pushd "${BMOPATH}"
 
     # Update Configmap parameters with correct urls
+    # Variable names inserted into the configmap might have different
+    # naming conventions than the dev-env e.g. PROVISIONING_IP and CIDR are
+    # called PROVISIONER_IP and CIDR in dev-env
     cat << EOF | sudo tee "${IRONIC_DATA_DIR}/ironic_bmo_configmap.env"
 HTTP_PORT=${HTTP_PORT}
 PROVISIONING_IP=${CLUSTER_BARE_METAL_PROVISIONER_IP}

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -29,6 +29,9 @@ function prefixlen() {
   export "${resultvar?}"
 }
 
+# Option to enable or disable fully NATed network topology
+export ENABLE_NATED_PROVISIONING_NETWORK="${ENABLE_NATED_PROVISIONING_NETWORK:-false}"
+
 # Provisioning Interface
 export BARE_METAL_PROVISIONER_INTERFACE="${BARE_METAL_PROVISIONER_INTERFACE:-ironicendpoint}"
 
@@ -99,14 +102,20 @@ fi
 
 export IP_STACK=${IP_STACK:-"v4"}
 if [[ "${IP_STACK}" == "v4" ]]; then
-    export EXTERNAL_SUBNET_V4=${EXTERNAL_SUBNET_V4:-"192.168.111.0/24"}
+    export EXTERNAL_SUBNET_V4="${EXTERNAL_SUBNET_V4:-192.168.111.0/24}"
     export EXTERNAL_SUBNET_V6=""
+    export PROVISIONING_SUBNET_V4="${PROVISIONING_SUBNET_V4:-172.23.23.0/24}"
+    export PROVISIONING_SUBNET_V6=""
 elif [[ "${IP_STACK}" == "v6" ]]; then
     export EXTERNAL_SUBNET_V4=""
-    export EXTERNAL_SUBNET_V6=${EXTERNAL_SUBNET_V6:-"fd55::/64"}
+    export EXTERNAL_SUBNET_V6="${EXTERNAL_SUBNET_V6:-fd55::/64}"
+    export PROVISIONING_SUBNET_V4=""
+    export PROVISIONING_SUBNET_V6="${PROVISIONING_SUBNET_V6:-fd56::/64}"
 elif [[ "${IP_STACK}" == "v4v6" ]]; then
-    export EXTERNAL_SUBNET_V4=${EXTERNAL_SUBNET_V4:-"192.168.111.0/24"}
-    export EXTERNAL_SUBNET_V6=${EXTERNAL_SUBNET_V6:-"fd55::/64"}
+    export EXTERNAL_SUBNET_V4="${EXTERNAL_SUBNET_V4:-192.168.111.0/24}"
+    export EXTERNAL_SUBNET_V6="${EXTERNAL_SUBNET_V6:-fd55::/64}"
+    export PROVISIONING_SUBNET_V4="${PROVISIONING_SUBNET_V4:-172.23.23.0/24}"
+    export PROVISIONING_SUBNET_V6="${PROVISIONING_SUBNET_V6:-fd56::/64}"
 else
     echo "Invalid value of IP_STACK: '${IP_STACK}'"
     exit 1
@@ -131,6 +140,11 @@ export CLUSTER_APIENDPOINT_PORT=${CLUSTER_APIENDPOINT_PORT:-"6443"}
 
 if [[ "${EPHEMERAL_CLUSTER}" == "minikube" ]] && [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
     network_address MINIKUBE_BMNET_V6_IP "${EXTERNAL_SUBNET_V6}" 9
+fi
+
+if [[ -n "${PROVISIONING_SUBNET_V4}" ]]; then
+    network_address PROVISIONING_DHCP_V4_START "${PROVISIONING_SUBNET_V4}" 1
+    network_address PROVISIONING_DHCP_V4_END "${PROVISIONING_SUBNET_V4}" 99
 fi
 
 if [[ -n "${EXTERNAL_SUBNET_V4}" ]]; then

--- a/tests/roles/run_tests/tasks/verify.yml
+++ b/tests/roles/run_tests/tasks/verify.yml
@@ -55,7 +55,7 @@
       kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
     register: install_cni
 
-  - name: Wait (maximum 3 mins) until Calico pods start running
+  - name: Wait (maximum 10 mins) until Calico pods start running
     kubernetes.core.k8s_info:
       api_version: v1
       kind: Pod
@@ -63,8 +63,8 @@
       kubeconfig: /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml
       field_selectors:
         - status.phase!=Running
-    retries: 9
-    delay: 20
+    retries: 60
+    delay: 10
     register: calico_pods
     until: (calico_pods is succeeded) and
            (calico_pods.resources | length == 0)

--- a/tests/roles/run_tests/tasks/verify_resources_states.yml
+++ b/tests/roles/run_tests/tasks/verify_resources_states.yml
@@ -38,8 +38,8 @@
       namespace: "{{ NAMESPACE }}"
       kubeconfig: "{{ kubeconfig }}"
     register: m3m
-    retries: 30
-    delay: 20
+    retries: 60
+    delay: 10
     vars:
       # Note: the 'ready' field is a boolean (not a string)
       query: "[? status.ready]"

--- a/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
@@ -1,18 +1,19 @@
 # CentOS specific controlplane kubeadm config
 preKubeadmCommands:
   - systemctl restart NetworkManager.service
-  - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-  - nmcli connection up eth0
   - nmcli connection load /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
   - nmcli connection up {{ IRONIC_ENDPOINT_BRIDGE }}
+  - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+  - nmcli connection up eth0
 {% if VM_EXTRADISKS == "true" %}
   - (echo n; echo p; echo 1; echo  ;echo  ;echo w) | fdisk /dev/vda
   - mkfs.{{ VM_EXTRADISKS_FILE_SYSTEM }} /dev/vda1
   - mkdir {{ VM_EXTRADISKS_MOUNT_DIR }}
   - mount /dev/vda1 {{ VM_EXTRADISKS_MOUNT_DIR }}
 {% endif %}
-  - systemctl enable --now crio keepalived kubelet
-  - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
+  - systemctl enable --now keepalived
+  - sleep 60
+  - systemctl enable --now crio kubelet
 {% if EXTERNAL_VLAN_ID != "" %}
   - nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
   - nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
@@ -41,38 +42,6 @@ files:
         else
           cat "$tmpfile"| sed '$d' > "$dst";
         fi
-  - path: /usr/local/bin/monitor.keepalived.sh
-    owner: root:root
-    permissions: '0755'
-    content: |
-        #!/bin/bash
-        while :; do
-          curl -sk https://127.0.0.1:{{ CLUSTER_APIENDPOINT_PORT }}/healthz 1>&2 > /dev/null
-          isOk=$?
-          isActive=$(systemctl show -p ActiveState keepalived.service | cut -d'=' -f2)
-          if [ $isOk == "0" ] &&  [ $isActive != "active" ]; then
-            logger 'API server is healthy, however keepalived is not running, starting keepalived'
-            echo 'API server is healthy, however keepalived is not running, starting keepalived'
-            sudo systemctl start keepalived.service
-          elif [ $isOk != "0" ] &&  [ $isActive == "active" ]; then
-            logger 'API server is not healthy, however keepalived running, stopping keepalived'
-            echo 'API server is not healthy, however keepalived running, stopping keepalived'
-            sudo systemctl stop keepalived.service
-          fi
-          sleep 5
-        done
-  - path: /lib/systemd/system/monitor.keepalived.service
-    owner: root:root
-    content: |
-      [Unit]
-      Description=Monitors keepalived adjusts status with that of API server
-      After=syslog.target network-online.target
-      [Service]
-      Type=simple
-      Restart=always
-      ExecStart=/usr/local/bin/monitor.keepalived.sh
-      [Install]
-      WantedBy=multi-user.target
   - path: /etc/keepalived/keepalived.conf
     content: |
       ! Configuration File for keepalived
@@ -106,24 +75,22 @@ files:
       interface-name=eth0
       master={{ IRONIC_ENDPOINT_BRIDGE }}
       slave-type=bridge
-      autoconnect=yes
-      autoconnect-priority=999
   - path: /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
     owner: root:root
     permissions: '0600'
     content: |
       [connection]
       id={{ IRONIC_ENDPOINT_BRIDGE }}
-      type=bridge
       interface-name={{ IRONIC_ENDPOINT_BRIDGE }}
-
+      type=bridge
+      autoconnect=yes
+      autoconnect-priority=1
       [bridge]
+      interface-name={{ IRONIC_ENDPOINT_BRIDGE }}
       stp=false
-
       [ipv4]
       address1={{ "{{ ds.meta_data.provisioningIP }}" }}/{{ "{{ ds.meta_data.provisioningCIDR }}" }}
       method=manual
-
       [ipv6]
       addr-gen-mode=eui64
       method=ignore

--- a/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-centos.yaml
@@ -1,10 +1,10 @@
 # CentOS specific worker kubeadm config
 preKubeadmCommands:
   - systemctl restart NetworkManager.service
-  - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-  - nmcli connection up eth0
   - nmcli connection load /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
   - nmcli connection up {{ IRONIC_ENDPOINT_BRIDGE }}
+  - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+  - nmcli connection up eth0
   - systemctl enable --now crio kubelet
 {% if EXTERNAL_VLAN_ID != "" %}
   - nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection

--- a/ubuntu_bridge_network_configuration.sh
+++ b/ubuntu_bridge_network_configuration.sh
@@ -15,8 +15,10 @@ if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
      # the IP address here.
      # Create a veth iterface peer.
      sudo ip link add ironicendpoint type veth peer name ironic-peer
-     # Create provisioning bridge.
-     sudo brctl addbr provisioning
+     # Create provisioning bridge, if the user allowed bridged provisioning network.
+     if [[ "${ENABLE_NATED_PROVISIONING_NETWORK:-false}" = "false" ]]; then
+         sudo brctl addbr provisioning
+     fi
      # sudo ifconfig provisioning 172.22.0.1 netmask 255.255.255.0 up
      # Use ip command. ifconfig commands are deprecated now.
      sudo ip link set provisioning up

--- a/vars.md
+++ b/vars.md
@@ -124,6 +124,7 @@ assured that they are persisted.
 | SUSHY_SOURCE | absolute path of the sushy source code used to build the sushy library in the ironic container image | | |
 | DHCP_HOSTS | A list of `;` separated dhcp-host directives for dnsmasq | e.g. `00:20:e0:3b:13:af;00:20:e0:3b:14:af` | |
 | DHCP_IGNORE | A set of tags on hosts to be ignored by dnsmasq | e.g. `tag:!known` | |
+| ENABLE_NATED_PROVISIONING_NETWORK | A single boolean to configure whether provisioner and provisioning networks are in separate subnets and there is NAT betweend them or not | "true","false" | "false" |
 
 **NOTE** `(BMO/CAPI/CAPM3/IPAM)RELEASE` variables are also affecting the `BRANCH` variables so make sure that
 RELEASE and BRANCH variables are not conflicting.

--- a/vm-setup/roles/common/defaults/main.yml
+++ b/vm-setup/roles/common/defaults/main.yml
@@ -32,6 +32,13 @@ external_dhcp_v4_end: "{{ lookup('env', 'EXTERNAL_DHCP_V4_END')|default('', true
 external_dhcp_v6_start: "{{ lookup('env', 'EXTERNAL_DHCP_V6_START')|default('', true) }}"
 external_dhcp_v6_end: "{{ lookup('env', 'EXTERNAL_DHCP_V6_END')|default('', true) }}"
 
+provisioning_network_cidr_v4: "{{ lookup('env', 'PROVISIONING_SUBNET_V4')|default('', true) }}"
+provisioning_network_cidr_v6: "{{ lookup('env', 'PROVISIONING_SUBNET_V6')|default('', true) }}"
+provisioning_dhcp_v4_start: "{{ lookup('env', 'PROVISIONING_DHCP_V4_START')|default('', true) }}"
+provisioning_dhcp_v4_end: "{{ lookup('env', 'PROVISIONING_DHCP_V4_END')|default('', true) }}"
+provisioning_dhcp_v6_start: "{{ lookup('env', 'PROVISIONING_DHCP_V6_START')|default('', true) }}"
+provisioning_dhcp_v6_end: "{{ lookup('env', 'PROVISIONING_DHCP_V6_END')|default('', true) }}"
+
 # Set this to `false` if you don't want your vms
 # to have a VNC console available.
 enable_vnc_console: true
@@ -47,7 +54,27 @@ ssh_user: root
 # the vm nodes in the order in which they are defined with the following caveats:
 #   *  The first bridge network defined will be used for pxe booting
 manage_external: 'y'
-provisioning_network:
+provisioning_network_nat:
+  - name: provisioning
+    bridge: provisioning
+    forward_mode: nat
+    address_v4: "{{ provisioning_network_cidr_v4|nthhost(1)|default('', true) }}"
+    netmask_v4: "{{ provisioning_network_cidr_v4|ipaddr('netmask') }}"
+    dhcp_range_v4:
+      - "{{ provisioning_dhcp_v4_start }}"
+      - "{{ provisioning_dhcp_v4_end }}"
+    # libvirt defaults to minutes as the unit
+    lease_expiry: 60
+    nat_port_range:
+      - 1024
+      - 65535
+    domain: "{{ cluster_domain }}"
+    dns:
+      hosts: "{{dns_extrahosts | default([])}}"
+      forwarders:
+        - domain: "apps.{{ cluster_domain }}"
+          addr: "127.0.0.1"
+provisioning_network_bridge:
   - name: provisioning
     bridge: provisioning
     forward_mode: bridge
@@ -79,4 +106,11 @@ external_network:
           addr: "{% if external_network_cidr_v4|ipv4 != False %}127.0.0.1{% else %}::1{% endif %}"
       srvs: "{{dns_externalsrvs | default([])}}"
 
-networks: "{{ provisioning_network + external_network }}"
+# Provisioning network is bridged and external network is nated
+networks_mixed: "{{ provisioning_network_bridge + external_network }}"
+# Both networks are nated
+networks_nated: "{{ provisioning_network_nat + external_network }}"
+# Enable only nated networks
+networks_nat_only: "{{ lookup('env', 'ENABLE_NATED_PROVISIONING_NETWORK') | bool }}"
+# Placeholder for the eventually selected network composition
+networks: "{{ networks_nated if networks_nat_only else networks_mixed }}"

--- a/vm-setup/roles/common/tasks/main.yml
+++ b/vm-setup/roles/common/tasks/main.yml
@@ -3,6 +3,10 @@
 - set_fact:
     generate_vm_nodes: "{{vm_nodes is not defined}}"
 
+- name: "Show network_mode data for debugging (common role)"
+  debug:
+    var: networks_nat_only
+
 - name: Set an empty default for vm_nodes if not already defined
   set_fact:
     vm_nodes: []
@@ -32,9 +36,9 @@
 
 - name: "Append extra networks when EXTRA_NETWORK_NAMES is configured"
   set_fact:
-    networks: "{{ networks + extra_networks}}"
+    networks: "{{ networks + extra_networks }}"
   when: generate_extra_networks
 
-- name: "Show networks data for debugging"
+- name: "Show networks data for debugging (common role)"
   debug:
     var: networks


### PR DESCRIPTION
In certain development scenarios the user might need to bootstrap
an environment where all the interfaces have NAT forwarding modes.

This commit also improves some kubeadm scripts to make the target node's bootstrap process more reliable.
The modifications related to interface setup and keepalived are added in this commit because
without the improvements the NATed topology seemed to be unstable.

This commit does the following:

NATed topology:
- Adds optional fully NATed network topology where both the external network.
  and the provisioning network are in separate subnets connected to the host network via NAT.
- IPs for both the external and the provisioning network are assigned by libvirt's dhcp during inspection.
- Introduces a new variable to make the provisioning subnet customizable.

Modifications in kubeadm scripts:
- Improves the initialization process of ironicendpoint bridge interface on the nodes.
- Introduces 60s time delay after the keepalived is started on the control plane nodes in order to avoid keepalived
  conflicting with other processes.
- Removes the custom keepalived monitoring script as it seems to be too agressive and restarts keepalived even when
  it is not needed + there should be no need for an external process to turn on/off keepalived if it is correctly
  deployed.
- Based on experience it seems that the time provided for calico to start up is not always engough so I
  moved the wait period from 3min to 10min and the frequency of the verification task from 20s to 10s.
- Implements the same 10min wait period for m3m verification as for calico verification.