### PR TITLE
Unify ansible extra_var handling

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -172,9 +172,8 @@ EOF
 fi
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
-    -e "{use_firewalld: $USE_FIREWALLD}" \
-    -e "external_subnet_v4: ${EXTERNAL_SUBNET_V4}" \
-    -e "provisioning_subnet: ${PROVISIONING_NETWORK}" \
+    -e "provisioning_subnet=${PROVISIONING_NETWORK}" \
+    -e "use_firewalld=${USE_FIREWALLD}" \
     -i vm-setup/inventory.ini \
     -b vm-setup/firewall.yml
 

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -42,14 +42,11 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -i vm-setup/inventory.ini \
     -b -v vm-setup/teardown-playbook.yml
 
-if [ "$USE_FIREWALLD" == "False" ]; then
- ANSIBLE_FORCE_COLOR=true ansible-playbook \
-    -e "{use_firewalld: $USE_FIREWALLD}" \
-    -e "external_subnet_v4: ${EXTERNAL_SUBNET_V4}" \
+ANSIBLE_FORCE_COLOR=true ansible-playbook \
+    -e "use_firewalld=${USE_FIREWALLD}" \
     -e "firewall_rule_state=absent" \
     -i vm-setup/inventory.ini \
     -b -v vm-setup/firewall.yml
-fi
 
 # There was a bug in this file, it may need to be recreated.
 if [[ $OS == "centos" || $OS == "rhel" ]]; then

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -361,9 +361,9 @@ if ! sudo -n uptime &> /dev/null ; then
 fi
 
 # Use firewalld on CentOS/RHEL, iptables everywhere else
-export USE_FIREWALLD=False
+export USE_FIREWALLD=false
 if [[ $DISTRO == "rhel"* || $DISTRO == "centos"* ]]; then
-  export USE_FIREWALLD=True
+  export USE_FIREWALLD=true
 fi
 
 # Check d_type support

--- a/vm-setup/roles/firewall/tasks/main.yml
+++ b/vm-setup/roles/firewall/tasks/main.yml
@@ -3,11 +3,12 @@
   args:
     apply:
       become: true
-  when: use_firewalld
+  when: use_firewalld | bool
+
 
 - name: "iptables"
   include_tasks: iptables.yaml
   args:
     apply:
       become: true
-  when: not use_firewalld
+  when: not use_firewalld | bool


### PR DESCRIPTION
It has been noticed that a firewalld related ansible extra_var was passed to Ansible in json format instead of regular key=value format.

The root cause of the isse was that this variable was handled as bool type and directly used in ansible "when" conditions.

I beleive it is a less complex aproach if ansible arguments are all strings in bash, then if the variable would be used in a condition in ansible, it can be type casted via a type filter at the place of use thus the cotributors modifying the bash code have no need to one by one investigate all the use-cases af all possible extra_var of ansible.

It has been decided to unify the extra_var syntax in the bash scripts to follow the "key=value" format.

This commit also removes an unnecessary external subnet related extra_var as it was actually both redundant and acted as a noop.

Co-authored-by: Tuomo Tanskanen <tuomo.tanskanen@est.tech>
Co-authored-by: @tuminoid
