### PR TITLE
Add firewalld cleanup

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -12,8 +12,8 @@ remove_ironic_containers
 # Remove existing pod
 if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
   for pod in ironic-pod infra-pod; do
-    if  sudo "${CONTAINER_RUNTIME}" pod exists "${pod}" ; then
-        sudo "${CONTAINER_RUNTIME}" pod rm "${pod}" -f
+    if sudo "${CONTAINER_RUNTIME}" pod exists "${pod}"; then
+      sudo "${CONTAINER_RUNTIME}" pod rm "${pod}" -f
     fi
   done
 fi
@@ -31,16 +31,15 @@ if [ "${CAPM3_RUN_LOCAL}" = true ]; then
   fi
 fi
 
-
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
-    -e "working_dir=$WORKING_DIR" \
-    -e "num_nodes=$NUM_NODES" \
-    -e "extradisks=$VM_EXTRADISKS" \
-    -e "virthost=$HOSTNAME" \
-    -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
-    -e "nodes_file=$NODES_FILE" \
-    -i vm-setup/inventory.ini \
-    -b -v vm-setup/teardown-playbook.yml
+  -e "working_dir=$WORKING_DIR" \
+  -e "num_nodes=$NUM_NODES" \
+  -e "extradisks=$VM_EXTRADISKS" \
+  -e "virthost=$HOSTNAME" \
+  -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
+  -e "nodes_file=$NODES_FILE" \
+  -i vm-setup/inventory.ini \
+  -b -v vm-setup/teardown-playbook.yml
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "use_firewalld=${USE_FIREWALLD}" \
@@ -52,16 +51,16 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
 if [[ $OS == "centos" || $OS == "rhel" ]]; then
   sudo rm -rf /etc/NetworkManager/conf.d/dnsmasq.conf
   if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
-      sudo nmcli con delete provisioning
+    sudo nmcli con delete provisioning
   fi
   # Baremetal net should have been cleaned already at this stage, but we double
   # check as leaving it around causes issues when the host is rebooted
   if [ "$MANAGE_BR_BRIDGE" == "y" ]; then
-      sudo nmcli con delete baremetal || true
+    sudo nmcli con delete baremetal || true
   fi
 fi
 
 # Clean up any serial logs
 sudo rm -rf /var/log/libvirt/qemu/*serial0.log*
 
-rm -rf  "${HOME}"/.cluster-api
+rm -rf "${HOME}"/.cluster-api

--- a/vm-setup/roles/firewall/tasks/firewalld.yaml
+++ b/vm-setup/roles/firewall/tasks/firewalld.yaml
@@ -8,7 +8,7 @@
     zone: libvirt
     interface: "{{ item }}"
     permanent: yes
-    state: enabled
+    state: "{{ firewalld_rule_state }}"
     immediate: yes
   loop:
     - "{{ provisioning_interface }}"
@@ -20,7 +20,7 @@
     zone: libvirt
     port: "{{ item }}/tcp"
     permanent: yes
-    state: enabled
+    state: "{{ firewalld_rule_state }}"
     immediate: yes
   loop: "{{ provisioning_host_ports }}"
 
@@ -29,7 +29,7 @@
     zone: libvirt
     port: "{{ item }}/tcp"
     permanent: yes
-    state: enabled
+    state: "{{ firewalld_rule_state }}"
     immediate: yes
   loop: "{{ ironic_ports }}"
 
@@ -38,7 +38,7 @@
     zone: libvirt
     port: "{{ item }}/udp"
     permanent: yes
-    state: enabled
+    state: "{{ firewalld_rule_state }}"
     immediate: yes
   loop: "{{ pxe_udp_ports }}"
 
@@ -47,7 +47,7 @@
     zone: libvirt
     port: "{{ vbmc_port_range | regex_replace(':', '-') }}/udp"
     permanent: yes
-    state: enabled
+    state: "{{ firewalld_rule_state }}"
     immediate: yes
 
 - name: "firewalld: sushy Port"
@@ -55,5 +55,5 @@
     zone: libvirt
     port: "{{ sushy_port }}/tcp"
     permanent: yes
-    state: enabled
+    state: "{{ firewalld_rule_state }}"
     immediate: yes

--- a/vm-setup/roles/firewall/tasks/main.yml
+++ b/vm-setup/roles/firewall/tasks/main.yml
@@ -3,8 +3,9 @@
   args:
     apply:
       become: true
+  vars:
+    firewalld_rule_state: "{{ 'enabled' if firewall_rule_state == 'present' else 'disabled' }}"
   when: use_firewalld | bool
-
 
 - name: "iptables"
   include_tasks: iptables.yaml


### PR DESCRIPTION
Currently, only the iptables rules could be configured to the `present` state during setup and `absent` during cleanup, while the firewalld rules were not being properly cleaned. To address this issue, we have introduced new parameters in `firewalld.yaml` that set the rules state to 'disabled' during the cleanup step.