### PR TITLE
Fix redefinition of OS variable during krew install

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -96,9 +96,9 @@ source lib/releases.sh
 ## Install krew
 if ! kubectl krew > /dev/null 2>&1; then
   cd "$(mktemp -d)" &&
-  OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+  KERNEL_OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
   ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
-  KREW="krew-${OS}_${ARCH}" &&
+  KREW="krew-${KERNEL_OS}_${ARCH}" &&
   curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
   tar zxvf "${KREW}.tar.gz" &&
   rm -f "${KREW}.tar.gz" &&


### PR DESCRIPTION
We should not redefine the OS variable during krew install because it breaks tests based on its original value assigned in common.sh Let's create and use a different variable instead with a smaller scope.