### PR TITLE
remove k8s from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,12 +54,6 @@
     },
     {
       "matchPackageNames": [
-        "kubernetes/kubernetes"
-      ],
-      "allowedVersions": "<=1.26"
-    },
-    {
-      "matchPackageNames": [
         "kindest/node"
       ],
       "allowedVersions": "<=1.26"
@@ -78,16 +72,6 @@
   "includeForks": false,
   "stabilityDays": 5,
   "regexManagers": [
-    {
-      "fileMatch": [
-        "^lib/common.sh$"
-      ],
-      "matchStrings": [
-        "KUBERNETES_VERSION:-\"(?<currentValue>.*?)\"}"
-      ],
-      "depNameTemplate": "kubernetes/kubernetes",
-      "datasourceTemplate": "github-releases"
-    },
     {
       "fileMatch": [
         "^lib/common.sh$"
@@ -140,7 +124,8 @@
     "Rozzii",
     "smoshiur1237",
     "Sunnatillo",
-    "adilGhaffarDev"
+    "adilGhaffarDev",
+    "tuminoid"
   ],
   "reviewersSampleSize": 2
 }


### PR DESCRIPTION
We always update k8s manually, and close renovate's PRs. This is extra work for everyone, so better to remove it from the config.

Add myself to renovate reviewers list.