### PR TITLE
Add support for building mariadb image

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -207,6 +207,9 @@ clone_repo "${BMOREPO}" "${BMOBRANCH}" "${BMOPATH}" "${BMOCOMMIT}"
 clone_repo "${CAPM3REPO}" "${CAPM3BRANCH}" "${CAPM3PATH}" "${CAPM3COMMIT}"
 clone_repo "${IPAMREPO}" "${IPAMBRANCH}" "${IPAMPATH}" "${IPAMCOMMIT}"
 clone_repo "${CAPIREPO}" "${CAPIBRANCH}" "${CAPIPATH}" "${CAPICOMMIT}"
+if [[ "${BUILD_MARIADB_IMAGE_LOCALLY:-}" == "true" ]]; then
+  clone_repo "${MARIADB_IMAGE_REPO}" "${MARIADB_IMAGE_BRANCH}" "${MARIADB_IMAGE_PATH}" "${MARIADB_IMAGE_COMMIT}"
+fi
 if [[ ${IRONIC_FROM_SOURCE:-} == "true" || ${BUILD_IRONIC_IMAGE_LOCALLY:-} == "true" ]]; then
     clone_repo "${IRONIC_IMAGE_REPO}" "${IRONIC_IMAGE_BRANCH}" "${IRONIC_IMAGE_PATH}" "${IRONIC_IMAGE_COMMIT}"
 fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -173,11 +173,17 @@ export IRONIC_IMAGE_REPO="${IRONIC_IMAGE_REPO:-https://github.com/metal3-io/iron
 export IRONIC_IMAGE_BRANCH="${IRONIC_IMAGE_BRANCH:-main}"
 export IRONIC_IMAGE_COMMIT="${IRONIC_IMAGE_COMMIT:-HEAD}"
 
+export MARIADB_IMAGE_PATH="${MARIADB_IMAGE_PATH:-/tmp/mariadb-image}"
+export MARIADB_IMAGE_REPO="${MARIADB_IMAGE_REPO:-https://github.com/metal3-io/mariadb-image.git}"
+export MARIADB_IMAGE_BRANCH="${MARIADB_IMAGE_BRANCH:-main}"
+export MARIADB_IMAGE_COMMIT="${MARIADB_IMAGE_COMMIT:-HEAD}"
+
 export BUILD_CAPM3_LOCALLY="${BUILD_CAPM3_LOCALLY:-false}"
 export BUILD_IPAM_LOCALLY="${BUILD_IPAM_LOCALLY:-false}"
 export BUILD_BMO_LOCALLY="${BUILD_BMO_LOCALLY:-false}"
 export BUILD_CAPI_LOCALLY="${BUILD_CAPI_LOCALLY:-false}"
 export BUILD_IRONIC_IMAGE_LOCALLY="${BUILD_IRONIC_IMAGE_LOCALLY:-false}"
+export BUILD_MARIADB_IMAGE_LOCALLY="${BUILD_MARIADB_IMAGE_LOCALLY:-false}"
 
 # If IRONIC_FROM_SOURCE has a "true" value that
 # automatically requires BUILD_IRONIC_IMAGE_LOCALLY to have "true" value too
@@ -201,6 +207,9 @@ fi
 if [[ "${BUILD_IRONIC_IMAGE_LOCALLY}" == "true" ]]; then
   export IRONIC_LOCAL_IMAGE="${IRONIC_IMAGE_PATH}"
 fi
+if [[ "${BUILD_MARIADB_IMAGE_LOCALLY}" == "true" ]]; then
+  export MARIADB_LOCAL_IMAGE="${MARIADB_IMAGE_PATH}"
+fi
 
 export BMO_RUN_LOCAL="${BMO_RUN_LOCAL:-false}"
 export CAPM3_RUN_LOCAL="${CAPM3_RUN_LOCAL:-false}"
@@ -222,6 +231,7 @@ export MAX_SURGE_VALUE="${MAX_SURGE_VALUE:-"1"}"
 export IRONIC_TAG="${IRONIC_TAG:-latest}"
 export BARE_METAL_OPERATOR_TAG="${BARE_METAL_OPERATOR_TAG:-latest}"
 export KEEPALIVED_TAG="${KEEPALIVED_TAG:-latest}"
+export MARIADB_TAG="${MARIADB_TAG:-latest}"
 
 # Docker Hub proxy registry (or docker.io if no proxy)
 export DOCKER_HUB_PROXY=${DOCKER_HUB_PROXY:-"docker.io"}
@@ -242,7 +252,6 @@ export IRONIC_BASIC_AUTH=${IRONIC_BASIC_AUTH:-"true"}
 export IPA_DOWNLOADER_IMAGE=${IPA_DOWNLOADER_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ironic-ipa-downloader"}
 export IRONIC_IMAGE=${IRONIC_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ironic:${IRONIC_TAG}"}
 export IRONIC_CLIENT_IMAGE=${IRONIC_CLIENT_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ironic-client"}
-export MARIADB_IMAGE=${MARIADB_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/mariadb"}
 export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
 export IRONIC_IMAGE_DIR="$IRONIC_DATA_DIR/html/images"
 export IRONIC_NAMESPACE=${IRONIC_NAMESPACE:-"baremetal-operator-system"}
@@ -278,6 +287,7 @@ fi
 
 
 export IRONIC_KEEPALIVED_IMAGE="${IRONIC_KEEPALIVED_IMAGE:-${CONTAINER_REGISTRY}/metal3-io/keepalived:${KEEPALIVED_TAG}}"
+export MARIADB_IMAGE="${MARIADB_IMAGE:-${CONTAINER_REGISTRY}/metal3-io/mariadb:${MARIADB_TAG}}"
 
 # Enable ironic restart feature when the TLS certificate is updated
 export RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-${IRONIC_TLS_SETUP}}

--- a/vars.md
+++ b/vars.md
@@ -103,16 +103,21 @@ assured that they are persisted.
 | IPAMREPO | IP Address Manager git repository URL | | https://github.com/metal3-io/ip-address-manageri/ |
 | IPAMBRANCH | IP Address Manager git repository branch to checkout | | main |
 | IPAMCOMMIT | IP Address Manager git commit to checkout on IPAMBRANCH | | HEAD |
-|IRONIC_IMAGE_PATH | Path to clone the Metal3's ironic-image Git repository to | | /tmp/ironic-image  |
-|IRONIC_IMAGE_REPO | Metal3's ironic-image Git repository address | | https://github.com/metal3-io/ironic-image.git |
-|IRONIC_IMAGE_BRANCH | Metal3's ironic-image Git repository branch | | main |
-|IRONIC_IMAGE_COMMIT | Metal3's ironic-image | | HEAD |
+| IRONIC_IMAGE_PATH | Path to clone the Metal3's ironic-image Git repository to | | /tmp/ironic-image  |
+| IRONIC_IMAGE_REPO | Metal3's ironic-image Git repository address | | https://github.com/metal3-io/ironic-image.git |
+| IRONIC_IMAGE_BRANCH | Metal3's ironic-image Git repository branch | | main |
+| IRONIC_IMAGE_COMMIT | Metal3's ironic-image | | HEAD |
+| MARIADB_IMAGE_PATH | Path to clone the mariadb-image Git repository to | | /tmp/mariadb-image  |
+| MARIADB_IMAGE_REPO | mariadb-image Git repository address | | https://github.com/metal3-io/mariadb-image.git |
+| MARIADB_IMAGE_BRANCH | mariadb-mage branch to checkout | | main |
+| MARIADB_IMAGE_COMMIT | mariadb-image commit to checkout | | HEAD |
 | FORCE_REPO_UPDATE | discard existing directories | "true","false" | "true" |
 | BUILD_CAPM3_LOCALLY | build Cluster API Provider Metal3 based on CAPM3PATH | "true","false" | "false" |
 | BUILD_IPAM_LOCALLY | build IP Address Manager based on IPAMPATH | "true","false" | "false" |
 | BUILD_BMO_LOCALLY | build Baremetal Operator based on BMOPATH | "true","false" | "false" |
 | BUILD_CAPI_LOCALLY | build Cluster API based on CAPIPATH | "true","false" | "false" |
 | BUILD_IRONIC_IMAGE_LOCALLY | build the Metal3's ironic-image based on IRONIC_IMAGE_PATH | "true","false" | "false" |
+| BUILD_MARIADB_IMAGE_LOCALLY | build the MariaDB container image based on MARIADB_IMAGE_PATH | "true", "false" | "false" |
 | IRONIC_FROM_SOURCE | installs ironic from source during container image building, if `true` then the `BUILD_IRONIC_IMAGE_LOCALLY` will be also set to `true` | "true","false" | "false" |
 | DHCP_HOSTS | A list of `;` separated dhcp-host directives for dnsmasq | e.g. `00:20:e0:3b:13:af;00:20:e0:3b:14:af` | |
 | DHCP_IGNORE | A set of tags on hosts to be ignored by dnsmasq | e.g. `tag:!known` | |


### PR DESCRIPTION
This adds support for building the mariadb container image in metal3-dev-env. It works similar to other container images, with a variable for where the repository is, where it should be cloned, what branch and commit to check out. Please note that it is not enough to just configure local image building, you also have to specify that mariadb should be used instead of sqlite but setting `IRONIC_USE_MARIADB="true"`.
The default behavior does not change. I.e. if nothing is specified, it will use sqlite instead of mariadb.

Part of #931 