### PR TITLE
 Fix IPA_BASEURI default value

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -237,8 +237,8 @@ if [[ "${IPA_DOWNLOAD_ENABLED}" = "true" ]] || [[ ! -r "${IRONIC_DATA_DIR}/html/
     for i in {1..5}; do
         echo "Attempting to download IPA. $i/5"
         #shellcheck disable=SC2086
-        sudo "${CONTAINER_RUNTIME}" run --rm --net host --name ipa-downloader "${POD_NAME}" \
-          -e "IPA_BASEURI=${IPA_BASEURI}" \
+        sudo "${CONTAINER_RUNTIME}" run --rm --net host --name ipa-downloader ${POD_NAME} \
+          -e "IPA_BASEURI=${IPA_BASEURI:-}" \
           -v "${IRONIC_DATA_DIR}:/shared" "${IPA_DOWNLOADER_IMAGE}" \
           /bin/bash -c "/usr/local/bin/get-resource.sh &> /dev/null" && s=0 && break || s=$?
     done


### PR DESCRIPTION
On our local development environment the file ironic-python-agent.kernel did not exist due to which it tried to download it which caused the command to fail since IPA_BASEURI env variable was not set to any default value. We have set it to a default value to fix this issue. Other than that, we removed the quotes around the POD_NAME env variable since this command was executed by docker and it considers the quotes as part of the variable causing crash as well.