### PR TITLE
Fix manifest image update and image tag for Keepalived

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -54,6 +54,11 @@ if [ "${EPHEMERAL_CLUSTER}" != "tilt" ]; then
   else
     update_component_image BMO "${BARE_METAL_OPERATOR_IMAGE}"
   fi
+  if [ -n "${IRONIC_KEEPALIVED_LOCAL_IMAGE:-}" ]; then
+    update_component_image Keepalived "${IRONIC_KEEPALIVED_LOCAL_IMAGE}"
+  else
+    update_component_image Keepalived "${IRONIC_KEEPALIVED_IMAGE}"
+  fi
 fi
 
   # Update Configmap parameters with correct urls

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -256,7 +256,6 @@ export IRONIC_IMAGE=${IRONIC_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ironic:${IR
 export IRONIC_CLIENT_IMAGE=${IRONIC_CLIENT_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ironic-client"}
 export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
 export IRONIC_IMAGE_DIR="$IRONIC_DATA_DIR/html/images"
-export IRONIC_KEEPALIVED_IMAGE="${IRONIC_KEEPALIVED_IMAGE:-${CONTAINER_REGISTRY}/metal3-io/keepalived}"
 export IRONIC_NAMESPACE="${IRONIC_NAMESPACE:-baremetal-operator-system}"
 export NAMEPREFIX="${NAMEPREFIX:-baremetal-operator}"
 


### PR DESCRIPTION
when a PR is going in BMO, keepalived image is also rebuilt locally it was not correctly updated in manifest. This PR would fix it. 

This PR also fixes a bug which was exporting keepalived image before the correct tag was determined.