### PR TITLE
Fix manifest collection for integration test

### DIFF
--- a/tests/roles/run_tests/vars/main.yml
+++ b/tests/roles/run_tests/vars/main.yml
@@ -125,7 +125,6 @@ verify_actions:
     - "pivoting"
     - "healthcheck"
 pivot_actions:
-    - "ci_test_provision"
     - "pivoting"
 repivot_actions:
     - "repivoting"

--- a/tests/scripts/fetch_manifests.sh
+++ b/tests/scripts/fetch_manifests.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 set -x
-mkdir -p /tmp/manifests
+DIR_NAME="/tmp/manifests/bootstrap"
+mkdir -p "${DIR_NAME}"
 
 manifests=(
   bmh
@@ -28,10 +29,12 @@ manifests=(
   m3datatemplate
 )
 
-for kind in "${manifests[@]}"; do
-  mkdir -p /tmp/manifests/"$kind"
-  for name in $(kubectl get -n metal3 -o name "$kind" || true)
-  do
-    kubectl get -n metal3 -o yaml "$name" | tee /tmp/manifests/"$kind"/"$(basename "$name")".yaml || true
+NAMESPACES="$(kubectl get namespace -o jsonpath='{.items[*].metadata.name}')"
+for NAMESPACE in ${NAMESPACES}; do
+  for kind in "${manifests[@]}"; do
+    mkdir -p "${DIR_NAME}/${kind}"
+    for name in $(kubectl get -n "${NAMESPACE}" -o name "${kind}" || true); do
+      kubectl get -n "${NAMESPACE}" -o yaml "${name}" | tee "${DIR_NAME}/${kind}/$(basename "${name}").yaml" || true
+    done
   done
 done

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -11,6 +11,12 @@ export ACTION="ci_test_provision"
 
 "${METAL3_DIR}"/tests/run.sh
 
+"${METAL3_DIR}"/tests/scripts/fetch_manifests.sh
+
+export ACTION="pivoting"
+
+"${METAL3_DIR}"/tests/run.sh
+
 "${METAL3_DIR}"/tests/scripts/fetch_target_logs.sh
 
 export ACTION="repivoting"
@@ -23,8 +29,6 @@ do
     status=$(kubectl get m3m -n "${NAMESPACE}" -o=jsonpath="{.items[*]['status.ready']}")
     sleep 1s
 done
-
-"${METAL3_DIR}"/tests/scripts/fetch_manifests.sh
 
 kubectl get secrets "${CLUSTER_NAME}-kubeconfig" -n "${NAMESPACE}" -o json | jq -r '.data.value'| base64 -d > "/tmp/kubeconfig-${CLUSTER_NAME}.yaml"
 NUM_DEPLOYED_NODES="$(kubectl get nodes --kubeconfig "/tmp/kubeconfig-${CLUSTER_NAME}.yaml" | grep -c -w Ready)"


### PR DESCRIPTION
This PR will fix the manifest collection in case of failed integration test. It should be collected before pivot during integration test.