### PR TITLE
Fix BMOBRANCH based on CAPM3 release branch. 

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -174,7 +174,7 @@ EOF
   fi
 
   # Copy the generated configmap for ironic deployment
-  if [[ ${BMOBRANCH} == "v0.1.2" ]] || [[ ${BMOBRANCH} == "v0.1.1" ]]; then # BMORELEASE until v0.1.2 used the old path TODO(mboukhalfa) can be removed after new bmo release
+  if [[ ${BMOBRANCH} == "v0.1.2" ]] || [[ ${BMOBRANCH} == "v0.1.1" ]]; then # BMOBRANCH until v0.1.2 used the old path TODO(mboukhalfa) can be removed once old releases are obsolete
     cp "${IRONIC_DATA_DIR}/ironic_bmo_configmap.env" "${BMOPATH}/ironic-deployment/keepalived/ironic_bmo_configmap.env"
   else
     cp "${IRONIC_DATA_DIR}/ironic_bmo_configmap.env"  "${BMOPATH}/ironic-deployment/components/keepalived/ironic_bmo_configmap.env"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -268,24 +268,24 @@ elif [[ "${CAPM3RELEASEBRANCH}" = "release-1.1" ]]; then
   export IPAM_IMAGE=${IPAM_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ip-address-manager:release-1.1"}
   export BARE_METAL_OPERATOR_TAG="v0.1.1"
   export KEEPALIVED_TAG="v0.1.1"
-  export BMORELEASE="v0.1.1"
+  export BMOBRANCH="${BMOBRANCH:-v0.1.1}"
 elif [[ "${CAPM3RELEASEBRANCH}" = "release-1.2" ]]; then
   export CAPM3_IMAGE=${CAPM3_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/cluster-api-provider-metal3:release-1.2"}
   export IPAM_IMAGE=${IPAM_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ip-address-manager:release-1.2"}
   export BARE_METAL_OPERATOR_TAG="v0.1.2"
   export KEEPALIVED_TAG="v0.1.2"
-  export BMORELEASE="v0.1.2"
+  export BMOBRANCH="${BMOBRANCH:-v0.1.2}"
 elif [[ "${CAPM3RELEASEBRANCH}" = "release-1.3" ]]; then
   export CAPM3_IMAGE=${CAPM3_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/cluster-api-provider-metal3:release-1.3"}
   export IPAM_IMAGE=${IPAM_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ip-address-manager:release-1.3"}
   export BARE_METAL_OPERATOR_TAG="v0.2.0"
   export KEEPALIVED_TAG="v0.2.0"
-  export BMORELEASE="v0.2.0"
+  export BMOBRANCH="${BMOBRANCH:-v0.2.0}"
 else
   export CAPM3_IMAGE="${CAPM3_IMAGE:-${CONTAINER_REGISTRY}/metal3-io/cluster-api-provider-metal3:main}"
   export IPAM_IMAGE="${IPAM_IMAGE:-${CONTAINER_REGISTRY}/metal3-io/ip-address-manager:main}"
+  export BMOBRANCH="${BMOBRANCH:-main}"
 fi
-
 
 export IRONIC_KEEPALIVED_IMAGE="${IRONIC_KEEPALIVED_IMAGE:-${CONTAINER_REGISTRY}/metal3-io/keepalived:${KEEPALIVED_TAG}}"
 export MARIADB_IMAGE="${MARIADB_IMAGE:-${CONTAINER_REGISTRY}/metal3-io/mariadb:${MARIADB_TAG}}"

--- a/lib/releases.sh
+++ b/lib/releases.sh
@@ -46,7 +46,6 @@ function get_latest_release() {
 # CAPM3, CAPI and BMO release path
 CAPM3RELEASEPATH="{https://api.github.com/repos/${CAPM3_BASE_URL:-metal3-io/cluster-api-provider-metal3}/releases}"
 CAPIRELEASEPATH="{https://api.github.com/repos/${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}/releases}"
-BMORELEASEPATH="{https://api.github.com/repos/${BMO_BASE_URL:-metal3-io/baremetal-operator}/releases}"
 
 # CAPM3, CAPI and BMO releases
 if [ "${CAPM3RELEASEBRANCH}" == "release-0.5" ]; then
@@ -68,10 +67,7 @@ else
   export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v1.4.")}"
 fi
 
-export BMORELEASE="${BMORELEASE:-$(get_latest_release "${BMORELEASEPATH}" "v0.2.")}"
-
 CAPIBRANCH="${CAPIBRANCH:-${CAPIRELEASE}}"
-BMOBRANCH="${BMOBRANCH:-${BMORELEASE}}"
 
 # On first iteration, jq might not be installed
 if [[ "$CAPIRELEASE" == "" ]]; then
@@ -80,8 +76,4 @@ fi
 
 if [[ "$CAPM3RELEASE" == "" ]]; then
   command -v jq &>/dev/null && echo "Failed to fetch CAPM3 release from Github" && exit 1
-fi
-
-if [[ "$BMORELEASE" == "" ]]; then
-  command -v jq &>/dev/null && echo "Failed to fetch BMO release from Github" && exit 1
 fi


### PR DESCRIPTION
Previously this was being set from project-infra but only for main branch periodic tests. This makes sure BMOBRANCH is main not only for periodic tests but also for PR jobs. Related to https://github.com/metal3-io/project-infra/pull/507.

Also it does not make any sense to fetch BMORELEASE in lib/releases anymore since different CAPM3 branch are tested with different BMO releases. So the easiest and cleanest way would be to set it upfront based on the branch. 