### PR TITLE
Remove leftover ISO images from the default pool

### DIFF
--- a/vm-setup/roles/libvirt/tasks/vm_teardown_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/vm_teardown_tasks.yml
@@ -97,3 +97,6 @@
       file:
         path: "{{ nodes_file }}"
         state: absent
+
+    - name: Remove any leftover ISO images
+      command: find /var/lib/libvirt/images/ -type f -name 'boot-*-iso-*' -delete


### PR DESCRIPTION
The redfish emulator creates these. In case of a tear down, they will
not be deleted and may occupy a lot of disk space.
