### PR TITLE
Add manifest collection after re-pivot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ pivoting_test:
 repivoting_test:
 	make -C ./tests/feature_tests/pivoting/ fetch_target_logs
 	make -C ./tests/feature_tests/pivoting/ repivoting
+	make -C ./tests/feature_tests/pivoting/ fetch_manifests
 	make -C ./tests//feature_tests/pivoting/ deprovision
 
 remediation_test:

--- a/tests/scripts/fetch_manifests.sh
+++ b/tests/scripts/fetch_manifests.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
 set -x
-DIR_NAME="/tmp/manifests/bootstrap"
-mkdir -p "${DIR_NAME}"
+
+DIR_NAME="/tmp/manifests/bootstrap-before-pivot"
+
+# Check if manifest directory exists
+if [ -d "${DIR_NAME}" ]; then
+  DIR_NAME="/tmp/manifests/bootstrap-after-repivot"
+  mkdir -p "${DIR_NAME}"
+else
+  mkdir -p "${DIR_NAME}"
+fi
 
 manifests=(
   bmh

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -10,6 +10,7 @@ export ACTION="ci_test_provision"
 
 "${METAL3_DIR}"/tests/run.sh
 
+# Manifest collection before pivot
 "${METAL3_DIR}"/tests/scripts/fetch_manifests.sh
 
 export ACTION="pivoting"
@@ -28,6 +29,9 @@ do
     status=$(kubectl get m3m -n "${NAMESPACE}" -o=jsonpath="{.items[*]['status.ready']}")
     sleep 1s
 done
+
+# Manifest collection after re-pivot
+"${METAL3_DIR}"/tests/scripts/fetch_manifests.sh
 
 kubectl get secrets "${CLUSTER_NAME}-kubeconfig" -n "${NAMESPACE}" -o json | jq -r '.data.value'| base64 -d > "/tmp/kubeconfig-${CLUSTER_NAME}.yaml"
 NUM_DEPLOYED_NODES="$(kubectl get nodes --kubeconfig "/tmp/kubeconfig-${CLUSTER_NAME}.yaml" | grep -c -w Ready)"


### PR DESCRIPTION
This change will allow the manifest collection both before pivot and after re-pivot.