### PR TITLE
Exclude install requirement script from CI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 all: install_requirements configure_host launch_mgmt_cluster verify
 
+ci_run: configure_host launch_mgmt_cluster verify
+
 install_requirements:
 	./01_prepare_host.sh
 
@@ -59,4 +61,4 @@ healthcheck_test:
 
 feature_tests: setup_env inspection_test remediation_test healthcheck_test cleanup_env pivoting_test node_reuse_test repivoting_test
 
-.PHONY: all install_requirements configure_host launch_mgmt_cluster clean delete_mgmt_cluster host_cleanup verify test lint
+.PHONY: all ci_run install_requirements configure_host launch_mgmt_cluster clean delete_mgmt_cluster host_cleanup verify test lint

--- a/lib/image_prepull.sh
+++ b/lib/image_prepull.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# shellcheck disable=SC1091
+source lib/images.sh
+
+mkdir -p "${IRONIC_IMAGE_DIR}"
+pushd "${IRONIC_IMAGE_DIR}"
+# Downloading image if it does not exist locally
+if [[ ! -f "${IMAGE_NAME}" ]]; then
+    wget --no-verbose --no-check-certificate "${IMAGE_LOCATION}/${IMAGE_NAME}"
+    IMAGE_SUFFIX="${IMAGE_NAME##*.}"
+    if [[ "${IMAGE_SUFFIX}" = "xz" ]]; then
+      unxz -v "${IMAGE_NAME}"
+      IMAGE_NAME="$(basename "${IMAGE_NAME}" .xz)"
+      export IMAGE_NAME
+      IMAGE_BASE_NAME="${IMAGE_NAME%.*}"
+      export IMAGE_RAW_NAME="${IMAGE_BASE_NAME}-raw.img"
+    fi
+    if [[ "${IMAGE_SUFFIX}" = "bz2" ]]; then
+        bunzip2 "${IMAGE_NAME}"
+        IMAGE_NAME="$(basename "${IMAGE_NAME}" .bz2)"
+        export IMAGE_NAME
+        IMAGE_BASE_NAME="${IMAGE_NAME%.*}"
+        export IMAGE_RAW_NAME="${IMAGE_BASE_NAME}-raw.img"
+    fi
+    if [[ "${IMAGE_SUFFIX}" != "iso" ]]; then
+        qemu-img convert -O raw "${IMAGE_NAME}" "${IMAGE_RAW_NAME}"
+    fi
+fi
+# Generating image checksum if right checksum does not exist locally
+if [[ ! -f "${IMAGE_RAW_NAME}.${IMAGE_RAW_CHECKSUM##*.}" ]]; then
+    IMAGE_SUFFIX="${IMAGE_NAME##*.}"
+    if [[ "${IMAGE_SUFFIX}" != "iso" ]]; then
+        sha256sum "${IMAGE_RAW_NAME}" | awk '{print $1}' > "${IMAGE_RAW_NAME}.sha256sum"
+    fi
+fi
+popd
+
+# NOTE(elfosardo): workaround for https://github.com/moby/moby/issues/44970
+# should be fixed in docker-ce 23.0.2
+if [[ "${OS}" = "ubuntu" ]]; then
+  sudo systemctl restart docker
+fi
+
+# Pulling all the images except any local image.
+for IMAGE_VAR in $(env | grep -v "_LOCAL_IMAGE=" | grep "_IMAGE=" | grep -o "^[^=]*") ; do
+  IMAGE="${!IMAGE_VAR}"
+  sudo "${CONTAINER_RUNTIME}" pull "${IMAGE}"
+ done

--- a/tests/feature_tests/setup_env.sh
+++ b/tests/feature_tests/setup_env.sh
@@ -8,4 +8,4 @@ M3PATH="$(dirname "$(readlink -f "${0}")")/../.."
 source "${M3PATH}/tests/feature_tests/feature_test_vars.sh"
 
 pushd "${M3PATH}" || exit
-make
+make ci_run


### PR DESCRIPTION
As we are running 01_prepare_host script when building new image, CI run doesn't need to run the install script again during CI run. So this PR will move some parts of the 01_prepare_host script to 02_configure_host script and exclude the 01_prepare_host script from integration test and feature test in dev-env.