### PR TITLE
Move clusterctl installation to support older version of releases

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -159,20 +159,6 @@ if [[ ! -r "${BASH_COMPLETION}" ]]; then
   kubectl completion bash | sudo tee "${BASH_COMPLETION}"
 fi
 
-# Install clusterctl client
-install_clusterctl() {
-  wget --no-verbose -O clusterctl "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPIRELEASE}/clusterctl-linux-amd64"
-  chmod +x ./clusterctl
-  sudo mv ./clusterctl /usr/local/bin/
-}
-
-if ! [[ -x "$(command -v clusterctl)" ]]; then
-  install_clusterctl
-elif [[ "$(clusterctl version | grep -o -P '(?<=GitVersion:").*?(?=",)')" != "${CAPIRELEASE}" ]]; then
-  sudo rm /usr/local/bin/clusterctl
-  install_clusterctl
-fi
-
 # Clean-up any old ironic containers
 remove_ironic_containers
 

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -359,6 +359,20 @@ function patch_clusterctl(){
   popd
 }
 
+# Install clusterctl client
+install_clusterctl() {
+  wget --no-verbose -O clusterctl "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPIRELEASE}/clusterctl-linux-amd64"
+  chmod +x ./clusterctl
+  sudo mv ./clusterctl /usr/local/bin/
+}
+
+if ! [[ -x "$(command -v clusterctl)" ]]; then
+  install_clusterctl
+elif [[ "$(clusterctl version | grep -o -P '(?<=GitVersion:").*?(?=",)')" != "${CAPIRELEASE}" ]]; then
+  sudo rm /usr/local/bin/clusterctl
+  install_clusterctl
+fi
+
 #
 # Launch the cluster-api provider metal3.
 #


### PR DESCRIPTION
Currently we are not using 01 script for our CI run which creates an issue with the version of clusterctl. Moving the installation of clusterctl before cluster init will solve the issue. 