### PR TITLE
Drop CAPM3 release-1.1 test support

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,4 +188,3 @@ The following table describes which branches are tested for different test trigg
 | release-1-4 | release-1.4  | release-1.4  | v0.3.0          | v0.3.0         |
 | release-1-3 | release-1.3  | release-1.3  | v0.2.0          | v0.2.0         |
 | release-1-2 | release-1.2  | release-1.2  | v0.1.2          | v0.1.2         |
-| release-1-1 | release-1.1  | release-1.1  | v0.1.1          | v0.1.1         |

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -139,10 +139,7 @@ export CAPM3_BASE_URL="${CAPM3_BASE_URL:-metal3-io/cluster-api-provider-metal3}"
 export CAPM3REPO="${CAPM3REPO:-https://github.com/${CAPM3_BASE_URL}}"
 export CAPM3RELEASEBRANCH="${CAPM3RELEASEBRANCH:-main}"
 
-if [[ "${CAPM3RELEASEBRANCH}" == "release-1.1" ]]; then
-  export CAPM3BRANCH="${CAPM3BRANCH:-release-1.1}"
-  export IPAMBRANCH="${IPAMBRANCH:-release-1.1}"
-elif [[ "${CAPM3RELEASEBRANCH}" == "release-1.2" ]]; then
+if [[ "${CAPM3RELEASEBRANCH}" == "release-1.2" ]]; then
   export CAPM3BRANCH="${CAPM3BRANCH:-release-1.2}"
   export IPAMBRANCH="${IPAMBRANCH:-release-1.2}"
 elif [[ "${CAPM3RELEASEBRANCH}" == "release-1.3" ]]; then
@@ -260,13 +257,7 @@ export IRONIC_NAMESPACE="${IRONIC_NAMESPACE:-baremetal-operator-system}"
 export NAMEPREFIX="${NAMEPREFIX:-baremetal-operator}"
 
 # CAPM3 and IPAM controller images
-if [[ "${CAPM3RELEASEBRANCH}" = "release-1.1" ]]; then
-  export CAPM3_IMAGE=${CAPM3_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/cluster-api-provider-metal3:release-1.1"}
-  export IPAM_IMAGE=${IPAM_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ip-address-manager:release-1.1"}
-  export BARE_METAL_OPERATOR_TAG="v0.1.1"
-  export KEEPALIVED_TAG="v0.1.1"
-  export BMOBRANCH="${BMOBRANCH:-v0.1.1}"
-elif [[ "${CAPM3RELEASEBRANCH}" = "release-1.2" ]]; then
+if [[ "${CAPM3RELEASEBRANCH}" = "release-1.2" ]]; then
   export CAPM3_IMAGE=${CAPM3_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/cluster-api-provider-metal3:release-1.2"}
   export IPAM_IMAGE=${IPAM_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ip-address-manager:release-1.2"}
   export BARE_METAL_OPERATOR_TAG="v0.1.2"

--- a/lib/releases.sh
+++ b/lib/releases.sh
@@ -48,10 +48,7 @@ CAPM3RELEASEPATH="{https://api.github.com/repos/${CAPM3_BASE_URL:-metal3-io/clus
 CAPIRELEASEPATH="{https://api.github.com/repos/${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}/releases}"
 
 # CAPM3, CAPI and BMO releases
-if [ "${CAPM3RELEASEBRANCH}" == "release-1.1" ]; then
-  export CAPM3RELEASE="${CAPM3RELEASE:-$(get_latest_release "${CAPM3RELEASEPATH}" "v1.1.")}"
-  export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v1.1.")}"
-elif [ "${CAPM3RELEASEBRANCH}" == "release-1.2" ]; then
+if [ "${CAPM3RELEASEBRANCH}" == "release-1.2" ]; then
   export CAPM3RELEASE="${CAPM3RELEASE:-$(get_latest_release "${CAPM3RELEASEPATH}" "v1.2.")}"
   export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v1.2.")}"
 elif [ "${CAPM3RELEASEBRANCH}" = "release-1.3" ]; then


### PR DESCRIPTION
This PR drops the test support for CAPM3/IPAM release-1.1 branch. 