### PR TITLE
pin downloaded scripts and binaries to a sha digest

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -360,6 +360,9 @@ function patch_clusterctl(){
 }
 
 # Install clusterctl client
+# TODO: use download_and_verify_clusterctl
+# Currently we just download latest CAPIRELEASE version, which means we don't know
+# the expected SHA, and can't pin it
 install_clusterctl() {
   wget --no-verbose -O clusterctl "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPIRELEASE}/clusterctl-linux-amd64"
   chmod +x ./clusterctl

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -59,8 +59,8 @@ export OS_VERSION_ID="${VERSION_ID}"
 export SUPPORTED_DISTROS=(centos8 centos9 rhel8 rhel9 ubuntu18 ubuntu20 ubuntu22)
 
 if [[ ! "${SUPPORTED_DISTROS[*]}" =~ ${DISTRO} ]]; then
-   echo "Supported OS distros for the host are: CentOS Stream 8/9 or RHEL8/9 or Ubuntu20.04 or Ubuntu 22.04"
-   exit 1
+  echo "Supported OS distros for the host are: CentOS Stream 8/9 or RHEL8/9 or Ubuntu20.04 or Ubuntu 22.04"
+  exit 1
 fi
 
 # Container runtime
@@ -309,24 +309,41 @@ else
   export EPHEMERAL_CLUSTER="minikube"
 fi
 
+# Kubectl version
+export KUBECTL_VERSION="${KUBECTL_VERSION:-${KUBERNETES_BINARIES_VERSION}}"
+export KUBECTL_SHA256="7fe3a762d926fb068bae32c399880e946e8caf3d903078bea9b169dcd5c17f6d"
+
+# Krew version
+export KREW_VERSION="${KREW_VERSION:-v0.4.3}"
+export KREW_SHA256="5df32eaa0e888a2566439c4ccb2ef3a3e6e89522f2f2126030171e2585585e4f"
+
 # Kustomize version
 export KUSTOMIZE_VERSION="${KUSTOMIZE_VERSION:-v4.4.1}"
+export KUSTOMIZE_SHA256="2d5927efec40ba32a121c49f6df9955b8b8a296ef1dec4515a46fc84df158798"
 
 # Minikube version (if EPHEMERAL_CLUSTER=minikube)
 export MINIKUBE_VERSION="${MINIKUBE_VERSION:-v1.30.1}"
+export MINIKUBE_SHA256="e53d9e8c31f4c5f683182f5323d3527aa0725f713945c6d081cf71aa548ab388"
+export MINIKUBE_DRIVER_SHA256="293833bb1dda970ca167fc2c8e80207f1a6782db374ed5e4b2a959a2f6783e5e"
 
 # Kind, kind node image versions (if EPHEMERAL_CLUSTER=kind)
 export KIND_VERSION=${KIND_VERSION:-"v0.19.0"}
-export KIND_NODE_IMAGE_VERSION=${KIND_NODE_IMAGE_VERSION:-"v1.27.1"}
+export KIND_SHA256="b543dca8440de4273be19ad818dcdfcf12ad1f767c962242fcccdb383dff893b"
 
+export KIND_NODE_IMAGE_VERSION=${KIND_NODE_IMAGE_VERSION:-"v1.27.1"}
 export KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-${DOCKER_HUB_PROXY}/kindest/node:${KIND_NODE_IMAGE_VERSION}}"
+
+# Tilt
+export TILT_VERSION="${TILT_VERSION:-v0.32.3}"
+export TILT_SHA256="b30ebbba68d4fd04f8afa11efc439515241dbcc2582eac2ced3e9fad09ce8318"
 
 # Ansible version
 # Older ubuntu version do no support 7.0.0 because of older python versions
 # Ubuntu 18/Centos8 have 4.10.0 as latest ansible
-# Ansible 7.0.0 requires python 3.10+
+# Ansible 7.0.0 or newer requires python 3.10+
+# TODO: Ansible pinning
 if [[ "${DISTRO}" = "ubuntu22" ]]; then
-    export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"8.0.0"}
+    export ANSIBLE_VERSION="${ANSIBLE_VERSION:-8.0.0}"
 elif [[ "${DISTRO}" = "ubuntu18" ]] || [[ "${DISTRO}" = "centos8" ]]; then
     export ANSIBLE_VERSION="${ANSIBLE_VERSION:-4.10.0}"
 else

--- a/lib/download.sh
+++ b/lib/download.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# utils to download and verify binary downloads in shell scripts
+#
+# this expects lib/common.sh to be sourced
+
+# set to true for testing without having to also change digests
+INSECURE_SKIP_DOWNLOAD_VERIFICATION="${INSECURE_SKIP_DOWNLOAD_VERIFICATION:-false}"
+
+# pip can't take hashes on the command line, so we need to create
+# temporary rqeuirements file with the hash and then clean it up
+pip_install_with_hash()
+{
+    local pkg_and_version="${1:?package==version missing}"
+    local sha256="${2:?sha256 missing}"
+    local tmpfile
+
+    if [[ "${INSECURE_SKIP_DOWNLOAD_VERIFICATION}" == "true" ]]; then
+        sudo python -m pip install "${pkg_and_version}"
+    else
+        tmpfile="$(mktemp)"
+        echo "${pkg_and_version} --hash=sha256:${sha256}" > "${tmpfile}"
+        sudo python -m pip install --require-hashes -r "${tmpfile}"
+        rm -f "${tmpfile}"
+    fi
+}
+
+# download an url and verify the downloaded object has the same sha as
+# supplied in the function call
+wget_and_verify()
+{
+    local url="${1:?url missing}"
+    local sha256="${2:?sha256 missing}"
+    local target="${3:?target missing}"
+    local checksum
+
+    declare -a args=(
+        --no-verbose
+        -O "${target}"
+        "${url}"
+    )
+
+    wget "${args[@]}"
+
+    checksum="$(sha256sum "${target}" | awk '{print $1;}')"
+    if [[ "${checksum}" != "${sha256}" ]]; then
+        if [[ "${INSECURE_SKIP_DOWNLOAD_VERIFICATION}" == "true" ]]; then
+            echo >&2 "warning: ${url} binary checksum '${checksum}' differs from expected checksum '${sha256}'"
+        else
+            echo >&2 "fatal: ${url} binary checksum '${checksum}' differs from expected checksum '${sha256}'"
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+download_and_install_krew()
+{
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
+    pushd "${tmp_dir}" || return 1
+
+    KERNEL_OS="$(uname | tr '[:upper:]' '[:lower:]')"
+    ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
+    KREW="krew-${KERNEL_OS}_${ARCH}"
+    KREW_URL="https://github.com/kubernetes-sigs/krew/releases/download/${KREW_VERSION}/${KREW}.tar.gz"
+    wget_and_verify "${KREW_URL}" "${KREW_SHA256}" "${KREW}.tar.gz"
+    tar zxvf "${KREW}.tar.gz"
+    rm -f "${KREW}.tar.gz"
+    ./"${KREW}" install krew
+
+    # Add krew to PATH by appending this line to .bashrc
+    krew_path_bashrc="export PATH=${KREW_ROOT:-${HOME}/.krew}/bin:${PATH}"
+    grep -qxF "${krew_path_bashrc}" ~/.bashrc || echo "${krew_path_bashrc}" >> ~/.bashrc
+    popd || return 1
+}
+
+download_and_install_minikube()
+{
+    MINIKUBE_URL="https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64"
+    MINIKUBE_BINARY="minikube"
+
+    wget_and_verify "${MINIKUBE_URL}" "${MINIKUBE_SHA256}" "${MINIKUBE_BINARY}"
+    chmod +x "${MINIKUBE_BINARY}"
+    sudo mv "${MINIKUBE_BINARY}" /usr/local/bin/
+}
+
+download_and_install_kvm2_driver()
+{
+    DRIVER_URL="https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/docker-machine-driver-kvm2"
+    DRIVER_BINARY="docker-machine-driver-kvm2"
+
+    wget_and_verify "${DRIVER_URL}" "${MINIKUBE_DRIVER_SHA256}" "${DRIVER_BINARY}"
+    chmod +x "${DRIVER_BINARY}"
+    sudo mv "${DRIVER_BINARY}" /usr/local/bin/
+}
+
+download_and_install_kind()
+{
+    KIND_URL="https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64"
+    KIND_BINARY="kind"
+
+    wget_and_verify "${KIND_URL}" "${KIND_SHA256}" "${KIND_BINARY}"
+    chmod +x "${KIND_BINARY}"
+    sudo mv "${KIND_BINARY}" /usr/local/bin/
+}
+
+download_and_install_tilt()
+{
+    TILT_URL="https://raw.githubusercontent.com/tilt-dev/tilt/${TILT_VERSION}/scripts/install.sh"
+    TILT_SCRIPT="install.sh"
+
+    wget_and_verify "${TILT_URL}" "${TILT_SHA256}" "${TILT_SCRIPT}"
+    bash "${TILT_SCRIPT}"
+    rm "${TILT_SCRIPT}"
+}
+
+# TODO: kubectl shouldd not be latest (same as k8s latest version), but
+# use kubernetes version - 1, so the version skew from the latest to the
+# old one used in upgrades is within +/- 1 version.
+# Currently we default to KUBERNETES_BINARIES_VERSION, which defaults to
+# KUBERNETES_VERSION
+download_and_install_kubectl()
+{
+    KUBECTL_PATH=$(whereis -b kubectl | cut -d ":" -f2 | awk '{print $1}')
+    KUBECTL_PATH="${KUBECTL_PATH:-/usr/local/bin/kubectl}"
+    KUBECTL_URL="https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+
+    wget_and_verify "${KUBECTL_URL}" "${KUBECTL_SHA256}" "kubectl"
+    chmod +x kubectl
+    sudo mv kubectl "${KUBECTL_PATH}"
+}
+
+download_and_install_kustomize()
+{
+    KUSTOMIZE_URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+    KUSTOMIZE_BINARY="kustomize"
+
+    wget_and_verify "${KUSTOMIZE_URL}" "${KUSTOMIZE_SHA256}" "${KUSTOMIZE_BINARY}.tar.gz"
+    tar -xzvf "${KUSTOMIZE_BINARY}.tar.gz"
+    rm "${KUSTOMIZE_BINARY}.tar.gz"
+    chmod +x "${KUSTOMIZE_BINARY}"
+    sudo mv "${KUSTOMIZE_BINARY}" /usr/local/bin/
+}
+
+# TODO: Currently we just download latest CAPIRELEASE version of clusterctl,
+# which means we don't know the expected SHA, and can't pin it. This function
+# is not used, but it is marked as TODO in 03 script as well.
+download_and_install_clusterctl()
+{
+    CLUSTERCTL_URL="https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPIRELEASE}/clusterctl-linux-amd64"
+    CLUSTERCTL_BINARY="clusterctl"
+
+    wget_and_verify "${CLUSTERCTL_URL}" "${CLUSTERCTL_SHA256}" "${CLUSTERCTL_BINARY}"
+    chmod +x "${CLUSTERCTL_BINARY}"
+    sudo mv "${CLUSTERCTL_BINARY}" /usr/local/bin/
+}

--- a/vars.md
+++ b/vars.md
@@ -154,3 +154,9 @@ export NMSTATE1_NETWORK_SUBNET_V6='fd2e:6f44:5dd8:ca56::/120'
 export NMSTATE2_NETWORK_SUBNET_V4='192.168.222.0/24'
 export NMSTATE2_NETWORK_SUBNET_V6='fd2e:6f44:5dd8:cc56::/120'
 ```
+
+## Pinned binaries and packages
+
+By default, we pin downloaded binaries and packages with SHA256 digests.
+For testing purposes, verification of the digests will be skipped if
+`INSECURE_SKIP_DOWNLOAD_VERIFICATION` is set to `true`.


### PR DESCRIPTION
For downloaded install scripts and readily-built binaries, we need to add a custom function to download them and verify the SHA in one go. This also means that when doing version update, we need to also change the SHA. It needs to be investigated if the renovate bot can handle that or if we should be disabling renovatebot for these binaries.

This PR adds versioning to many of the binaries, instead of using latest. Using latest is often a wrong choice anyways, for example kubectl has +/- 1 version skew allowed, and using the latest is having 2 versions skew.
We also add override variable `INSECURE_SKIP_DOWNLOAD_VERIFICATION` for testing purposes, which skips the verification of the digests, so dependency bumps can be tested without worrying about the digests.

This PR also has couple TODO:s for future:
- clusterctl is following CAPIRELEASE variable which is downloaded from Github, ie. it is not possible to pin it
- kubectl version skew fix
- ansible pip install