### PR TITLE
add improvements to the test  kubeadm scripts

### DIFF
--- a/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
@@ -11,9 +11,12 @@ preKubeadmCommands:
   - mkdir {{ VM_EXTRADISKS_MOUNT_DIR }}
   - mount /dev/vda1 {{ VM_EXTRADISKS_MOUNT_DIR }}
 {% endif %}
+  - rm /etc/cni/net.d/*
   - systemctl enable --now keepalived
-  - sleep 60
-  - systemctl enable --now crio kubelet
+  - sleep 30
+  - systemctl enable --now crio
+  - sleep 30
+  - systemctl enable -now kubelet
 {% if EXTERNAL_VLAN_ID != "" %}
   - nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
   - nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
@@ -54,6 +57,15 @@ files:
           smtp_server localhost
           smtp_connect_timeout 30
       }
+
+      script k8s_api_check {
+          script "curl -sk https://127.0.0.1:6443/healthz"
+          interval 5
+          timeout 5
+          rise 3
+          fall 3
+      }
+
       vrrp_instance VI_1 {
           state MASTER
           interface {% if EXTERNAL_VLAN_ID == "" %}eth1{% else %}eth0.{{ EXTERNAL_VLAN_ID }}{% endif %}
@@ -63,6 +75,9 @@ files:
           advert_int 1
           virtual_ipaddress {
               {{ CLUSTER_APIENDPOINT_HOST }}
+          }
+          track_script {
+              k8s_api_check
           }
       }
   - path: /etc/NetworkManager/system-connections/eth0.nmconnection

--- a/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-ubuntu.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-ubuntu.yaml
@@ -1,5 +1,6 @@
 # Ubuntu specific controlplane kubeadm config
 preKubeadmCommands:
+  - rm /etc/cni/net.d/*
   - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
 {% if VM_EXTRADISKS == "true" %}
   - (echo n; echo p; echo 1; echo  ;echo  ;echo w) | fdisk /dev/vda
@@ -8,7 +9,9 @@ preKubeadmCommands:
   - mount /dev/vda1 {{ VM_EXTRADISKS_MOUNT_DIR }}
 {% endif %}
   - netplan apply
-  - systemctl enable --now crio kubelet
+  - systemctl enable --now crio
+  - sleep 30
+  - systemctl enable -now kubelet
   - if (curl -sk --max-time 10 https://{{ CLUSTER_APIENDPOINT_HOST }}:{{ CLUSTER_APIENDPOINT_PORT }}/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
   - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
 postKubeadmCommands:
@@ -18,40 +21,6 @@ postKubeadmCommands:
   - systemctl enable --now keepalived
   - chown {{ IMAGE_USERNAME }}:{{ IMAGE_USERNAME }} /home/{{ IMAGE_USERNAME }}/.kube/config
 files:
-  - path: /usr/local/bin/monitor.keepalived.sh
-    owner: root:root
-    permissions: '0755'
-    content: |
-        #!/bin/bash
-        while :; do
-          curl -sk https://127.0.0.1:{{ CLUSTER_APIENDPOINT_PORT }}/healthz 1>&2 > /dev/null
-          isOk=$?
-          isActive=$(systemctl show -p ActiveState keepalived.service | cut -d'=' -f2)
-          if [ $isOk == "0" ] &&  [ $isActive != "active" ]; then
-            logger 'API server is healthy, however keepalived is not running, starting keepalived'
-            echo 'API server is healthy, however keepalived is not running, starting keepalived'
-            sudo systemctl start keepalived.service
-          elif [ $isOk != "0" ] &&  [ $isActive == "active" ]; then
-            logger 'API server is not healthy, however keepalived running, stopping keepalived'
-            echo 'API server is not healthy, however keepalived running, stopping keepalived'
-            sudo systemctl stop keepalived.service
-          fi
-          sleep 5
-        done
-  - path: /lib/systemd/system/monitor.keepalived.service
-    owner: root:root
-    content: |
-        [Unit]
-        Description=Monitors keepalived adjusts status with that of API server
-        After=syslog.target network-online.target
-
-        [Service]
-        Type=simple
-        Restart=always
-        ExecStart=/usr/local/bin/monitor.keepalived.sh
-
-        [Install]
-        WantedBy=multi-user.target
   - path: /etc/keepalived/keepalived.conf
     content: |
       ! Configuration File for keepalived
@@ -64,6 +33,15 @@ files:
           smtp_server localhost
           smtp_connect_timeout 30
       }
+
+      vrrp_script k8s_api_check {
+          script "curl -sk https://127.0.0.1:6443/healthz"
+          interval 5
+          timeout 5
+          rise 3
+          fall 3
+      }
+
       vrrp_instance VI_2 {
           state MASTER
           interface {% if EXTERNAL_VLAN_ID == "" %}enp2s0{% else %}enp1s0.{{ EXTERNAL_VLAN_ID }}{% endif %}
@@ -73,6 +51,9 @@ files:
           advert_int 1
           virtual_ipaddress {
               {{ CLUSTER_APIENDPOINT_HOST }}
+          }
+          track_script {
+              k8s_api_check
           }
       }
   - path : /etc/netplan/52-ironicendpoint.yaml

--- a/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-centos.yaml
@@ -1,11 +1,14 @@
 # CentOS specific worker kubeadm config
 preKubeadmCommands:
+  - rm /etc/cni/net.d/*
   - systemctl restart NetworkManager.service
   - nmcli connection load /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
   - nmcli connection up {{ IRONIC_ENDPOINT_BRIDGE }}
   - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
   - nmcli connection up eth0
-  - systemctl enable --now crio kubelet
+  - systemctl enable --now crio
+  - sleep 30
+  - systemctl enable -now kubelet
 {% if EXTERNAL_VLAN_ID != "" %}
   - nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
   - nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection

--- a/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-ubuntu.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-ubuntu.yaml
@@ -2,7 +2,9 @@
 preKubeadmCommands:
   - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
   - netplan apply
-  - systemctl enable --now crio kubelet
+  - systemctl enable --now crio
+  - sleep 30
+  - systemctl enable -now kubelet
 files:
   - path : /etc/netplan/52-ironicendpoint.yaml
     owner: root:root


### PR DESCRIPTION
- introduce vrrp_script for checking the K8s API servers health for keepalvied instead of a custom daemon
- add half minute delay after the preKubeadm to let all systemd daemons finish bootstrapping (this will be changed to a polling based status check in a followup commit)
- clean the /etc/cni/net.d to make sure there are no default cni network configurations present that would collide with calico's cni configuration