### PR TITLE
fix incorrect subnet lookup of the iptable config

### DIFF
--- a/vm-setup/roles/firewall/defaults/main.yml
+++ b/vm-setup/roles/firewall/defaults/main.yml
@@ -3,7 +3,7 @@ external_interface: external
 provisioning_interface: provisioning
 bare_metal_provisioner_interface: "{{ lookup('env', 'BARE_METAL_PROVISIONER_INTERFACE') | default('ironicendpoint', true) }}"
 external_subnet_v4: "{{ lookup('env', 'EXTERNAL_SUBNET_V4') | default('192.168.111.0/24', true) }}"
-provisioning_subnet_v4: "{{ lookup('env', 'PROVISIONING_SUBNET_V4') | default('172.22.0.0/24', true) }}"
+bare_metal_provisioner_subnet_v4: "{{ lookup('env', 'BARE_METAL_PROVISIONER_NETWORK') | default('172.22.0.0/24', true) }}"
 kind_subnet: '172.18.0.0/24'
 registry_port: "{{ lookup('env', 'REGISTRY_PORT') | default('5000', true) }}"
 http_port: "{{ lookup('env', 'HTTP_PORT') | default('6180', true) }}"

--- a/vm-setup/roles/firewall/tasks/iptables.yaml
+++ b/vm-setup/roles/firewall/tasks/iptables.yaml
@@ -116,7 +116,7 @@
         action: insert
         protocol: tcp
         match: tcp
-        destination: "{{ provisioning_subnet_v4 }}"
+        destination: "{{ bare_metal_provisioner_subnet_v4 }}"
         destination_port: "{{ item }}"
         jump: ACCEPT
         state: "{{ firewall_rule_state }}"


### PR DESCRIPTION
The IPtable configuration was looking up the provisioner subnet by default, but that subnet is only present when the NATEd topology is enabled thus causing issues.