### PR TITLE
Fix running consecutive make test

### DIFF
--- a/tests/roles/run_tests/tasks/main.yml
+++ b/tests/roles/run_tests/tasks/main.yml
@@ -71,27 +71,6 @@
   include_tasks: cleanup.yml
   when: v1aX_integration_test_action in cleanup_actions
 
-- name: Delete BareMetalHosts
-  block:
-    - name: Delete BareMetalHosts CRs
-      kubernetes.core.k8s:
-        state: absent
-        src: "{{ WORKING_DIR }}/bmhosts_crs.yaml"
-        namespace: "{{ NAMESPACE }}"
-      ignore_errors: yes
-
-    - name: Wait until no BareMetalHost is remaining
-      kubernetes.core.k8s_info:
-        api_version: metal3.io/v1alpha1
-        kind: BareMetalHost
-        namespace: "{{ NAMESPACE }}"
-      register: dedeleted_baremetalhost
-      retries: 100
-      delay: 3
-      until: (dedeleted_baremetalhost is succeeded) and
-            (dedeleted_baremetalhost.resources | length ==  0)
-  when: v1aX_integration_test_action == "ci_test_deprovision"
-
 - name: Node remediation
   include_tasks: remediation.yml
   when: v1aX_integration_test_action == "remediation"


### PR DESCRIPTION
Currently when running `make test` 2 times consecutive the second run will fail because integration test expect BMH crs to pre-exist but as the first test is deleting them at the end the second will fail

This PR fix this issue by making integration test cleaning avoid deleting the bmh crs