### PR TITLE
add mitigation for kubeadm join issue

### DIFF
--- a/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
@@ -11,16 +11,17 @@ preKubeadmCommands:
   - mkdir {{ VM_EXTRADISKS_MOUNT_DIR }}
   - mount /dev/vda1 {{ VM_EXTRADISKS_MOUNT_DIR }}
 {% endif %}
+{% if EXTERNAL_VLAN_ID != "" %}
+  - nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+  - nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+{% endif %}
   - rm /etc/cni/net.d/*
   - systemctl enable --now keepalived
   - sleep 30
   - systemctl enable --now crio
   - sleep 30
-  - systemctl enable -now kubelet
-{% if EXTERNAL_VLAN_ID != "" %}
-  - nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
-  - nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
-{% endif %}
+  - systemctl enable --now kubelet
+  - sleep 120
 postKubeadmCommands:
   - mkdir -p /home/{{ IMAGE_USERNAME }}/.kube
   - chown {{ IMAGE_USERNAME }}:{{ IMAGE_USERNAME }} /home/{{ IMAGE_USERNAME }}/.kube
@@ -48,15 +49,6 @@ files:
   - path: /etc/keepalived/keepalived.conf
     content: |
       ! Configuration File for keepalived
-      global_defs {
-          notification_email {
-          sysadmin@example.com
-          support@example.com
-          }
-          notification_email_from lb@example.com
-          smtp_server localhost
-          smtp_connect_timeout 30
-      }
 
       script k8s_api_check {
           script "curl -sk https://127.0.0.1:6443/healthz"

--- a/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-ubuntu.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-ubuntu.yaml
@@ -9,30 +9,21 @@ preKubeadmCommands:
   - mount /dev/vda1 {{ VM_EXTRADISKS_MOUNT_DIR }}
 {% endif %}
   - netplan apply
+  - systemctl enable --now keepalived
+  - sleep 30
   - systemctl enable --now crio
   - sleep 30
-  - systemctl enable -now kubelet
-  - if (curl -sk --max-time 10 https://{{ CLUSTER_APIENDPOINT_HOST }}:{{ CLUSTER_APIENDPOINT_PORT }}/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
-  - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
+  - systemctl enable --now kubelet
+  - sleep 120
 postKubeadmCommands:
   - mkdir -p /home/{{ IMAGE_USERNAME }}/.kube
   - chown {{ IMAGE_USERNAME }}:{{ IMAGE_USERNAME }} /home/{{ IMAGE_USERNAME }}/.kube
   - cp /etc/kubernetes/admin.conf /home/{{ IMAGE_USERNAME }}/.kube/config
-  - systemctl enable --now keepalived
   - chown {{ IMAGE_USERNAME }}:{{ IMAGE_USERNAME }} /home/{{ IMAGE_USERNAME }}/.kube/config
 files:
   - path: /etc/keepalived/keepalived.conf
     content: |
       ! Configuration File for keepalived
-      global_defs {
-          notification_email {
-          sysadmin@example.com
-          support@example.com
-          }
-          notification_email_from lb@example.com
-          smtp_server localhost
-          smtp_connect_timeout 30
-      }
 
       vrrp_script k8s_api_check {
           script "curl -sk https://127.0.0.1:6443/healthz"

--- a/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-centos.yaml
@@ -6,14 +6,14 @@ preKubeadmCommands:
   - nmcli connection up {{ IRONIC_ENDPOINT_BRIDGE }}
   - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
   - nmcli connection up eth0
-  - systemctl enable --now crio
-  - sleep 15
-  - systemctl enable --now kubelet
-  - sleep 15
 {% if EXTERNAL_VLAN_ID != "" %}
   - nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
   - nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
 {% endif %}
+  - systemctl enable --now crio
+  - sleep 30
+  - systemctl enable --now kubelet
+  - sleep 120
 files:
   - path: /usr/local/bin/retrieve.configuration.files.sh
     owner: root:root

--- a/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-ubuntu.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-workers-kubeadm-config-ubuntu.yaml
@@ -4,7 +4,8 @@ preKubeadmCommands:
   - netplan apply
   - systemctl enable --now crio
   - sleep 30
-  - systemctl enable -now kubelet
+  - systemctl enable --now kubelet
+  - sleep 120
 files:
   - path : /etc/netplan/52-ironicendpoint.yaml
     owner: root:root


### PR DESCRIPTION
For some reason kubeadm can't validate the api server because
of a JSW error, but it seems the issue is related to timing.

These additional delays introduced in this commit are not a real solution to
the problem, but something is needed to unclog the CI and decrease the number
of failures experienced on local dev-env deployments.

This commit also removes some keepalived monitoring code fragments that are not needed and
some keepalived example config data that is not needed either.