### PR TITLE
Fix package installation for ubuntu 20

### DIFF
--- a/vm-setup/roles/packages_installation/tasks/ubuntu_required_packages.yml
+++ b/vm-setup/roles/packages_installation/tasks/ubuntu_required_packages.yml
@@ -55,6 +55,11 @@
 
     - name: Install docker
       block:
+        - name: Create /etc/apt/keyrings folder
+          file:
+            path: /etc/apt/keyrings
+            state: directory
+
         - name: Add Docker’s GPG key
           get_url:
             url: https://download.docker.com/linux/ubuntu/gpg


### PR DESCRIPTION
Fixes package installation for ubuntu 20 by creating missing folder /etc/apt/keyrings for gpg key storage