### PR TITLE
move sourcing of libs after initial package install

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -5,15 +5,6 @@ set -eux
 source lib/logging.sh
 # shellcheck disable=SC1091
 source lib/common.sh
-# shellcheck disable=SC1091
-source lib/releases.sh
-# shellcheck disable=SC1091
-source lib/download.sh
-# NOTE(fmuyassarov) Make sure to source before runnig install-package-playbook.yml
-# because there are some vars exported in network.sh and used by
-# install-package-playbook.yml.
-# shellcheck disable=SC1091
-source lib/network.sh
 
 if [[ "$(id -u)" -eq 0 ]]; then
   echo "Please run 'make' as a non-root user"
@@ -66,6 +57,18 @@ elif [[ "${OS}" = "centos" ]] || [[ "${OS}" = "rhel" ]]; then
   sudo dnf -y install python3-pip jq curl wget pkgconf-pkg-config bash-completion
   sudo ln -s /usr/bin/python3 /usr/bin/python || true
 fi
+
+# NOTE(tuminoid) lib/releases.sh must be after the jq and python installation
+# TODO: fix all of the lib/ scripts not to actually run code, but only define functions
+# shellcheck disable=SC1091
+source lib/releases.sh
+# shellcheck disable=SC1091
+source lib/download.sh
+# NOTE(fmuyassarov) Make sure to source before runnig install-package-playbook.yml
+# because there are some vars exported in network.sh and used by
+# install-package-playbook.yml.
+# shellcheck disable=SC1091
+source lib/network.sh
 
 # TODO: since ansible 8.0.0, pinning by digest is PITA, due additional ansible
 # dependencies, which would need to be pinned as well, so it is skipped for now


### PR DESCRIPTION
Many of the `lib/*.sh` actually run code requiring additional command line tooling, which is only installed after sourcing them. Running `make` on the vanilla Ubuntu fails currently. For this reason, we want to source `lib/releases.sh` and `lib/network.sh` after installing `jq` and `python` alternative, and `lib/download.sh` which needs `lib/common.sh`.

This is kind of first-aid to fix the issue. The real solution would be for the libs not to run any code when sourced, only create functions for later use.