### PR TITLE
Add a check before deleting virbr0 to avoid errors in the loop

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -53,7 +53,9 @@ init_minikube() {
         fi
         sudo su -l -c 'minikube delete --all --purge' "${USER}"
         # NOTE (Mohammed): workaround for https://github.com/kubernetes/minikube/issues/9878
-        sudo ip link delete virbr0
+        if ip link show virbr0 > /dev/null 2>&1; then
+          sudo ip link delete virbr0
+        fi
       done
       sudo su -l -c "minikube stop" "${USER}"
     fi


### PR DESCRIPTION
Sometimes, for some unknown reason, minikube will not start successfully. init_minikube() will try to start minikube again after deleting the bridge virbr0, but if the cause of the error is not the bridge, minikube will still fail to start successfully. Then "sudo ip link delete virbr0" will be executed again, but the bridge has been deleted, and the script will report an error and stop running, but the actual error is not there.

This PR ensures that "sudo ip link delete virbr0" is not executed again if there is a problem with minikube initialization, helping to locate the correct error location more quickly.