### PR TITLE
Fix use of mariadb install option for CAPM3 branch

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -24,7 +24,9 @@ if [ "${IRONIC_BASIC_AUTH}" == "false" ]; then
   BMO_IRONIC_ARGS+=("-n")
 fi
 if [ "${IRONIC_USE_MARIADB:-true}" == "true" ]; then
-  BMO_IRONIC_ARGS+=("-m")
+  if [[ "${CAPM3BRANCH}" != "release-1.3" ]] && [[ "${CAPM3BRANCH}" != "release-1.2" ]]; then
+    BMO_IRONIC_ARGS+=("-m")
+  fi
 fi
 
 sudo mkdir -p "${IRONIC_DATA_DIR}"
@@ -138,7 +140,11 @@ function update_images(){
 #
 function launch_ironic() {
   pushd "${BMOPATH}"
-
+    if [[ "${CAPM3BRANCH}" != "release-1.3" ]] && [[ "${CAPM3BRANCH}" != "release-1.2" ]]; then
+      export IRONIC_USE_MARIADB="true"
+    else
+      export IRONIC_USE_MARIADB="false"
+  fi
     # Update Configmap parameters with correct urls
     # Variable names inserted into the configmap might have different
     # naming conventions than the dev-env e.g. PROVISIONING_IP and CIDR are


### PR DESCRIPTION
After enabling the use of mariadb variable, we are seeing issue with release 1.2 and 1.3 branch of CAPM3. Which doesn't have any use of the install mariadb options. So excluding the -m option for those CAPM3 branches.