### PR TITLE
Fix incorrect EFI firmware reference in VM template

### DIFF
--- a/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
+++ b/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
@@ -9,7 +9,7 @@
   <os>
     <type arch='{{ libvirt_arch }}' machine='q35'>hvm</type>
 {% if libvirt_firmware  == 'uefi' %}
-     <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE.secboot.fd</loader>
+     <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE.fd</loader>
 {% if libvirt_secure_boot|bool %}
      <nvram template="/usr/share/OVMF/OVMF_VARS.secboot.fd">/var/lib/libvirt/qemu/nvram/{{ item.name }}.fd</nvram>
 {% else %}


### PR DESCRIPTION
Until this change a secure boot enabled EFI firmware was used even when secure boot was not requested. The old reference caused boot failures whit non secure bootable EFI compatoble boot media.

NOTE: there is a separate option already to enable secure EFI boot in the dev-env.