### PR TITLE
Fix minikube delete hanging issue

### DIFF
--- a/cluster_cleanup.sh
+++ b/cluster_cleanup.sh
@@ -20,5 +20,9 @@ if [ "${EPHEMERAL_CLUSTER}" == "kind" ] ||  [ "${EPHEMERAL_CLUSTER}" == "tilt" ]
 fi
 
 if [ "${EPHEMERAL_CLUSTER}" == "minikube" ]; then
+  # TODO: remove this line once minikube delete hanging issue is resolved.
+  # The issue started with minikube version v1.31.1 and is tracked here
+  # https://github.com/metal3-io/metal3-dev-env/issues/1264
+  sudo systemctl restart libvirtd.service
   sudo su -l -c "minikube delete" "${USER}"
 fi


### PR DESCRIPTION
Restart libvirtd helps in local test to allow minikube delete to proceed. This is a workaround until real issue is found. Its a workaround for #1264 