### PR TITLE
Download and install kvm2 driver with minikube

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -108,6 +108,7 @@ fi
 if [[ "${EPHEMERAL_CLUSTER}" = "minikube" ]]; then
   if ! command -v minikube &>/dev/null || [[ "$(minikube version --short)" != "${MINIKUBE_VERSION}" ]]; then
     download_and_install_minikube
+    download_and_install_kvm2_driver
   fi
 
   if ! command -v docker-machine-driver-kvm2 &>/dev/null ; then


### PR DESCRIPTION
We should download the kvm2 driver whenever minikube is downloaded since minikube is dependant on the driver itself and current check would not download newer version of the driver in case newer minikube is downloaded in CI images. Keeping the old check in place though since that might be needed for vanilla images. 