### PR TITLE
Bump CAPI to v1.5.0

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -331,9 +331,10 @@ function update_component_image(){
 # Update the clusterctl deployment files to use local repositories
 #
 function patch_clusterctl(){
+
   pushd "${CAPM3PATH}"
-  mkdir -p "${HOME}"/.cluster-api
-  touch "${HOME}"/.cluster-api/clusterctl.yaml
+  mkdir -p "${CAPI_CONFIG_FOLDER}"
+  touch "${CAPI_CONFIG_FOLDER}"/clusterctl.yaml
 
   # At this point the images variables have been updated with update_images
   # Reflect the change in components files
@@ -352,10 +353,9 @@ function patch_clusterctl(){
   update_capm3_imports
   make release-manifests
 
-  rm -rf "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
-  mkdir -p "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
-  cp out/*.yaml "${HOME}"/.cluster-api/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
-
+  rm -rf "${CAPI_CONFIG_FOLDER}"/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
+  mkdir -p "${CAPI_CONFIG_FOLDER}"/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
+ cp out/*.yaml "${CAPI_CONFIG_FOLDER}"/overrides/infrastructure-metal3/"${CAPM3RELEASE}"
   popd
 }
 

--- a/lib/releases.sh
+++ b/lib/releases.sh
@@ -83,8 +83,8 @@ else
   # We need to fix this to a non-existent CAPM3 release version to make sure
   # the local override created for main branch is not conflicting with existing
   # release tag. 
-  export CAPM3RELEASE="v1.4.99"
-  export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v1.4.")}"
+  export CAPM3RELEASE="v1.5.99"
+  export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v1.5.")}"
 fi
 
 CAPIBRANCH="${CAPIBRANCH:-${CAPIRELEASE}}"
@@ -96,4 +96,21 @@ fi
 
 if [[ "$CAPM3RELEASE" == "" ]]; then
   command -v jq &>/dev/null && echo "Failed to fetch CAPM3 release from Github" && exit 1
+fi
+
+# Set CAPI_CONFIG_FOLDER variable according to CAPIRELEASE minor version
+  # Starting from CAPI v1.5.0 version cluster-api config folder location has changed
+  # to XDG_CONFIG_HOME folder.
+  # Following code defines the cluster-api config folder location according to CAPI
+  # release version
+
+version_string="${CAPIRELEASE#v}"
+IFS='.' read -r _ minor _ <<< "$version_string"
+
+if [ "$minor" -lt 5 ]; then
+  export CAPI_CONFIG_FOLDER="${HOME}/.cluster-api"
+else
+  # Default CAPI_CONFIG_FOLDER to $HOME/.config folder if XDG_CONFIG_HOME not set
+  CONFIG_FOLDER="${XDG_CONFIG_HOME:-$HOME/.config}"
+  export CAPI_CONFIG_FOLDER="${CONFIG_FOLDER}/cluster-api"
 fi

--- a/tests/roles/run_tests/tasks/generate_templates.yml
+++ b/tests/roles/run_tests/tasks/generate_templates.yml
@@ -20,14 +20,14 @@
   - name: Deploy clusterctl variables to clusterctl config
     ansible.builtin.blockinfile:
       block: "{{lookup('ansible.builtin.template', '{{ CRS_PATH }}/clusterctl-vars.yaml')}}"
-      path: "{{ HOME }}/.cluster-api/clusterctl.yaml"
+      path: "{{ CAPI_CONFIG_FOLDER }}/clusterctl.yaml"
       create: yes 
       state: present
 
   - name: Generate clusterctl cluster template
     template:
       src: "{{ CRS_PATH }}/cluster-template-{{ item }}.yaml"
-      dest: "{{ HOME }}/.cluster-api/overrides/infrastructure-metal3/{{ CAPM3RELEASE }}/cluster-template-{{ item }}.yaml"
+      dest: "{{CAPI_CONFIG_FOLDER }}/overrides/infrastructure-metal3/{{ CAPM3RELEASE }}/cluster-template-{{ item }}.yaml"
     with_items:
       - cluster
       - controlplane
@@ -38,7 +38,7 @@
       clusterctl_var: "{{ 'generate' if CAPI_VERSION == 'v1beta1' else 'config' }}"
     shell: >
       clusterctl {{ clusterctl_var }} cluster {{ CLUSTER_NAME }}
-      --from {{ HOME }}/.cluster-api/overrides/infrastructure-metal3/{{ CAPM3RELEASE }}/cluster-template-{{ item }}.yaml
+      --from {{CAPI_CONFIG_FOLDER }}/overrides/infrastructure-metal3/{{ CAPM3RELEASE }}/cluster-template-{{ item }}.yaml
       --kubernetes-version {{ KUBERNETES_VERSION }}
       --control-plane-machine-count={{ CONTROL_PLANE_MACHINE_COUNT }}
       --worker-machine-count={{ WORKER_MACHINE_COUNT }}

--- a/tests/roles/run_tests/vars/main.yml
+++ b/tests/roles/run_tests/vars/main.yml
@@ -7,6 +7,7 @@ NAMEPREFIX: "{{ lookup('env', 'NAMEPREFIX') | default('baremetal-operator', true
 CRS_PATH: "{{ metal3_dir }}/tests/roles/run_tests/templates"
 TEMP_GEN_DIR: "{{ metal3_dir }}/tests/roles/run_tests/files/manifests"
 EPHEMERAL_CLUSTER: "{{ lookup('env', 'EPHEMERAL_CLUSTER') | default('kind', true) }}"
+CAPI_CONFIG_FOLDER: "{{ lookup('env', 'CAPI_CONFIG_FOLDER') | default('$HOME/.config/cluster-api', true) }}"
 CLUSTER_APIENDPOINT_HOST: "{{ lookup('env', 'CLUSTER_APIENDPOINT_HOST') }}"
 CLUSTER_APIENDPOINT_PORT: "{{ lookup('env', 'CLUSTER_APIENDPOINT_PORT') | default(6443, true) }}"
 CLUSTER_APIENDPOINT_IP: "{{ lookup('env', 'CLUSTER_APIENDPOINT_IP') }}"

--- a/vars.md
+++ b/vars.md
@@ -126,6 +126,7 @@ assured that they are persisted.
 | DHCP_HOSTS | A list of `;` separated dhcp-host directives for dnsmasq | e.g. `00:20:e0:3b:13:af;00:20:e0:3b:14:af` | |
 | DHCP_IGNORE | A set of tags on hosts to be ignored by dnsmasq | e.g. `tag:!known` | |
 | ENABLE_NATED_PROVISIONING_NETWORK | A single boolean to configure whether provisioner and provisioning networks are in separate subnets and there is NAT betweend them or not | "true","false" | "false" |
+| CAPI_CONFIG_FOLDER | Cluster API config folder path  | `$HOME/.cluster-api/`, `$XDG_CONFIG_HOME/cluster-api`, `$HOME/.config/cluster-api` | `$HOME/.config/cluster-api` |
 
 **NOTE** `(BMO/CAPI/CAPM3/IPAM)RELEASE` variables are also affecting the `BRANCH` variables so make sure that
 RELEASE and BRANCH variables are not conflicting.


### PR DESCRIPTION
This PR add CAPI v1.5 uplift related changes:
 - Uplifts CAPI version
 - Introduces new CAPI_CONFIG_FOLDER variable as [CAPI started following XDG standard](https://github.com/kubernetes-sigs/cluster-api/pull/6913) 