### PR TITLE
add python3-dev for libvirt-python building

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -16,7 +16,7 @@ if [[ "${OS}" = "ubuntu" ]]; then
   # make the data retrival more reliable
   sudo sh -c ' echo "Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries '
   sudo apt-get update
-  sudo apt-get -y install python3-pip jq curl wget pkg-config bash-completion
+  sudo apt-get -y install python3-pip python3-dev jq curl wget pkg-config bash-completion
 
   # Set update-alternatives to python3
   if [[ "${DISTRO}" = "ubuntu18" ]]; then


### PR DESCRIPTION
Vanilla Ubuntu image is missing python3-dev required to build and install libvirt-python. 01 script is failing on vanilla because of this.
Starting libvirt-python 9.5.0, released in July 2023, they state they need python development headers, which wasn't there in 9.4.0.