### PR TITLE
fix local ironic image building and ipa downloader logic

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -124,7 +124,12 @@ else
 fi
 
 # shellcheck disable=SC2034
-export IPA_DOWNLOAD_ENABLED="${IPA_DOWNLOAD_ENABLED:-false}"
+# USE_LOCAL_IPA and IPA_DOWNLOAD_ENABLED also have effect on BMO repo
+export USE_LOCAL_IPA="${USE_LOCAL_IPA:-false}"
+if [[ "${USE_LOCAL_IPA}" == "true" ]]; then
+    export IPA_DOWNLOAD_ENABLED="false"
+fi
+export IPA_DOWNLOAD_ENABLED="${IPA_DOWNLOAD_ENABLED:-true}"
 export FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-true}"
 
 export M3PATH="${M3PATH:-${GOPATH}/src/github.com/metal3-io}"
@@ -204,7 +209,7 @@ if [[ "${BUILD_CAPI_LOCALLY}" == "true" ]]; then
   export CAPI_LOCAL_IMAGE="${CAPIPATH}"
 fi
 if [[ "${BUILD_IRONIC_IMAGE_LOCALLY}" == "true" ]]; then
-  export IRONIC_LOCAL_IMAGE="${IRONIC_IMAGE_PATH}"
+  export IRONIC_LOCAL_IMAGE="${IRONIC_LOCAL_IMAGE:-${IRONIC_IMAGE_PATH}}"
 fi
 if [[ "${BUILD_MARIADB_IMAGE_LOCALLY}" == "true" ]]; then
   export MARIADB_LOCAL_IMAGE="${MARIADB_IMAGE_PATH}"

--- a/vars.md
+++ b/vars.md
@@ -130,6 +130,12 @@ assured that they are persisted.
 **NOTE** `(BMO/CAPI/CAPM3/IPAM)RELEASE` variables are also affecting the `BRANCH` variables so make sure that
 RELEASE and BRANCH variables are not conflicting.
 
+## Local IPA
+
+The use of local IPA enabled via `USE_LOCAL_IPA` is only supported on
+Ubuntu host when `EPHEMERAL_CLUSTER` is `kind` cluster and Ironic is
+directly deployed to  the OCI runtime (no K8s pod)
+
 ## Local images
 
 Environment variables with `_LOCAL_IMAGE` in their name are used to specify directories that contain the code to build the


### PR DESCRIPTION
This commit changes:

  - There is no more IPA download in dev-env as BMO deploy and run_local scripts would download IPA anyways
  - Now it is explicitly stated that local IPA is only supported when the ephemeral cluster is a 'kind' cluster and ironic is directly deployed not as part of a K8s pod
  - From now upstream OCI images are not tagged and pushed to local registry if a locally built counterpart exists
  - now the locally built CAPI,CAPM3,IPAM and BMO images have to be in sync with the related repositories cloned by the dev-env in order to avoid miss match issues