### PR TITLE
introducing custom iPXE firmware buiding support

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -254,7 +254,7 @@ export DOCKER_REGISTRY_IMAGE="${DOCKER_REGISTRY_IMAGE:-${DOCKER_HUB_PROXY}/libra
 # Registry to pull metal3 container images from
 export CONTAINER_REGISTRY="${CONTAINER_REGISTRY:-quay.io}"
 
-# VBMC and Redfish images
+# BMC emulator images
 export VBMC_IMAGE="${VBMC_IMAGE:-${CONTAINER_REGISTRY}/metal3-io/vbmc}"
 export SUSHY_TOOLS_IMAGE="${SUSHY_TOOLS_IMAGE:-${CONTAINER_REGISTRY}/metal3-io/sushy-tools}"
 
@@ -293,6 +293,9 @@ else
   export BMOBRANCH="${BMORELEASEBRANCH:-main}"
 fi
 
+# IPXE support image
+export IPXE_BUILDER_IMAGE="${IPXE_BUILDER_IMAGE:-${CONTAINER_REGISTRY}/metal3-io/ipxe-builder}"
+
 # Ironic vars
 export IRONIC_TLS_SETUP=${IRONIC_TLS_SETUP:-"true"}
 export IRONIC_BASIC_AUTH=${IRONIC_BASIC_AUTH:-"true"}
@@ -303,6 +306,14 @@ export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
 export IRONIC_IMAGE_DIR="$IRONIC_DATA_DIR/html/images"
 export IRONIC_NAMESPACE="${IRONIC_NAMESPACE:-baremetal-operator-system}"
 export NAMEPREFIX="${NAMEPREFIX:-baremetal-operator}"
+
+# iPXE vars of ironic-image
+export BUILD_IPXE="${BUILD_IPXE:-false}"
+export IPXE_ENABLE_TLS="${IPXE_ENABLE_TLS:-false}"
+export IPXE_ENABLE_IPV6="${IPXE_ENABLE_IPV6:-false}"
+export IPXE_RELEASE_BRANCH="${IPXE_RELEASE_BRANCH:-v1.21.1}"
+export IPXE_SOURCE_FORCE_UPDATE="${IPXE_SOURCE_FORCE_UPDATE:-false}"
+export IPXE_SOURCE_DIR="${IRONIC_DATA_DIR}/ipxe-source"
 
 export IRONIC_KEEPALIVED_IMAGE="${IRONIC_KEEPALIVED_IMAGE:-${CONTAINER_REGISTRY}/metal3-io/keepalived:${KEEPALIVED_TAG}}"
 export MARIADB_IMAGE="${MARIADB_IMAGE:-${CONTAINER_REGISTRY}/metal3-io/mariadb:${MARIADB_TAG}}"
@@ -567,7 +578,7 @@ differs(){
 #
 remove_ironic_containers() {
   #shellcheck disable=SC2015
-  for name in ipa-downloader vbmc sushy-tools httpd-infra; do
+  for name in ipa-downloader vbmc sushy-tools httpd-infra ipxe-builder; do
     if sudo "${CONTAINER_RUNTIME}" ps | grep -w -q "${name}$"; then
         sudo "${CONTAINER_RUNTIME}" kill "${name}" || true
     fi

--- a/lib/ironic_tls_setup.sh
+++ b/lib/ironic_tls_setup.sh
@@ -23,6 +23,10 @@ if [ "${IRONIC_TLS_SETUP}" == "true" ]; then
     export MARIADB_CERT_FILE="${MARIADB_CERT_FILE:-"${WORKING_DIR}/certs/mariadb.crt"}"
     export MARIADB_KEY_FILE="${MARIADB_KEY_FILE:-"${WORKING_DIR}/certs/mariadb.key"}"
 
+    export IPXE_CACERT_FILE="${IPXE_CACERT_FILE:-"${WORKING_DIR}/certs/ipxe-ca.pem"}"
+    export IPXE_CAKEY_FILE="${IPXE_CAKEY_FILE:-"${WORKING_DIR}/certs/ipxe-ca.key"}"
+    export IPXE_CERT_FILE="${IPXE_CERT_FILE:-"${WORKING_DIR}/certs/ipxe.crt"}"
+    export IPXE_KEY_FILE="${IPXE_KEY_FILE:-"${WORKING_DIR}/certs/ipxe.key"}"
 
     # Generate CA Key files
     if [ ! -f "${IRONIC_CAKEY_FILE}" ]; then
@@ -33,6 +37,9 @@ if [ "${IRONIC_TLS_SETUP}" == "true" ]; then
     fi
     if [ ! -f "${MARIADB_CAKEY_FILE}" ]; then
         openssl genrsa -out "${MARIADB_CAKEY_FILE}" 2048
+    fi
+    if [ ! -f "${IPXE_CAKEY_FILE}" ]; then
+        openssl genrsa -out "${IPXE_CAKEY_FILE}" 2048
     fi
 
     # Generate CA cert files
@@ -45,6 +52,9 @@ if [ "${IRONIC_TLS_SETUP}" == "true" ]; then
     if [ ! -f "${MARIADB_CACERT_FILE}" ]; then
         openssl req -x509 -new -nodes -key "${MARIADB_CAKEY_FILE}" -sha256 -days 1825 -out "${MARIADB_CACERT_FILE}" -subj /CN="mariadb CA"/
     fi
+    if [ ! -f "${IPXE_CACERT_FILE}" ]; then
+        openssl req -x509 -new -nodes -key "${IPXE_CAKEY_FILE}" -sha256 -days 1825 -out "${IPXE_CACERT_FILE}" -subj /CN="ipxe CA"/
+    fi
 
     # Generate Key files
     if [ ! -f "${IRONIC_KEY_FILE}" ]; then
@@ -55,6 +65,9 @@ if [ "${IRONIC_TLS_SETUP}" == "true" ]; then
     fi
     if [ ! -f "${MARIADB_KEY_FILE}" ]; then
         openssl genrsa -out "${MARIADB_KEY_FILE}" 2048
+    fi
+    if [ ! -f "${IPXE_KEY_FILE}" ]; then
+        openssl genrsa -out "${IPXE_KEY_FILE}" 2048
     fi
 
     # Generate CSR and certificate files
@@ -70,6 +83,10 @@ if [ "${IRONIC_TLS_SETUP}" == "true" ]; then
     if [ ! -f "${MARIADB_CERT_FILE}" ]; then
         openssl req -new -key "${MARIADB_KEY_FILE}" -out /tmp/mariadb.csr -subj /CN="${MARIADB_HOST}"/
         openssl x509 -req -in /tmp/mariadb.csr -CA "${MARIADB_CACERT_FILE}" -CAkey "${MARIADB_CAKEY_FILE}" -CAcreateserial -out "${MARIADB_CERT_FILE}" -days 825 -sha256 -extfile <(printf "subjectAltName=IP:%s" "${MARIADB_HOST_IP}")
+    fi
+    if [ ! -f "${IPXE_CERT_FILE}" ]; then
+        openssl req -new -key "${IPXE_KEY_FILE}" -out /tmp/ipxe.csr -subj /CN="${IRONIC_HOST}"/
+        openssl x509 -req -in /tmp/ipxe.csr -CA "${IPXE_CACERT_FILE}" -CAkey "${IPXE_CAKEY_FILE}" -CAcreateserial -out "${IPXE_CERT_FILE}" -days 825 -sha256 -extfile <(printf "subjectAltName=IP:%s" "${IRONIC_HOST_IP}")
     fi
 
     #Populate the CA certificate B64 variable
@@ -98,4 +115,7 @@ else
     unset MARIADB_CACERT_FILE
     unset MARIADB_CERT_FILE
     unset MARIADB_KEY_FILE
+    unset IPXE_CACERT_FILE
+    unset IPXE_CERT_FILE
+    unset IPXE_KEY_FILE
 fi


### PR DESCRIPTION
This PR:
  - Implements a function to initiate iPXE firmware bilding process
     based on the 'buildipxe' script of the 'ironic-image'
  - Implements logic to generate TLS certificates for the custom
     iPXE firmware
   - Adds a set of iPXE specific environment variables to help
     parameterizing the custom iPXE build process

This pr can be merged only after https://github.com/metal3-io/metal3-dev-env/pull/1272 has been merged.