### PR TITLE
Adding default value for LOCAL_IPA_PATH

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -126,6 +126,7 @@ fi
 # shellcheck disable=SC2034
 # USE_LOCAL_IPA and IPA_DOWNLOAD_ENABLED also have effect on BMO repo
 export USE_LOCAL_IPA="${USE_LOCAL_IPA:-false}"
+export LOCAL_IPA_PATH="${LOCAL_IPA_PATH:-/tmp/dib}"
 if [[ "${USE_LOCAL_IPA}" == "true" ]]; then
     export IPA_DOWNLOAD_ENABLED="false"
 fi


### PR DESCRIPTION
In CI `metal3_daily_main_fullstack_building` test starts failing after the merge of this PR: https://github.com/metal3-io/metal3-dev-env/pull/1272
With following error:
`./02_configure_host.sh: line 19: LOCAL_IPA_PATH: unbound variable`

This PR is setting default value of LOCAL_IPA_PATH.