### PR TITLE
fix KUBECTL_SHA256 to match KUBERNETES_VERSION

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -315,9 +315,9 @@ else
   export EPHEMERAL_CLUSTER="minikube"
 fi
 
-# Kubectl version
+# Kubectl version (do not forget to update KUBECTL_SHA256 when changing KUBERNETES_VERSION!)
 export KUBECTL_VERSION="${KUBECTL_VERSION:-${KUBERNETES_BINARIES_VERSION}}"
-export KUBECTL_SHA256="4685bfcf732260f72fce58379e812e091557ef1dfc1bc8084226c7891dd6028f"
+export KUBECTL_SHA256="e7a7d6f9d06fab38b4128785aa80f65c54f6675a0d2abef655259ddd852274e1"
 
 # Krew version
 export KREW_VERSION="${KREW_VERSION:-v0.4.3}"


### PR DESCRIPTION
When KUBERNETES_VERSION is changed, it changes the KUBECTL_SHA256 as well as the versions are coupled. There is TODO item to get rid of this coupling.

The issue is not visible until CI images are rebuilt as 01_script does not get executed during regular integration tests. Anyone using vanilla image will get the error though, like Ironic CI.