### PR TITLE
Add version check to kubectl installation

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -124,7 +124,7 @@ else
   fi
 fi
 
-if ! command -v kubectl &>/dev/null; then
+if ! command -v kubectl &>/dev/null || [[ "$(kubectl version --client -o json|jq -r '.clientVersion.gitVersion')" != "${KUBECTL_VERSION}" ]]; then
   download_and_install_kubectl
 fi
 


### PR DESCRIPTION
This PR fixes a bug in kubectl installation. Currently kubectl installation doesn't check the version and as a result even if the it is bumped and if in CI image the old binary exists, new installation will not happen. This PR adds the version check.