### PR TITLE
add a helper script to print digests of downloaded artifacts

### DIFF
--- a/hack/print_checksums.sh
+++ b/hack/print_checksums.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# This is a helper for verifying/printing digests of downloaded, pinned
+# dependencies.
+
+set -eu
+
+METAL3_DEV_ENV_DIR="$(dirname "$(readlink -f "${0}")")/.."
+
+# shellcheck disable=SC1091
+. "${METAL3_DEV_ENV_DIR}/lib/common.sh"
+# shellcheck disable=SC1091
+. "${METAL3_DEV_ENV_DIR}/lib/download.sh"
+
+# this downloads and prints sha256 digests for all pinned dependencies
+_download_and_print_checksums


### PR DESCRIPTION
For updating pinned binary downloads, getting the correct digest has been more work than it needs to be.

Workflow:
- update the version numbers in `lib/common.sh`
- run `./hack/print_checksums.sh` 
- update the sha256 in `lib/common.sh` as needed