### PR TITLE
Fix CAPI config folder location

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -63,4 +63,11 @@ fi
 # Clean up any serial logs
 sudo rm -rf /var/log/libvirt/qemu/*serial0.log*
 
+# TODO(Sunnatillo): Remove first line after deprication of camp3 v1.4
 rm -rf "${HOME}"/.cluster-api
+
+if [[ -n "${XDG_CONFIG_HOME}" ]]; then
+    rm -rf "${XDG_CONFIG_HOME}"/cluster-api
+else
+    rm -rf "${HOME}"/.config/cluster-api
+fi

--- a/lib/releases.sh
+++ b/lib/releases.sh
@@ -104,6 +104,10 @@ fi
   # Following code defines the cluster-api config folder location according to CAPI
   # release version
 
+# TODO(Sunnatillo): Following condition should be removed when CAPM3 v1.4 reaches EOL
+# NOTE(Sunnatillo): When CAPM3 v1.4 reaches EOL CAPI_CONFIG_FOLDER variable can be removed
+# for the sake of reducing variables
+
 version_string="${CAPIRELEASE#v}"
 IFS='.' read -r _ minor _ <<< "$version_string"
 

--- a/tests/roles/run_tests/templates/clusterctl-vars.yaml
+++ b/tests/roles/run_tests/templates/clusterctl-vars.yaml
@@ -1,5 +1,5 @@
 # Cluster API variables used for generating templates
-# For deployment to ~/.cluster-api/
+# For deployment to ~/.config/cluster-api/
 ## Note these settings are overridden by environment variables.
 
 # Cluster settings

--- a/tilt-setup/deploy_tilt_env.sh
+++ b/tilt-setup/deploy_tilt_env.sh
@@ -27,7 +27,7 @@ make kind-reset
 kind create cluster --name capm3 --image="${KIND_NODE_IMAGE}"
 kubectl create namespace "${NAMESPACE}"
 kubectl create namespace "${IRONIC_NAMESPACE}"
-mkdir -p "${HOME}/.cluster-api/overrides/infrastructure-metal3/${CAPM3RELEASE}"
+mkdir -p "${HOME}/.config/cluster-api/overrides/infrastructure-metal3/${CAPM3RELEASE}"
 make tilt-up &
 # wait for cert-manager to be ready
 sleep 120


### PR DESCRIPTION
This PR fixes CAPI config folder location for tilt env and host_cleanup.sh file