### PR TITLE
fix the application of the kvm_tdp_mmu workaround

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -25,18 +25,6 @@ if [[ "${OS}" = "ubuntu" ]]; then
     sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
   elif [[ "${DISTRO}" = "ubuntu22" ]]; then
     sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1
-    # (workaround) disable tdp_mmu to avoid
-    # kernel crashes with  NULL pointer dereference
-    # note(elfosardo): run this only if we have kvm support
-    if grep -q vmx /proc/cpuinfo; then
-      sudo modprobe -r -a kvm_intel kvm
-      sudo modprobe kvm tdp_mmu=0
-      sudo modprobe -a kvm kvm_intel
-    elif grep -q svm /proc/cpuinfo; then
-      sudo modprobe -r -a kvm_amd kvm
-      sudo modprobe kvm tdp_mmu=0
-      sudo modprobe -a kvm kvm_amd
-    fi
   fi
 elif [[ "${OS}" = "centos" ]] || [[ "${OS}" = "rhel" ]]; then
   sudo dnf upgrade -y

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -13,6 +13,18 @@ source lib/releases.sh
 # shellcheck disable=SC1091
 source lib/image_prepull.sh
 
+# (workaround) disable tdp_mmu to avoid
+# kernel crashes with  NULL pointer dereference
+# note(elfosardo): run this only if we have kvm support
+if grep -q vmx /proc/cpuinfo; then
+  sudo modprobe -r -a kvm_intel kvm
+  sudo modprobe kvm tdp_mmu=0
+  sudo modprobe -a kvm kvm_intel
+elif grep -q svm /proc/cpuinfo; then
+  sudo modprobe -r -a kvm_amd kvm
+  sudo modprobe kvm tdp_mmu=0
+  sudo modprobe -a kvm kvm_amd
+fi
 # Clean, copy and extract local IPA
 if [[ "${USE_LOCAL_IPA}" = "true" ]]; then
   sudo rm -f  "${IRONIC_DATA_DIR}/html/images/ironic-python-agent*"


### PR DESCRIPTION
At the time of writing the CI is experiencing broken pipe issues for a week. The issues are present for both Centos and Ubuntu. In the previous implementation the fix was applied in 01 script but that is not executed in most of the scripts currently. This commit moves the application of the fix into 02 script and enables it for both distros again.