### PR TITLE
Properly manage libvirt services

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -87,10 +87,9 @@ if ! kubectl krew > /dev/null 2>&1; then
 fi
 
 # Allow local non-root-user access to libvirt
-# Restart libvirtd service to get the new group membership loaded
 if ! id "${USER}" | grep -q libvirt; then
   sudo usermod -a -G "libvirt" "${USER}"
-  sudo systemctl restart libvirtd
+  gpasswd -a "${USER}" libvirt
 fi
 
 if [[ "${EPHEMERAL_CLUSTER}" = "minikube" ]]; then

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -49,9 +49,9 @@ init_minikube() {
       # Loop to ignore minikube issues
       while /bin/true; do
         minikube_error=0
-        # Restart libvirtd.service as suggested here
-        # https://github.com/kubernetes/minikube/issues/3566
-        sudo systemctl restart libvirtd.service
+        # This method, defined in lib/common.sh, will either ensure sockets are up'n'running
+        # for CS9 and RHEL9, or restart the libvirtd.service for other DISTRO
+        manage_libvirtd
         configure_minikube
         #NOTE(elfosardo): workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2057769
         sudo mkdir -p "/etc/qemu/firmware"

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -437,7 +437,9 @@ function start_management_cluster () {
   if [ "${EPHEMERAL_CLUSTER}" == "kind" ]; then
     launch_kind
   elif [ "${EPHEMERAL_CLUSTER}" == "minikube" ]; then
-    sudo systemctl restart libvirtd.service
+    # This method, defined in lib/common.sh, will either ensure sockets are up'n'running
+    # for CS9 and RHEL9, or restart the libvirtd.service for other DISTRO
+    manage_libvirtd
     while /bin/true; do
         minikube_error=0
         sudo su -l -c 'minikube start' "${USER}" || minikube_error=1

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -559,3 +559,21 @@ remove_ironic_containers() {
     fi
   done
 }
+
+#
+# Manage libvirtd services based on OS
+#
+manage_libvirtd() {
+  case ${DISTRO} in
+      centos9|rhel9)
+          for i in qemu network nodedev nwfilter secret storage interface; do
+              sudo systemctl enable --now virt${i}d.socket
+              sudo systemctl enable --now virt${i}d-ro.socket
+              sudo systemctl enable --now virt${i}d-admin.socket
+          done
+          ;;
+      *)
+          sudo systemctl restart libvirtd.service
+        ;;
+esac
+}

--- a/vm-setup/roles/libvirt/tasks/install_setup_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/install_setup_tasks.yml
@@ -1,6 +1,46 @@
-- name: Start libvirtd
+---
+- name: Start and enable libvirtd service
+  when:
+    - not (ansible_facts['distribution'] in ['CentOS', 'RedHat'] and
+           ansible_facts['distribution_major_version'] >= '9')
   service:
     name: "{{ libvirtd_service }}"
     state: started
     enabled: true
   become: true
+
+- name: Ensure socket services are enabled on newer distros
+  when:
+    - ansible_facts['distribution'] in ['CentOS', 'RedHat']
+    - ansible_facts['distribution_major_version'] >= '9'
+  become: true
+  vars:
+    _services:
+      - qemu
+      - network
+      - nodedev
+      - nwfilter
+      - secret
+      - storage
+      - interface
+  block:
+    - name: Ensure libvirt modular sockets are enabled and started
+      ansible.builtin.service:
+        name: "virt{{ item }}d.socket"
+        state: started
+        enabled: true
+      loop: "{{ _services }}"
+
+    - name: Ensure libvirt modular ro sockets are enabled and started
+      ansible.builtin.service:
+        name: "virt{{ item }}d-ro.socket"
+        state: started
+        enabled: true
+      loop: "{{ _services }}"
+
+    - name: Ensure libvirt modular admin sockets are enabled and started
+      ansible.builtin.service:
+        name: "virt{{ item }}d-admin.socket"
+        state: started
+        enabled: true
+      loop: "{{ _services }}"


### PR DESCRIPTION
With newer CS9 and RHEL-9, libvirtd has moved to a modular, socket activated layout.

This new layout conflicts with the single, monolithic "libvirtd.service" that was restarted until now, creating issues with other projects that may wrap this metal3-dev-env.

Fixes: #1312