### PR TITLE
Do not install NetworkManager-initscripts-updown anymore for el9

### DIFF
--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -95,7 +95,6 @@ packages:
         - redhat-lsb-core
     el9:
       packages:
-        - NetworkManager-initscripts-updown
         - python3-requests-oauthlib
     pip3:
       - flask_oauthlib==0.9.6


### PR DESCRIPTION
We don't use legacy ifup/ifdown scripts anymore