### PR TITLE
Use CAPM3RELEASEBRANCH instead of CAPM3BRANCH for kustomization

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -264,7 +264,7 @@ function update_capm3_imports(){
   pushd "${CAPM3PATH}"
 
   # Modify the kustomization imports to use local BMO repo instead of Github Main
-  if [[ "${CAPM3BRANCH}" == "release-1.5" ]] || [[ "${CAPM3BRANCH}" == "release-1.4" ]]; then
+  if [[ "${CAPM3RELEASEBRANCH}" == "release-1.5" ]] || [[ "${CAPM3RELEASEBRANCH}" == "release-1.4" ]]; then
     make hack/tools/bin/kustomize
   else
     make kustomize


### PR DESCRIPTION
for a PR in release-1.5 or release-1.4 branch, `CAPM3BRANCH` is exported as the branch commit hash, this causes the check to fail and the kustomization errors out as we see here https://github.com/metal3-io/cluster-api-provider-metal3/pull/1468. Using `CAPM3RELESEBRANCH` should solve this issue. 