### PR TITLE
Remove inspector container

### DIFF
--- a/tests/roles/run_tests/tasks/move.yml
+++ b/tests/roles/run_tests/tasks/move.yml
@@ -9,7 +9,6 @@
           - vbmc
       ironic_containers:
           - ironic
-          - ironic-inspector
           - ironic-endpoint-keepalived
           - ironic-log-watch
           - dnsmasq


### PR DESCRIPTION
We no longer deploy inspector so we should not try to get logs from it.