### PR TITLE
🐛 Fix BMO Deployment Deletion and Installation Issues during Pivoting

### DIFF
--- a/tests/roles/run_tests/tasks/move.yml
+++ b/tests/roles/run_tests/tasks/move.yml
@@ -65,13 +65,6 @@
       namespace: "{{ IRONIC_NAMESPACE }}"
     when: EPHEMERAL_CLUSTER == "minikube"
   
-  - name: Remove BMO deployment from source cluster
-    kubernetes.core.k8s:
-      name: "{{ NAMEPREFIX }}"
-      kind: Deployment
-      state: absent
-      namespace: "{{ IRONIC_NAMESPACE }}"
-
   - name: Label baremetalhost CRD to pivot.
     shell: "kubectl label --overwrite crds baremetalhosts.metal3.io {{ item }}"
     with_items:
@@ -175,6 +168,13 @@
 
   - name: Pivot objects to target cluster
     shell: "clusterctl move --to-kubeconfig /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml -n {{ NAMESPACE }} -v 10"
+
+  - name: Remove BMO deployment from source cluster
+    kubernetes.core.k8s:
+      name: "{{ NAMEPREFIX }}-controller-manager"
+      kind: Deployment
+      state: absent
+      namespace: "{{ IRONIC_NAMESPACE }}"
 
   - name: Verify that all machines are provisioned and running.
     include_tasks: verify_resources_states.yml

--- a/tests/roles/run_tests/tasks/move_back.yml
+++ b/tests/roles/run_tests/tasks/move_back.yml
@@ -15,9 +15,8 @@
     environment:
       IRONIC_HOST: "{{ IRONIC_HOST }}"
       IRONIC_HOST_IP: "{{ IRONIC_HOST_IP }}"
-      KUBECTL_ARGS: "{{ KUBECTL_ARGS }}"
     args:
-      chdir: "{{ BMOPATH }}"    
+      chdir: "{{ BMOPATH }}"
 
   - name: Install Ironic in Source cluster (Ephemeral Cluster is kind)
     shell: "{{ BMOPATH }}/tools/run_local_ironic.sh"


### PR DESCRIPTION
Co-authored-by: Max Rantil <max.rantil@est.tech>

BMO deployment was not getting deleted from the source cluster in the ansible test this PR fix it.