### PR TITLE
Echo error string in stderr instead of stdout

### DIFF
--- a/lib/releases.sh
+++ b/lib/releases.sh
@@ -58,7 +58,7 @@ function get_latest_release() {
 
   # if release_tag is not found
   if [ -z "${release_tag}" ]; then
-    echo "Error: release is not found from ${release_path}"
+    echo "Error: release is not found from ${release_path}" >&2
     exit 1
   else
     echo "${release_tag}"


### PR DESCRIPTION
Function `get_latest_release()` is called as a subshell and since the echo is in stdout in case an error has occurred, this error string is exported wrongly as the release versions in variables.This in turn fools the empty check and causes the `lib/releases.sh` not to error out. The test moves on and fails elsewhere with a confusing error output. 