### PR TITLE
Downgrade ironic-image to v24.0.0 for release-1.6 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The following table describes which branches are tested for different test trigg
 | test suffix | CAPM3 branch | IPAM branch  | BMO branch/tag  | Keepalived tag | Ironic tag |
 | ----------- | ------------ | -----------  | --------------- | -------------- | ---------- |
 | main        | main         | main         | main            | latest         | latest     |
-| release-1-6 | release-1.6  | release-1.6  | release-0.5     | v0.5.1         | v24.1.0    |
+| release-1-6 | release-1.6  | release-1.6  | release-0.5     | v0.5.1         | v24.0.0    |
 | release-1-5 | release-1.5  | release-1.5  | release-0.4     | v0.4.2         | v23.1.0    |
 | release-1-4 | release-1.4  | release-1.4  | release-0.3     | v0.3.1         | v23.1.0    |
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -275,7 +275,7 @@ elif [[ "${CAPM3RELEASEBRANCH}" = "release-1.6" ]]; then
   export IPAM_IMAGE=${IPAM_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ip-address-manager:release-1.6"}
   export BARE_METAL_OPERATOR_TAG="v0.5.1"
   export KEEPALIVED_TAG="v0.5.1"
-  export IRONIC_TAG="v24.1.0"
+  export IRONIC_TAG="v24.0.0"
   export BMOBRANCH="${BMORELEASEBRANCH:-release-0.5}"
 else
   export CAPM3_IMAGE="${CAPM3_IMAGE:-${CONTAINER_REGISTRY}/metal3-io/cluster-api-provider-metal3:main}"


### PR DESCRIPTION
its basically a revert of #1378

Reason: we have decided to stick to a minor release of  ironic with a minor release of CAPM3/BMO/IPAM. This will allow us to still test 24.0.x with older release branch and test 24.1.x with the upcoming release-1.7.x of IPAM/CAPM3 and 0.6.x of BMO. 