### PR TITLE
There is conflicting rpm packages add --nobest flag

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -27,7 +27,7 @@ if [[ "${OS}" = "ubuntu" ]]; then
     sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1
   fi
 elif [[ "${OS}" = "centos" ]] || [[ "${OS}" = "rhel" ]]; then
-  sudo dnf upgrade -y
+  sudo dnf upgrade -y --nobest
   case "${VERSION_ID}" in
     8)
       sudo dnf config-manager --set-enabled powertools

--- a/vm-setup/roles/packages_installation/tasks/centos_required_packages.yml
+++ b/vm-setup/roles/packages_installation/tasks/centos_required_packages.yml
@@ -23,6 +23,7 @@
   dnf:
     name: "*"
     state: latest
+    nobest: true
   become: yes
 
 - name: Install podman


### PR DESCRIPTION
This flag ignores updating packages to the newest that are conflicting. 
This allows running dev-env even when some pakcages might be conflicting as this is not directly in our control.

This is related to this issue: https://github.com/metal3-io/project-infra/issues/738

Hopefully this would fix this issue to get the tests passing again 