### PR TITLE
speed up git cloning in dev-env

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -104,14 +104,17 @@ clone_repo() {
   if [[ -d "${REPO_PATH}" ]] && [[ "${FORCE_REPO_UPDATE}" = "true" ]]; then
     rm -rf "${REPO_PATH}"
   fi
-  if [[ ! -d "${REPO_PATH}" ]] ; then
+  if [[ ! -d "${REPO_PATH}" ]]; then
     pushd "${M3PATH}" || exit
-    git clone "${REPO_URL}" "${REPO_PATH}"
-    popd || exit
-    pushd "${REPO_PATH}" || exit
-    git checkout "${REPO_BRANCH}"
-    git checkout "${REPO_COMMIT}"
-    git pull -r || true
+    if [[ "${REPO_COMMIT}" = "HEAD" ]]; then
+        git clone --depth 1 --branch "${REPO_BRANCH}" "${REPO_URL}" \
+            "${REPO_PATH}"
+    else
+        git clone --branch "${REPO_BRANCH}" "${REPO_URL}" "${REPO_PATH}"
+        pushd "${REPO_PATH}" || exit
+        git checkout "${REPO_COMMIT}"
+        popd || exit
+    fi
     popd || exit
   fi
 }


### PR DESCRIPTION
This commit:
  - Aims to speed up the git cloning operations in dev-env by making the git clone operations shallow with depth 1
  - Implements a condition to avoid redundant commit checkout
  - Decreases number of checkout operations by one