### PR TITLE
add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,26 +1,20 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
- - kashifest
- - lentzi90
- - mboukhalfa
- - smoshiur1237
+- metal3-dev-env-maintainers
 
 reviewers:
- - dtantsur
- - elfosardo
- - Rozzii
- - Sunnatillo
- - tuminoid
+- metal3-dev-env-maintainers
+- metal3-dev-env-reviewers
 
 emeritus_approvers:
- - fmuyassarov
- - furkatgofurov7
- - hardys
- - maelk
+- fmuyassarov
+- furkatgofurov7
+- hardys
+- maelk
 
 emeritus_reviewers:
- - jan-est
- - macaptain
- - namnx228
- - xenwar 
+- jan-est
+- macaptain
+- namnx228
+- xenwar

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,15 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  metal3-dev-env-maintainers:
+  - kashifest
+  - lentzi90
+  - mboukhalfa
+  - smoshiur1237
+
+  metal3-dev-env-reviewers:
+  - dtantsur
+  - elfosardo
+  - Rozzii
+  - Sunnatillo
+  - tuminoid


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests.