### PR TITLE
Bump golang to v1.22.3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,7 +50,7 @@
       "matchPackageNames": [
         "golang"
       ],
-      "allowedVersions": "<=1.21"
+      "allowedVersions": "<=1.22"
     },
     {
       "matchPackageNames": [

--- a/vm-setup/install-package-playbook.yml
+++ b/vm-setup/install-package-playbook.yml
@@ -8,5 +8,5 @@
   - import_role:
       name: fubarhouse.golang
     vars:
-      go_version: 1.21.9
+      go_version: 1.22.3
       go_install_clean: true


### PR DESCRIPTION
This PR bumps golang to v1.22.3 for dev-env based tests. This is a minor version upgrade of go from v1.21.x to v1.22.x
Signed-off-by: Kashif Khan <kashif.khan@est.tech>