### PR TITLE
Install ansible in a virtual environment

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -16,7 +16,7 @@ if [[ "${OS}" = "ubuntu" ]]; then
   # make the data retrival more reliable
   sudo sh -c ' echo "Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries '
   sudo apt-get update
-  sudo apt-get -y install python3-pip python3-dev jq curl wget pkg-config bash-completion
+  sudo apt-get -y install python3-pip python3-dev python3-venv jq curl wget pkg-config bash-completion
 
   # Set update-alternatives to python3
   if [[ "${DISTRO}" = "ubuntu18" ]]; then
@@ -58,15 +58,18 @@ source lib/download.sh
 # shellcheck disable=SC1091
 source lib/network.sh
 
+# NOTE(dtantsur): system-site-packages is required because of certain Python
+# packages that cannot be pip-installed (firewalld, selinux, etc).
+sudo python -m venv --system-site-packages "${ANSIBLE_VENV}"
 # TODO: since ansible 8.0.0, pinning by digest is PITA, due additional ansible
 # dependencies, which would need to be pinned as well, so it is skipped for now
-sudo python -m pip install ansible=="${ANSIBLE_VERSION}"
+sudo "${ANSIBLE_VENV}/bin/pip" install ansible=="${ANSIBLE_VERSION}"
 
 # Install requirements
-ansible-galaxy install -r vm-setup/requirements.yml
+"${ANSIBLE}-galaxy" install -r vm-setup/requirements.yml
 
 # Install required packages
-ANSIBLE_FORCE_COLOR=true ansible-playbook \
+ANSIBLE_FORCE_COLOR=true "${ANSIBLE}-playbook" \
   -e "working_dir=${WORKING_DIR}" \
   -e "metal3_dir=${SCRIPTDIR}" \
   -e "virthost=${HOSTNAME}" \

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -105,7 +105,7 @@ if ! sudo test -f /root/.ssh/id_rsa_virt_power; then
     sudo cat /root/.ssh/id_rsa_virt_power.pub | sudo tee -a /root/.ssh/authorized_keys
 fi
 
-ANSIBLE_FORCE_COLOR=true ansible-playbook \
+ANSIBLE_FORCE_COLOR=true "${ANSIBLE}-playbook" \
     -e "working_dir=${WORKING_DIR}" \
     -e "num_nodes=${NUM_NODES}" \
     -e "extradisks=${VM_EXTRADISKS}" \
@@ -259,7 +259,7 @@ EOF
     fi
 fi
 
-ANSIBLE_FORCE_COLOR=true ansible-playbook \
+ANSIBLE_FORCE_COLOR=true "${ANSIBLE}-playbook" \
     -e "use_firewalld=${USE_FIREWALLD}" \
     -i vm-setup/inventory.ini \
     -b vm-setup/firewall.yml

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -31,7 +31,7 @@ if [ "${CAPM3_RUN_LOCAL}" = true ]; then
   fi
 fi
 
-ANSIBLE_FORCE_COLOR=true ansible-playbook \
+ANSIBLE_FORCE_COLOR=true "${ANSIBLE}-playbook" \
     -e "working_dir=$WORKING_DIR" \
     -e "num_nodes=$NUM_NODES" \
     -e "extradisks=$VM_EXTRADISKS" \
@@ -41,7 +41,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -i vm-setup/inventory.ini \
     -b -v vm-setup/teardown-playbook.yml
 
-ANSIBLE_FORCE_COLOR=true ansible-playbook \
+ANSIBLE_FORCE_COLOR=true "${ANSIBLE}-playbook" \
     -e "use_firewalld=${USE_FIREWALLD}" \
     -e "firewall_rule_state=absent" \
     -i vm-setup/inventory.ini \

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -232,6 +232,9 @@ export CAPM3_RUN_LOCAL="${CAPM3_RUN_LOCAL:-false}"
 export WORKING_DIR="${WORKING_DIR:-/opt/metal3-dev-env}"
 export NODES_FILE="${NODES_FILE:-${WORKING_DIR}/ironic_nodes.json}"
 export NODES_PLATFORM="${NODES_PLATFORM:-libvirt}"
+export ANSIBLE_VENV="${ANSIBLE_VENV:-"${WORKING_DIR}/venv"}"
+# shellcheck disable=SC2034
+ANSIBLE="${ANSIBLE_VENV}/bin/ansible"
 
 # Metal3
 export NAMESPACE="${NAMESPACE:-metal3}"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -32,7 +32,7 @@ export ANSIBLE_HOST_KEY_CHECKING=False
 # Ansible config file
 export ANSIBLE_CONFIG=${METAL3_DIR}/ansible.cfg
 
-ANSIBLE_FORCE_COLOR=true ansible-playbook \
+ANSIBLE_FORCE_COLOR=true "${ANSIBLE}-playbook" \
    -e "metal3_dir=$SCRIPTDIR" \
    -e "v1aX_integration_test_action=${ACTION}" \
    -i "${METAL3_DIR}/tests/inventory.ini" \

--- a/vm-setup/roles/packages_installation/tasks/main.yml
+++ b/vm-setup/roles/packages_installation/tasks/main.yml
@@ -25,7 +25,7 @@
       become: yes
     - name: Install packages using pip3
       pip:
-        executable: "pip3"
+        executable: "{{ ANSIBLE_VENV | default('/usr') }}/bin/pip"
         name: "{{ packages.ubuntu.pip3 }}"
         state: present
     - name: Add TPM emulator
@@ -66,7 +66,7 @@
       include_tasks: centos_required_packages.yml
     - name: Install packages using pip3
       pip:
-        executable: "pip3"
+        executable: "{{ ANSIBLE_VENV | default('/usr') }}/bin/pip"
         name: "{{ packages.centos.pip3 }}"
         state: present
     - name: Install TPM emulator packages


### PR DESCRIPTION
Installing packages globally with pip is not recommended since such
packages may conflict with the system. Using a virtual environment is
the approach we have employed in Bifrost for a long time, let's do the
same here.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
