### PR TITLE
Use Python from the Ansible venv when importing Jinja2

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -409,7 +409,7 @@ function launch_cluster_api_provider_metal3() {
 # -------------
 
 function render_j2_config () {
-  python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < "${1}"
+  "${ANSIBLE_VENV}/bin/python" -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < "${1}"
 }
 
 #


### PR DESCRIPTION
Nothing installs Jinja2, we just expect Ansible to pull it in. Now that
Ansible is installed in a venv, use Jinja2 from there.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
