### PR TITLE
restore centos required packages task

### DIFF
--- a/vm-setup/roles/packages_installation/tasks/centos_required_packages.yml
+++ b/vm-setup/roles/packages_installation/tasks/centos_required_packages.yml
@@ -1,0 +1,35 @@
+# Perform CentOS/RHEL related configurations
+- name: Fail if CONTAINER_RUNTIME is not set to podman
+  fail:
+    msg: Only Podman is supported in CentOS/RHEL
+  when: CONTAINER_RUNTIME != "podman"
+
+- name: Enable SELinux
+  ansible.posix.selinux:
+    policy: targeted
+    state: permissive
+  become: yes
+  when: ansible_selinux.status == "enabled"
+
+# Remove any previous tripleo-repos to avoid version conflicts
+# (see FIXME re oniguruma below)
+- name: Remove any previous tripleo-repos to avoid version conflicts
+  dnf:
+    name: python*-tripleo-repos
+    state: absent
+  become: yes
+
+- name: Upgrade all packages
+  dnf:
+    name: "*"
+    state: latest
+    nobest: true
+  become: yes
+
+- name: Install podman
+  dnf:
+    name: podman
+    state: present
+  become: yes
+  when: CONTAINER_RUNTIME == "podman"
+

--- a/vm-setup/roles/packages_installation/tasks/main.yml
+++ b/vm-setup/roles/packages_installation/tasks/main.yml
@@ -62,6 +62,8 @@
         executable: "{{ ANSIBLE_VENV | default('/usr') }}/bin/pip"
         name: "{{ packages.centos.pip3 }}"
         state: present
+    - name: Perform CentOS/RHEL required configurations
+      include_tasks: centos_required_packages.yml
     - name: Install TPM emulator packages
       when: tpm_emulator|default(false)|bool
       package:


### PR DESCRIPTION
It was removed in [Centos8 cleanup](https://github.com/metal3-io/metal3-dev-env/pull/1422), but it applies to Centos 9 too.

Without this, we don't have podman etc so it cannot work.