### PR TITLE
Remove support for Ubuntu 18 Bionic

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -19,9 +19,7 @@ if [[ "${OS}" = "ubuntu" ]]; then
   sudo apt-get -y install python3-pip python3-dev python3-venv jq curl wget pkg-config bash-completion
 
   # Set update-alternatives to python3
-  if [[ "${DISTRO}" = "ubuntu18" ]]; then
-    sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
-  elif [[ "${DISTRO}" = "ubuntu20" ]]; then
+  if [[ "${DISTRO}" = "ubuntu20" ]]; then
     sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
   elif [[ "${DISTRO}" = "ubuntu22" ]]; then
     sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -60,7 +60,7 @@ source /etc/os-release
 export DISTRO="${ID}${VERSION_ID%.*}"
 export OS="${ID}"
 export OS_VERSION_ID="${VERSION_ID}"
-export SUPPORTED_DISTROS=(centos9 rhel9 ubuntu18 ubuntu20 ubuntu22)
+export SUPPORTED_DISTROS=(centos9 rhel9 ubuntu20 ubuntu22)
 
 if [[ ! "${SUPPORTED_DISTROS[*]}" =~ ${DISTRO} ]]; then
   echo "Supported OS distros for the host are: CentOS Stream 9 or RHEL9 or Ubuntu20.04 or Ubuntu 22.04"
@@ -375,13 +375,10 @@ export TILT_SHA256="${TILT_SHA256:-b30ebbba68d4fd04f8afa11efc439515241dbcc2582ea
 
 # Ansible version
 # Older ubuntu version do no support 7.0.0 because of older python versions
-# Ubuntu 18 has 4.10.0 as latest ansible
 # Ansible 7.0.0 or newer requires python 3.10+
 # TODO: Ansible pinning
 if [[ "${DISTRO}" = "ubuntu22" ]]; then
     export ANSIBLE_VERSION="${ANSIBLE_VERSION:-8.0.0}"
-elif [[ "${DISTRO}" = "ubuntu18" ]]; then
-    export ANSIBLE_VERSION="${ANSIBLE_VERSION:-4.10.0}"
 else
     export ANSIBLE_VERSION="${ANSIBLE_VERSION:-6.7.0}"
 fi

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -31,12 +31,6 @@ packages:
         - ca-certificates
         - gnupg-agent
         - software-properties-common
-    bionic:
-      packages:
-        - libvirt-bin
-        - libpolkit-backend-1-0
-        - libssl1.0-dev
-        - python3-bcrypt
     focal_jammy:
       packages:
         - apparmor

--- a/vm-setup/roles/packages_installation/tasks/main.yml
+++ b/vm-setup/roles/packages_installation/tasks/main.yml
@@ -6,11 +6,6 @@
       package:
         name: "{{ packages.ubuntu.common.packages}}"
         state: present
-    - name: Install packages using standard package manager for Ubuntu 18.04
-      when: ansible_distribution_version == "18.04"
-      package:
-        name: "{{ packages.ubuntu.bionic.packages}}"
-        state: present
     - name: Install packages using standard package manager for Ubuntu 20.04 or Ubuntu 22.04
       when: ansible_distribution_version == "20.04" or ansible_distribution_version == "22.04"
       package:


### PR DESCRIPTION
It's not tested anymore and it has reached end of standard support a year ago.