### PR TITLE
[WIP] PoC Hostnetworkless Ironic with VirtualMedia Using MetalLB LoadBalancer

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -310,7 +310,8 @@ mkdir -p "${M3PATH}"
 # of the path
 detect_mismatch "${BMO_LOCAL_IMAGE:-}" "${BMOPATH}"
 clone_repo "${BMOREPO}" "${BMOBRANCH}" "${BMOPATH}" "${BMOCOMMIT}"
-
+# edit cloned bmo to run ironic without hostnetwork access
+cp -f ironic.yaml "${BMOPATH}/ironic-deployment/base/ironic.yaml"
 detect_mismatch "${CAPM3_LOCAL_IMAGE:-}" "${CAPM3PATH}"
 clone_repo "${CAPM3REPO}" "${CAPM3BRANCH}" "${CAPM3PATH}" "${CAPM3COMMIT}"
 

--- a/config_example.sh
+++ b/config_example.sh
@@ -79,7 +79,7 @@
 #
 # Force deletion of the BMO and CAPM3 repositories before cloning them again
 #
-#export FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-false}"
+export FORCE_REPO_UPDATE=false
 
 #
 # Run a local baremetal operator instead of deploying in Kubernetes
@@ -113,7 +113,7 @@
 # Set the driver. The default value is 'mixed' (alternate nodes between ipmi
 # and redfish). Can also be set explicitly to ipmi/redfish/redfish-virtualmedia.
 #
-#export BMC_DRIVER="mixed"
+export BMC_DRIVER="redfish-virtualmedia"
 
 #
 # Set libvirt firmware and BMC bootMode

--- a/ironic.yaml
+++ b/ironic.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ironic
+spec:
+  replicas: 1
+  minReadySeconds: 10
+  strategy:
+    # We cannot run Ironic with more than one replica at a time. The recreate
+    # strategy makes sure that the old pod is gone before a new is started.
+    type: Recreate
+  selector:
+    matchLabels:
+      name: ironic
+  template:
+    metadata:
+      labels:
+        name: ironic
+    spec:
+      containers:
+      - name: ironic
+        image: quay.io/metal3-io/ironic
+        imagePullPolicy: Always
+        command:
+        - /bin/runironic
+        volumeMounts:
+        - mountPath: /shared
+          name: ironic-data-volume
+        envFrom:
+        - configMapRef:
+            name: ironic-bmo-configmap
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: true
+          runAsUser: 0 # ironic
+          runAsGroup: 0 # ironic
+      - name: ironic-log-watch
+        image: quay.io/metal3-io/ironic
+        imagePullPolicy: Always
+        command:
+        - /bin/runlogwatch.sh
+        volumeMounts:
+        - mountPath: /shared
+          name: ironic-data-volume
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: true
+          runAsUser: 0 # ironic
+          runAsGroup: 0 # ironic
+      - name: ironic-httpd
+        image: quay.io/metal3-io/ironic
+        imagePullPolicy: Always
+        command:
+        - /bin/runhttpd
+        volumeMounts:
+        - mountPath: /shared
+          name: ironic-data-volume
+        envFrom:
+        - configMapRef:
+            name: ironic-bmo-configmap
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: true
+          runAsUser: 0 # ironic
+          runAsGroup: 0 # ironic
+      initContainers:
+      - name: ironic-ipa-downloader
+        image: quay.io/metal3-io/ironic-ipa-downloader
+        imagePullPolicy: Always
+        command:
+        - /usr/local/bin/get-resource.sh
+        envFrom:
+        - configMapRef:
+            name: ironic-bmo-configmap
+        volumeMounts:
+        - mountPath: /shared
+          name: ironic-data-volume
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: true
+          runAsUser: 0 # ironic
+          runAsGroup: 0 # ironic
+      volumes:
+      - name: ironic-data-volume
+        emptyDir: {}
+      securityContext:
+        runAsNonRoot: false
+        seccompProfile:
+          type: RuntimeDefault
+        fsGroup: 0

--- a/tests/roles/run_tests/tasks/move.yml
+++ b/tests/roles/run_tests/tasks/move.yml
@@ -132,6 +132,88 @@
     args:
       chdir: "{{ BMOPATH }}"
 
+  # Download and apply MetalLB manifest
+  - name: Download metrics-server manifest to the cluster.
+    ansible.builtin.get_url:
+      url: https://raw.githubusercontent.com/metallb/metallb/v0.14.5/config/manifests/metallb-native.yaml
+      dest: ~/metallb-native.yaml
+      mode: '0664'
+
+  - name: Apply MetalLB manifest to the cluster.
+    kubernetes.core.k8s:
+      state: present
+      src: ~/metallb-native.yaml
+      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
+
+  # Check for MetalLB pods on the target cluster
+  - name: Check if MetalLB  pods in running state
+    kubernetes.core.k8s_info:
+      kind: pods
+      namespace: metallb-system
+      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
+      field_selectors:
+        - status.phase!=Running
+    register: target_running_pods
+    retries: 20
+    delay: 20
+    until: (target_running_pods is succeeded) and
+           (target_running_pods.resources | length == 0)
+  - name: Pause for 1 minutes to avoid failure with the next steps
+    ansible.builtin.pause:
+      minutes: 1
+  - name: Create the IPAddressPool
+    kubernetes.core.k8s:
+      state: present
+      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
+      definition:
+        apiVersion: metallb.io/v1beta1
+        kind: IPAddressPool
+        metadata:
+          name: ironic-pool
+          namespace: metallb-system
+        spec:
+          addresses:
+          - 172.22.0.2-172.22.0.2
+  - name: Create the L2Advertisement
+    kubernetes.core.k8s:
+      state: present
+      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
+      definition:
+        apiVersion: metallb.io/v1beta1
+        kind: L2Advertisement
+        metadata:
+          name: ironic
+          namespace: metallb-system
+        spec:
+          ipAddressPools:
+          - ironic-pool
+  - name: Create the loadbalancer service
+    kubernetes.core.k8s:
+      state: present
+      kubeconfig: "/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"
+      definition:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ironic
+          namespace: baremetal-operator-system
+          annotations:
+            metallb.universe.tf/loadBalancerIPs: 172.22.0.2
+        spec:
+          ports:
+            - name: ironic
+              port: 6385
+              targetPort: 6385
+            - name: inspector
+              port: 5050
+              targetPort: 5050
+            - name: httpd
+              port: 6180
+              targetPort: 6180
+          selector:
+            name: ironic
+          type: LoadBalancer
+
   - name: Label baremetalhost CRD in target cluster to pivot back.
     shell: "kubectl --kubeconfig /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml label crds baremetalhosts.metal3.io {{ item }} --overwrite "
     with_items:

--- a/tests/roles/run_tests/vars/main.yml
+++ b/tests/roles/run_tests/vars/main.yml
@@ -94,7 +94,7 @@ IPAM_INSECURE_DIAGNOSTICS: "true"
 
 # Args to pass to the deploy.sh script when deploying Ironic and BMO
 # [k]eepalived [t]ls [n]o basic auth or [m]ariadb
-BMO_IRONIC_ARGS: "-k {{ (IRONIC_TLS_SETUP == 'true') | ternary('-t', '') }} {{ (IRONIC_BASIC_AUTH == 'true') | ternary('', '-n') }} {{ (IRONIC_USE_MARIADB == 'true') | ternary('-m', '') }}"
+BMO_IRONIC_ARGS: "{{ (IRONIC_TLS_SETUP == 'true') | ternary('-t', '') }} {{ (IRONIC_BASIC_AUTH == 'true') | ternary('', '-n') }} {{ (IRONIC_USE_MARIADB == 'true') | ternary('-m', '') }}"
 
 provision_cluster_actions:
 - "ci_test_provision"


### PR DESCRIPTION
⚠️ Do not merge this is only to demonstrate a PoC

This is a small PoC part of the short focus discussion https://github.com/metal3-io/baremetal-operator/discussions/1739. It demonstrate running Ironic without hostNetwork, limited to the virtualMedia use case, using a LoadBalancer service.

## Changes Needed

1. **Edit Ironic Deployment:**
   - Remove `hostNetwork: true`.
   - Remove `dnsmasq` container.
   -  Remove `keepalived` container.
   - Remove security restrictions to allow root access for debugging inside the containers.

2. **Add MetalLB Service:**
  Enable MetalLB on Minikube : `minikube addons enable metallb` 
  and install it on the target cluster :  `kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.5/config/manifests/metallb-native.yaml`
and create an ip pool: 
    ```
    apiVersion: metallb.io/v1beta1
    kind: IPAddressPool
    metadata:
      name: ironic-pool
      namespace: metallb-system
    spec:
      addresses:
      - 172.22.0.2-172.22.0.2
    ---
    apiVersion: metallb.io/v1beta1
    kind: L2Advertisement
    metadata:
      name: ironic
      namespace: metallb-system
    spec:
      ipAddressPools:
          - ironic-pool
    ```
2. **Add LoadBalancer Service:**
     ```
    apiVersion: v1
    kind: Service
    metadata:
      name: ironic
      annotations:
        metallb.universe.tf/loadBalancerIPs: 172.22.0.2
    spec:
      ports:
        - name: ironic
          port: 6385
          targetPort: 6385
        - name: inspector
          port: 5050
          targetPort: 5050
        - name: httpd
          port: 6180
          targetPort: 6180
      selector:
        name: ironic
      type: LoadBalancer
     ```

4. **Edit Ironic ConfigMap:**
   - Remove `PROVISIONING_IP` so that the `runironic` script uses the pod's IP from the `eth0` interface.
   - Add external Ironic IPs to be published to external components like IPA.

5. **Provisioning Networks:**
    - No need to configure the `ironicendpoint` with 172.22.0.2

/hold