### PR TITLE
:seedling: Verbose "Image not found" error, if local image doesn't exist or the url is missing the http part

### DIFF
--- a/lib/image_prepull.sh
+++ b/lib/image_prepull.sh
@@ -12,9 +12,12 @@ if [[ ! -f "${IMAGE_NAME}" ]]; then
     if [[ -f "${IMAGE_LOCATION}/${IMAGE_NAME}" ]]; then
       # Copy local image  
       cp "${IMAGE_LOCATION}/${IMAGE_NAME}" .
-    else
+    elif [[ "${IMAGE_LOCATION}" =~ ^http.* ]]; then
       # Downloading image if it does not exist locally
       wget --no-verbose --no-check-certificate "${IMAGE_LOCATION}/${IMAGE_NAME}"
+    else
+      echo "Image not found at ${IMAGE_LOCATION}/${IMAGE_NAME}"
+      exit 1
     fi
     IMAGE_SUFFIX="${IMAGE_NAME##*.}"
     if [[ "${IMAGE_SUFFIX}" = "xz" ]]; then


### PR DESCRIPTION
In `lib/image_prepull.sh`, if the local image doesn't exist, but IMAGE_LOCATION isn't pointing to a remote location, then the script should verbose the image, instead of trying to download.