### PR TITLE
Silence fetch logs and fetch manifests

### DIFF
--- a/tests/scripts/fetch_manifests.sh
+++ b/tests/scripts/fetch_manifests.sh
@@ -48,6 +48,8 @@ manifests=(
   m3datatemplate
 )
 
+set +x
+
 NAMESPACES="$(kubectl --kubeconfig="${kconfig}" get namespace -o jsonpath='{.items[*].metadata.name}')"
 for NAMESPACE in ${NAMESPACES}; do
   for kind in "${manifests[@]}"; do

--- a/tests/scripts/fetch_target_logs.sh
+++ b/tests/scripts/fetch_target_logs.sh
@@ -5,6 +5,9 @@ set -x
 KUBECONFIG_WORKLOAD="$(sudo find /tmp/ -type f -name "kubeconfig*")"
 DIR_NAME="/tmp/target_cluster_logs"
 NAMESPACES="$(kubectl --kubeconfig="${KUBECONFIG_WORKLOAD}" get namespace -o jsonpath='{.items[*].metadata.name}')"
+
+set +x
+
 mkdir -p "${DIR_NAME}"
 for NAMESPACE in ${NAMESPACES}
 do


### PR DESCRIPTION
Silence fetch logs and fetch manifests as they are too noise in the jenkins logs, which makes  debugging difficult. 