### PR TITLE
:seedling: Remove release 1.5 branch config

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -268,12 +268,7 @@ function apply_bm_hosts() {
 function update_capm3_imports(){
   pushd "${CAPM3PATH}"
 
-  # Modify the kustomization imports to use local BMO repo instead of Github Main
-  if [[ "${CAPM3RELEASEBRANCH}" == "release-1.5" ]] || [[ "${CAPM3RELEASEBRANCH}" == "release-1.4" ]]; then
-    make hack/tools/bin/kustomize
-  else
-    make kustomize
-  fi
+  make kustomize
   ./hack/tools/bin/kustomize build "${IPAMPATH}/config/default" > config/ipam/metal3-ipam-components.yaml
 
   sed -i -e "s#https://github.com/metal3-io/ip-address-manager/releases/download/v.*/ipam-components.yaml#metal3-ipam-components.yaml#" "config/ipam/kustomization.yaml"

--- a/README.md
+++ b/README.md
@@ -180,9 +180,8 @@ The following table describes which branches are tested for different test trigg
 | test suffix | CAPM3 branch | IPAM branch  | BMO branch/tag  | Keepalived tag | Ironic tag |
 | ----------- | ------------ | -----------  | --------------- | -------------- | ---------- |
 | main        | main         | main         | main            | latest         | latest     |
-| release-1-8 | release-1.8  | release-1.8  | release-0.8     | v0.8.0-rc.0    | v26.0.0    |
-| release-1-7 | release-1.7  | release-1.7  | release-0.6     | v0.6.1         | v24.1.1    |
-| release-1-6 | release-1.6  | release-1.6  | release-0.5     | v0.5.1         | v24.0.0    |
-| release-1-5 | release-1.5  | release-1.5  | release-0.4     | v0.4.2         | v23.1.0    |
+| release-1-8 | release-1.8  | release-1.8  | release-0.8     | v0.8.0         | v26.0.1    |
+| release-1-7 | release-1.7  | release-1.7  | release-0.6     | v0.6.1         | v25.0.1    |
+| release-1-6 | release-1.6  | release-1.6  | release-0.5     | v0.5.1         | v24.1.1    |
 
 <!-- markdownlint-enable MD013 -->

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -155,10 +155,7 @@ export CAPM3_BASE_URL="${CAPM3_BASE_URL:-metal3-io/cluster-api-provider-metal3}"
 export CAPM3REPO="${CAPM3REPO:-https://github.com/${CAPM3_BASE_URL}}"
 export CAPM3RELEASEBRANCH="${CAPM3RELEASEBRANCH:-main}"
 
-if [[ "${CAPM3RELEASEBRANCH}" == "release-1.5" ]]; then
-  export CAPM3BRANCH="${CAPM3BRANCH:-release-1.5}"
-  export IPAMBRANCH="${IPAMBRANCH:-release-1.5}"
-elif [[ "${CAPM3RELEASEBRANCH}" == "release-1.6" ]]; then
+if [[ "${CAPM3RELEASEBRANCH}" == "release-1.6" ]]; then
   export CAPM3BRANCH="${CAPM3BRANCH:-release-1.6}"
   export IPAMBRANCH="${IPAMBRANCH:-release-1.6}"
 elif [[ "${CAPM3RELEASEBRANCH}" == "release-1.7" ]]; then

--- a/lib/releases.sh
+++ b/lib/releases.sh
@@ -69,11 +69,7 @@ function get_latest_release() {
 CAPIRELEASEPATH="{https://api.github.com/repos/${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}/releases}"
 
 # CAPM3, CAPI and BMO releases
-if [ "${CAPM3RELEASEBRANCH}" = "release-1.5" ]; then
-  # 1.5.99 points to the head of the release-1.5 branch. Local override for CAPM3 is created for this version.
-  export CAPM3RELEASE="v1.5.99"
-  export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v1.5.")}"
-elif [ "${CAPM3RELEASEBRANCH}" = "release-1.6" ]; then
+if [ "${CAPM3RELEASEBRANCH}" = "release-1.6" ]; then
   # 1.6.99 points to the head of the release-1.6 branch. Local override for CAPM3 is created for this version.
   export CAPM3RELEASE="v1.6.99"
   export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v1.6.")}"

--- a/vars.md
+++ b/vars.md
@@ -31,7 +31,7 @@ assured that they are persisted.
 | TEST_MAX_TIME | Number of maximum verification or test retries | | 120 |
 | BMO_ROLLOUT_WAIT | Number of minutes(Until max 10m that is the default value of deployment.spec.progressDeadlineSeconds) to wait for BMO rollout | | 5 |
 | BMC_DRIVER | Set the BMC driver | "ipmi", "redfish", "redfish-virtualmedia" | "mixed" |
-| BMORELEASEBRANCH | BMO Release branch | "main", "release-0.4" | Set via jjb for CI, for local dev it gets default value based on CAPM3 branch |
+| BMORELEASEBRANCH | BMO Release branch | "main", "release-0.5", "release-0.6", "release-0.8" | Set via jjb for CI, for local dev it gets default value based on CAPM3 branch |
 | BOOT_MODE  | Set libvirt firmware and BMH bootMode | "legacy", "UEFI", "UEFISecureBoot" | "legacy" |
 | IMAGE_OS | OS of the image to boot the nodes from, overriden by IMAGE\_\* if set | "centos", "cirros", "FCOS", "ubuntu", "flatcar" | "centos" |
 | IMAGE_NAME | Image for target hosts deployment | | "CENTOS_9_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2" |

--- a/vm-setup/install-package-playbook.yml
+++ b/vm-setup/install-package-playbook.yml
@@ -8,5 +8,5 @@
   - import_role:
       name: fubarhouse.golang
     vars:
-      go_version: "{{ '1.21.11' if lookup('env', 'CAPM3RELEASEBRANCH') == 'release-1.5' else '1.22.4' }}"
+      go_version: 1.22.7
       go_install_clean: true


### PR DESCRIPTION
This PR removes release-1.5 related config, fixes BMO version and ironic-image versions, as ironic release-26.0 is out now.