### PR TITLE
:seedling: Fix `make` pass if ironic endpoint returns 000

### DIFF
--- a/04_verify.sh
+++ b/04_verify.sh
@@ -290,8 +290,7 @@ elif [[ $status == 401 ]]; then
     echo "OK - Ironic endpoint is secured"
 else
     echo "FAIL- got $status from ${IRONIC_NODES_ENDPOINT}, expected 401"
-    echo ""
-    exit "$status"
+    exit 1
 fi
 echo ""
 


### PR DESCRIPTION
Recently we faced this issue when `04_verify.sh` script will pass, even if IRONIC_NODES_ENDPOINT does not return code 401 [1]

The edge case was when ironic is not up, or the `curl` request did not reach ironic server, then the return will be of code `000`. Exiting the script with that code will mean the script passes.

This PR changes the behavior and exits the script with code `1` instead.

https://jenkins.nordix.org/blue/organizations/jenkins/metal3-periodic-dev-env-integration-test-centos-main/detail/metal3-periodic-dev-env-integration-test-centos-main/150/pipeline/