### PR TITLE
Enable 'redfish-uefihttp' as a vm_driver_tmp

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -111,7 +111,7 @@
 
 #
 # Set the driver. The default value is 'mixed' (alternate nodes between ipmi
-# and redfish). Can also be set explicitly to ipmi/redfish/redfish-virtualmedia.
+# and redfish). Can also be set explicitly to ipmi/redfish/redfish-virtualmedia/redfish-uefihttp.
 #
 #export BMC_DRIVER="mixed"
 

--- a/vars.md
+++ b/vars.md
@@ -31,7 +31,7 @@ assured that they are persisted.
 | TEST_TIME_INTERVAL | Interval between retries after verification or test failure (seconds) | | 10 |
 | TEST_MAX_TIME | Number of maximum verification or test retries | | 120 |
 | BMO_ROLLOUT_WAIT | Number of minutes(Until max 10m that is the default value of deployment.spec.progressDeadlineSeconds) to wait for BMO rollout | | 5 |
-| BMC_DRIVER | Set the BMC driver | "ipmi", "redfish", "redfish-virtualmedia" | "mixed" |
+| BMC_DRIVER | Set the BMC driver | "ipmi", "redfish", "redfish-virtualmedia", "redfish-uefihttp" | "mixed" |
 | BMORELEASEBRANCH | BMO Release branch | "main", "release-0.5", "release-0.6", "release-0.8" | Set via jjb for CI, for local dev it gets default value based on CAPM3 branch |
 | BOOT_MODE  | Set libvirt firmware and BMH bootMode | "legacy", "UEFI", "UEFISecureBoot" | "legacy" |
 | IMAGE_OS | OS of the image to boot the nodes from, overriden by IMAGE\_\* if set | "centos", "cirros", "FCOS", "ubuntu", "flatcar" | "centos" |

--- a/vm-setup/roles/common/templates/ironic_nodes.json.j2
+++ b/vm-setup/roles/common/templates/ironic_nodes.json.j2
@@ -45,6 +45,9 @@
         {% elif vm_driver_tmp == 'redfish-virtualmedia' -%}
         "port": "8000",
         "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
+        {% elif vm_driver_tmp == 'redfish-uefihttp' -%}
+        "port": "8000",
+        "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
         {% else -%}
         "port": "{{ node.virtualbmc_port }}",
         "address": "{{vm_driver_tmp}}://{{lvars['host_ip'] | ipwrap }}:{{node.virtualbmc_port}}",


### PR DESCRIPTION
Enable driver to boot VM's with 'BootSourceOverrideTarget': 'UefiHttp'