### PR TITLE
🌱 Add tls certs to fakeIPA config

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -344,26 +344,30 @@ EOF
 #
 # Launch and configure fakeIPA
 #
-launch_fake_ipa()
-{
-    # Create a folder to host fakeIPA config and certs
-    mkdir -p "${WORKING_DIR}/fake-ipa"
-    if [[ "${EPHEMERAL_CLUSTER}" = "kind" ]] && [[ "${IRONIC_TLS_SETUP}" = "true" ]]; then
-        cp "${IRONIC_CACERT_FILE}" "${WORKING_DIR}/fake-ipa/ironic-ca.crt"
-    elif [[ "${IRONIC_TLS_SETUP}" = "true" ]]; then
-        # wait for ironic to be running to ensure ironic-cert is created
-        kubectl -n baremetal-operator-system wait --for=condition=available deployment/baremetal-operator-ironic --timeout=900s
-        # Extract ironic-cert to be used inside fakeIPA for TLS
-        kubectl get secret -n baremetal-operator-system ironic-cert -o json -o=jsonpath="{.data.ca\.crt}" | base64 -d > "${WORKING_DIR}/fake-ipa/ironic-ca.crt"
-    fi
-
-    # Create fake IPA custom config
-    cat <<EOF > "${WORKING_DIR}/fake-ipa/config.py"
+launch_fake_ipa() {
+  # Create a folder to host fakeIPA config and certs
+  mkdir -p "${WORKING_DIR}/fake-ipa"
+  if [[ "${EPHEMERAL_CLUSTER}" == "kind" ]] && [[ "${IRONIC_TLS_SETUP}" == "true" ]]; then
+    cp "${IRONIC_CACERT_FILE}" "${WORKING_DIR}/fake-ipa/ironic-ca.crt"
+    cp "${IRONIC_CERT_FILE}" "${WORKING_DIR}/fake-ipa/ironic-tls.crt"
+    cp "${IRONIC_KEY_FILE}" "${WORKING_DIR}/fake-ipa/ironic-tls.key"
+  elif [[ "${IRONIC_TLS_SETUP}" == "true" ]]; then
+    # wait for ironic to be running to ensure ironic-cert is created 
+    kubectl -n baremetal-operator-system wait --for=condition=available deployment/baremetal-operator-ironic --timeout=900s
+    # Extract ironic-cert to be used inside fakeIPA for TLS 
+    kubectl get secret -n baremetal-operator-system ironic-cert -o json -o=jsonpath="{.data.ca\.crt}" | base64 -d > "${WORKING_DIR}/fake-ipa/ironic-ca.crt"
+    kubectl get secret -n baremetal-operator-system ironic-cert -o json -o=jsonpath="{.data.tls\.crt}" | base64 -d > "${WORKING_DIR}/fake-ipa/ironic-tls.crt"
+    kubectl get secret -n baremetal-operator-system ironic-cert -o json -o=jsonpath="{.data.tls\.key}" | base64 -d > "${WORKING_DIR}/fake-ipa/ironic-tls.key"
+  fi
+  # Create fake IPA custom config
+  cat << EOF > "${WORKING_DIR}/fake-ipa/config.py"
 FAKE_IPA_API_URL = "https://${CLUSTER_BARE_METAL_PROVISIONER_IP}:${IRONIC_API_PORT}"
 FAKE_IPA_INSPECTION_CALLBACK_URL = "${IRONIC_URL}/continue_inspection"
 FAKE_IPA_ADVERTISE_ADDRESS_IP = "${EXTERNAL_SUBNET_V4_HOST}"
 FAKE_IPA_INSECURE = ${FAKE_IPA_INSECURE:-False}
 FAKE_IPA_CAFILE = "${FAKE_IPA_CAFILE:-/root/cert/ironic-ca.crt}"
+FAKE_IPA_CERTFILE = "${FAKE_IPA_CERTFILE:-/root/cert/ironic-tls.crt}"
+FAKE_IPA_KEYFILE = "${FAKE_IPA_KEYFILE:-/root/cert/ironic-tls.key}"
 FAKE_IPA_MIN_BOOT_TIME = ${FAKE_IPA_MIN_BOOT_TIME:-20}
 FAKE_IPA_MAX_BOOT_TIME = ${FAKE_IPA_MAX_BOOT_TIME:-30}
 EOF

--- a/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
+++ b/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
@@ -149,6 +149,7 @@
       SUSHY_EMULATOR_VMEDIA_VERIFY_SSL = {{ sushy_vmedia_verify_ssl }}
       SUSHY_EMULATOR_AUTH_FILE = "/root/sushy/htpasswd"
       SUSHY_EMULATOR_FAKE_DRIVER = True
+      EXTERNAL_NOTIFICATION_URL = "https://localhost:9999"
       SUSHY_EMULATOR_FAKE_IPA = True
       SUSHY_EMULATOR_FAKE_SYSTEMS = {{ lookup('ansible.builtin.file', fake_nodes_file ) }}
   become: true


### PR DESCRIPTION
After merging https://github.com/metal3-io/utility-images/pull/26 we can set TLS certs path in fakeIPA config to enable TLS

This needs to wait for sushy-tools image and release with the following patch :https://review.opendev.org/c/openstack/sushy-tools/+/933551

/hold