### PR TITLE
Initial support for ironic-standalone-operator

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -321,6 +321,9 @@ clone_repo "${IPAMREPO}" "${IPAMBRANCH}" "${IPAMPATH}" "${IPAMCOMMIT}"
 detect_mismatch "${CAPI_LOCAL_IMAGE:-}" "${CAPIPATH}"
 clone_repo "${CAPIREPO}" "${CAPIBRANCH}" "${CAPIPATH}" "${CAPICOMMIT}"
 
+detect_mismatch "${IRSO_LOCAL_IMAGE:-}" "${IRSOPATH}"
+clone_repo "${IRSOREPO}" "${IRSOBRANCH}" "${IRSOPATH}" "${IRSOCOMMIT}"
+
 # MariaDB and Ironic source is not needed unless the images are built locally
 # If the repo path does not match with the IMAGE location that means the image
 # is built from a repo that is not under dev-env's control thus there is no

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -311,56 +311,57 @@ function update_capm3_imports(){
   popd
 }
 
-#
-# Update the CAPM3 and BMO manifests to use local images as defined in variables
-#
-function update_component_image(){
-  IMPORT=$1
-  ORIG_IMAGE=$2
+function get_component_image(){
+  local ORIG_IMAGE=$1
   # Split the image IMAGE_NAME AND IMAGE_TAG, if any tag exist
-  TMP_IMAGE="${ORIG_IMAGE##*/}"
-  TMP_IMAGE_NAME="${TMP_IMAGE%%:*}"
-  TMP_IMAGE_TAG="${TMP_IMAGE##*:}"
+  local TMP_IMAGE="${ORIG_IMAGE##*/}"
+  local TMP_IMAGE_NAME="${TMP_IMAGE%%:*}"
+  local TMP_IMAGE_TAG="${TMP_IMAGE##*:}"
   # Assign the image tag to latest if there is no tag in the image
   if [ "${TMP_IMAGE_NAME}" == "${TMP_IMAGE_TAG}" ]; then
     TMP_IMAGE_TAG="latest"
   fi
 
+  echo "${REGISTRY}/localimages/${TMP_IMAGE_NAME}:${TMP_IMAGE_TAG}"
+}
+
+#
+# Update the CAPM3 and BMO manifests to use local images as defined in variables
+#
+function update_component_image(){
+  local IMPORT=$1
+  local ORIG_IMAGE=$2
+  local TMP_IMAGE
+  TMP_IMAGE="$(get_component_image "$ORIG_IMAGE")"
+  if [[ "${IMPORT}" == "IPAM" ]]; then
+    export MANIFEST_IMG_IPAM="${TMP_IMAGE%:*}"
+    export MANIFEST_TAG_IPAM="${TMP_IMAGE##*:}"
+  else
+    export MANIFEST_IMG="${TMP_IMAGE%:*}"
+    export MANIFEST_TAG="${TMP_IMAGE##*:}"
+  fi
+
   # NOTE: It is assumed that we are already in the correct directory to run make
   case "${IMPORT}" in
     "BMO")
-      export MANIFEST_IMG="${REGISTRY}/localimages/${TMP_IMAGE_NAME}"
-      export MANIFEST_TAG="${TMP_IMAGE_TAG}"
       make set-manifest-image-bmo
       ;;
     "CAPM3")
-      export MANIFEST_IMG="${REGISTRY}/localimages/${TMP_IMAGE_NAME}"
-      export MANIFEST_TAG="${TMP_IMAGE_TAG}"
       make set-manifest-image
       ;;
     "IPAM")
-      export MANIFEST_IMG_IPAM="${REGISTRY}/localimages/$TMP_IMAGE_NAME"
-      export MANIFEST_TAG_IPAM="$TMP_IMAGE_TAG"
       make set-manifest-image-ipam
       ;;
     "Ironic")
-      export MANIFEST_IMG="${REGISTRY}/localimages/${TMP_IMAGE_NAME}"
-      export MANIFEST_TAG="${TMP_IMAGE_TAG}"
       make set-manifest-image-ironic
       ;;
     "Mariadb")
-      export MANIFEST_IMG="${REGISTRY}/localimages/${TMP_IMAGE_NAME}"
-      export MANIFEST_TAG="${TMP_IMAGE_TAG}"
       make set-manifest-image-mariadb
       ;;
     "Keepalived")
-      export MANIFEST_IMG="${REGISTRY}/localimages/${TMP_IMAGE_NAME}"
-      export MANIFEST_TAG="${TMP_IMAGE_TAG}"
       make set-manifest-image-keepalived
       ;;
     "IPA-downloader")
-      export MANIFEST_IMG="${REGISTRY}/localimages/${TMP_IMAGE_NAME}"
-      export MANIFEST_TAG="${TMP_IMAGE_TAG}"
       make set-manifest-image-ipa-downloader
       ;;
   esac

--- a/config_example.sh
+++ b/config_example.sh
@@ -213,3 +213,6 @@
 # To enable FakeIPA and run dev-env on a fake platform
 # export NODES_PLATFORM="fake"
 # export FAKE_IPA_IMAGE=192.168.111.1:5000/localimages/fake-ipa
+
+# Whether to use ironic-standalone-operator to deploy Ironic.
+# export USE_IRSO="true"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -155,6 +155,7 @@ export CAPM3_BASE_URL="${CAPM3_BASE_URL:-metal3-io/cluster-api-provider-metal3}"
 export CAPM3REPO="${CAPM3REPO:-https://github.com/${CAPM3_BASE_URL}}"
 export CAPM3RELEASEBRANCH="${CAPM3RELEASEBRANCH:-main}"
 
+export USE_IRSO="${USE_IRSO:-false}"
 export IRSOPATH="${IRSOPATH:-${M3PATH}/ironic-standalone-operator}"
 export IRSO_BASE_URL="${IRSO_BASE_URL:-metal3-io/ironic-standalone-operator}"
 export IRSOREPO="${IRSOREPO:-https://github.com/${IRSO_BASE_URL}}"
@@ -204,6 +205,7 @@ export BUILD_BMO_LOCALLY="${BUILD_BMO_LOCALLY:-false}"
 export BUILD_CAPI_LOCALLY="${BUILD_CAPI_LOCALLY:-false}"
 export BUILD_IRONIC_IMAGE_LOCALLY="${BUILD_IRONIC_IMAGE_LOCALLY:-false}"
 export BUILD_MARIADB_IMAGE_LOCALLY="${BUILD_MARIADB_IMAGE_LOCALLY:-false}"
+export BUILD_IRSO_LOCALLY="${BUILD_IRSO_LOCALLY:-false}"
 
 # If IRONIC_FROM_SOURCE has a "true" value that
 # automatically requires BUILD_IRONIC_IMAGE_LOCALLY to have "true" value too
@@ -400,6 +402,7 @@ TEST_MAX_TIME="${TEST_MAX_TIME:-240}"
 FAILS=0
 RESULT_STR=""
 BMO_ROLLOUT_WAIT="${BMO_ROLLOUT_WAIT:-5}"
+IRONIC_ROLLOUT_WAIT="${IRONIC_ROLLOUT_WAIT:-10}"
 
 # Avoid printing skipped Ansible tasks
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS="no"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -155,6 +155,11 @@ export CAPM3_BASE_URL="${CAPM3_BASE_URL:-metal3-io/cluster-api-provider-metal3}"
 export CAPM3REPO="${CAPM3REPO:-https://github.com/${CAPM3_BASE_URL}}"
 export CAPM3RELEASEBRANCH="${CAPM3RELEASEBRANCH:-main}"
 
+export IRSOPATH="${IRSOPATH:-${M3PATH}/ironic-standalone-operator}"
+export IRSO_BASE_URL="${IRSO_BASE_URL:-metal3-io/ironic-standalone-operator}"
+export IRSOREPO="${IRSOREPO:-https://github.com/${IRSO_BASE_URL}}"
+export IRSOBRANCH="${IRSOBRANCH:-main}"
+
 if [[ "${CAPM3RELEASEBRANCH}" == "release-1.6" ]]; then
   export CAPM3BRANCH="${CAPM3BRANCH:-release-1.6}"
   export IPAMBRANCH="${IPAMBRANCH:-release-1.6}"
@@ -181,6 +186,7 @@ export BMOCOMMIT="${BMOCOMMIT:-HEAD}"
 export CAPM3COMMIT="${CAPM3COMMIT:-HEAD}"
 export IPAMCOMMIT="${IPAMCOMMIT:-HEAD}"
 export CAPICOMMIT="${CAPICOMMIT:-HEAD}"
+export IRSOCOMMIT="${IRSOCOMMIT:-HEAD}"
 
 export IRONIC_IMAGE_PATH="${IRONIC_IMAGE_PATH:-/tmp/ironic-image}"
 export IRONIC_IMAGE_REPO="${IRONIC_IMAGE_REPO:-https://github.com/metal3-io/ironic-image.git}"
@@ -225,6 +231,9 @@ fi
 if [[ "${BUILD_MARIADB_IMAGE_LOCALLY}" == "true" ]]; then
   export MARIADB_LOCAL_IMAGE="${MARIADB_IMAGE_PATH}"
 fi
+if [[ "${BUILD_IRSO_LOCALLY}" == "true" ]]; then
+  export IRSO_LOCAL_IMAGE="${IRSOPATH}"
+fi
 
 export BMO_RUN_LOCAL="${BMO_RUN_LOCAL:-false}"
 export CAPM3_RUN_LOCAL="${CAPM3_RUN_LOCAL:-false}"
@@ -251,6 +260,7 @@ export IRONIC_TAG="${IRONIC_TAG:-latest}"
 export BARE_METAL_OPERATOR_TAG="${BARE_METAL_OPERATOR_TAG:-latest}"
 export KEEPALIVED_TAG="${KEEPALIVED_TAG:-latest}"
 export MARIADB_TAG="${MARIADB_TAG:-latest}"
+export IRSO_TAG="${IRSO_TAG:-latest}"
 
 # Docker Hub proxy registry (or docker.io if no proxy)
 export DOCKER_HUB_PROXY="${DOCKER_HUB_PROXY:-docker.io}"
@@ -311,6 +321,7 @@ export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
 export IRONIC_IMAGE_DIR="$IRONIC_DATA_DIR/html/images"
 export IRONIC_NAMESPACE="${IRONIC_NAMESPACE:-baremetal-operator-system}"
 export NAMEPREFIX="${NAMEPREFIX:-baremetal-operator}"
+export IRSO_IMAGE=${IRSO_IMAGE:-"${CONTAINER_REGISTRY}/metal3-io/ironic-standalone-operator:${IRSO_TAG}"}
 
 # iPXE vars of ironic-image
 export BUILD_IPXE="${BUILD_IPXE:-false}"

--- a/lib/ironic_basic_auth.sh
+++ b/lib/ironic_basic_auth.sh
@@ -9,7 +9,7 @@ if [ "${IRONIC_BASIC_AUTH}" == "true" ]; then
     if [ -z "${IRONIC_USERNAME:-}" ]; then
         if [ ! -f "${IRONIC_AUTH_DIR}ironic-username" ]; then
             IRONIC_USERNAME="$(uuidgen)"
-            echo "$IRONIC_USERNAME" > "${IRONIC_AUTH_DIR}ironic-username"
+            echo -n "$IRONIC_USERNAME" > "${IRONIC_AUTH_DIR}ironic-username"
         else
             IRONIC_USERNAME="$(cat "${IRONIC_AUTH_DIR}ironic-username")"
         fi
@@ -17,7 +17,7 @@ if [ "${IRONIC_BASIC_AUTH}" == "true" ]; then
     if [ -z "${IRONIC_PASSWORD:-}" ]; then
         if [ ! -f "${IRONIC_AUTH_DIR}ironic-password" ]; then
             IRONIC_PASSWORD="$(uuidgen)"
-            echo "$IRONIC_PASSWORD" > "${IRONIC_AUTH_DIR}ironic-password"
+            echo -n "$IRONIC_PASSWORD" > "${IRONIC_AUTH_DIR}ironic-password"
         else
             IRONIC_PASSWORD="$(cat "${IRONIC_AUTH_DIR}ironic-password")"
         fi

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -82,8 +82,8 @@ else
 fi
 
 # Calculate DHCP range
-network_address ironic_dhcp_range_start "$BARE_METAL_PROVISIONER_NETWORK" 10
-network_address ironic_dhcp_range_end "$BARE_METAL_PROVISIONER_NETWORK" 100
+network_address CLUSTER_DHCP_RANGE_START "$BARE_METAL_PROVISIONER_NETWORK" 10
+network_address CLUSTER_DHCP_RANGE_END "$BARE_METAL_PROVISIONER_NETWORK" 100
 # The nex range is for IPAM to know what is the pool that porovisioned noodes
 # can get IP's from
 network_address IPAM_PROVISIONING_POOL_RANGE_START "$BARE_METAL_PROVISIONER_NETWORK" 100
@@ -91,7 +91,7 @@ network_address IPAM_PROVISIONING_POOL_RANGE_END "$BARE_METAL_PROVISIONER_NETWOR
 
 export IPAM_PROVISIONING_POOL_RANGE_START
 export IPAM_PROVISIONING_POOL_RANGE_END
-export CLUSTER_DHCP_RANGE=${CLUSTER_DHCP_RANGE:-"$ironic_dhcp_range_start,$ironic_dhcp_range_end"}
+export CLUSTER_DHCP_RANGE=${CLUSTER_DHCP_RANGE:-"$CLUSTER_DHCP_RANGE_START,$CLUSTER_DHCP_RANGE_END"}
 
 EXTERNAL_SUBNET=${EXTERNAL_SUBNET:-""}
 if [[ -n "${EXTERNAL_SUBNET}" ]]; then

--- a/vars.md
+++ b/vars.md
@@ -138,6 +138,9 @@ assured that they are persisted.
 | IPA_BASEURI | IPA downloader will download IPA from this url | | https://tarballs.opendev.org/openstack/ironic-python-agent/dib |
 | IPA_BRANCH | The last part of the name of the IPA archive | | master |
 | IPA_FLAVOR | The middle part of the name of the IPA archive | | centos9 |
+| IRSOREPO | Ironic Standalone Operator git repository URL | | https://github.com/metal3-io/ironic-standalone-operator.git |
+| IRSOBRANCH | Ironic Standalone Operator git repository branch to checkout | | main |
+| IRSOCOMMIT | Ironic Standalone Operator git commit to checkout on IRSOBRANCH | | HEAD |
 <!-- markdownlint-enable MD013 MD034 -->
 
 **NOTE** `(BMO/CAPI/CAPM3/IPAM)RELEASE` variables are also affecting the


### PR DESCRIPTION
Installs ironic-standalone-operator by default (but does not use it).

Adds a new option USE_IRSO (default false) to use the operator to provision Ironic.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
