### PR TITLE
Disable ironic agent tls with fakeIPA until sushy-tools support external notifer tls

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -173,6 +173,11 @@ EOF
     echo "IRONIC_KERNEL_PARAMS=console=ttyS0" | sudo tee -a "${IRONIC_DATA_DIR}/ironic_bmo_configmap.env"
   fi
 
+  # TODO (mboukhalfa) enable heartbeating and ironic TLS when sushy-tools release v1.3.1
+  if [[ "${NODES_PLATFORM}" == "fake" ]]; then
+    echo "OS_AGENT__REQUIRE_TLS=false" | sudo tee -a "${IRONIC_DATA_DIR}/ironic_bmo_configmap.env"
+  fi
+
   if [ -n "${DHCP_IGNORE:-}" ]; then
     echo "DHCP_IGNORE=${DHCP_IGNORE}" | sudo tee -a "${IRONIC_DATA_DIR}/ironic_bmo_configmap.env"
   fi


### PR DESCRIPTION
This PR addresses disable supporting TLS between FakeIPA and Ironic due to the sushy-tools notifier issue https://kubernetes.slack.com/archives/CHD49TLE7/p1730115443534169?thread_ts=1721659136.820069&cid=CHD49TLE7. The existing implementation is incompatible with TLS.

TLS support can be enabled following the next release of sushy-tools, which will include the patch to resolve this issue [sushy-tools patch](https://review.opendev.org/c/openstack/sushy-tools/+/933551).