### PR TITLE
Temporary pin ironic-standalone-operator image

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -420,7 +420,7 @@ for IMAGE_VAR in $(env | grep -v "_LOCAL_IMAGE=" | grep "_IMAGE=" | grep -o "^[^
     # shellcheck disable=SC2086
     IMAGE_NAME="${IMAGE##*/}"
     # shellcheck disable=SC2086
-    LOCAL_IMAGE="${REGISTRY}/localimages/${IMAGE_NAME}"
+    LOCAL_IMAGE="${REGISTRY}/localimages/${IMAGE_NAME%@*}"
     sudo "${CONTAINER_RUNTIME}" tag "${IMAGE}" "${LOCAL_IMAGE}"
 
     if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -408,6 +408,8 @@ function get_component_image(){
   local ORIG_IMAGE=$1
   # Split the image IMAGE_NAME AND IMAGE_TAG, if any tag exist
   local TMP_IMAGE="${ORIG_IMAGE##*/}"
+  # Remove the digest (already considered when caching the image)
+  TMP_IMAGE="${TMP_IMAGE%@*}"
   local TMP_IMAGE_NAME="${TMP_IMAGE%%:*}"
   local TMP_IMAGE_TAG="${TMP_IMAGE##*:}"
   # Assign the image tag to latest if there is no tag in the image

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -262,7 +262,8 @@ export IRONIC_TAG="${IRONIC_TAG:-latest}"
 export BARE_METAL_OPERATOR_TAG="${BARE_METAL_OPERATOR_TAG:-latest}"
 export KEEPALIVED_TAG="${KEEPALIVED_TAG:-latest}"
 export MARIADB_TAG="${MARIADB_TAG:-latest}"
-export IRSO_TAG="${IRSO_TAG:-latest}"
+# FIXME(dtantsur): pinned temporary to avoid breakages while we're preparing the MVP release
+export IRSO_TAG="${IRSO_TAG:-main@sha256:8fe5e8338d791550cc53d28ae9b63bd4ce3ed687ce147ea33021c21379170a33}"
 
 # Docker Hub proxy registry (or docker.io if no proxy)
 export DOCKER_HUB_PROXY="${DOCKER_HUB_PROXY:-docker.io}"


### PR DESCRIPTION
We're going to merge a few API breaking changes in preparation for the
MVP release. To ensure that metal3-dev-env can be used in the meantime,
pin the image to the current digest.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
