### PR TITLE
Wait for local ironic to be up

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -232,6 +232,9 @@ EOF
     if [[ "${EPHEMERAL_CLUSTER}" != "minikube" ]]; then
         update_images
         ${RUN_LOCAL_IRONIC_SCRIPT}
+        # Wait for ironic to become ready
+        echo "Waiting for Ironic to become ready"
+        retry sudo "${CONTAINER_RUNTIME}" exec ironic /bin/ironic-readiness
     else
         # Deploy Ironic using deploy.sh script
         "${BMOPATH}/tools/deploy.sh" -i "${BMO_IRONIC_ARGS[@]}"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -521,6 +521,26 @@ iterate(){
   return "${TMP_RET_CODE}"
 }
 
+#
+# Retry a command until it runs successfully or exceeds the maximum retries
+#
+# Inputs:
+# - the command to run
+#
+retry()
+{
+    local retries=10
+    local i
+    for i in $(seq 1 "${retries}"); do
+        if "${@}"; then
+            return 0
+        fi
+        echo "Retrying... ${i}/${retries}"
+        sleep 5
+    done
+    return 1
+}
+
 
 #
 # Check the return code


### PR DESCRIPTION
This ensures that ironic is ready before proceeding when running ironic locally. It is specifically needed when SKIP_APPLY_BMH is set to true. In this case we will otherwise continue straight to 04_verify.sh with a high probability of finding the ironic endpoint unavailable.

When SKIP_APPLY_BMH is NOT true, we will in any case implicitly wait for ironic, since the BMHs won't become ready until ironic does.

This should fix the clusterctl upgrade job: https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3-periodic-e2e-clusterctl-upgrade-test-main/