### PR TITLE
launch irso only we we actually use it

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -731,8 +731,8 @@ patch_clusterctl
 launch_cluster_api_provider_metal3
 BMO_NAME_PREFIX="${NAMEPREFIX}"
 launch_baremetal_operator
-launch_ironic_standalone_operator
 if [[ "${USE_IRSO}" = true ]]; then
+    launch_ironic_standalone_operator
     launch_ironic_via_irso
 else
     launch_ironic


### PR DESCRIPTION
Currently IRSO is launched even we don't want IRSO controlled Ironic. Thanks to a manifest mismatch now, it is just crashing around. Move launching IRSO behind "if USE_IRSO" check.