### PR TITLE
Add move labels to BMH CRDs

### DIFF
--- a/tests/roles/run_tests/tasks/move.yml
+++ b/tests/roles/run_tests/tasks/move.yml
@@ -69,6 +69,8 @@
     shell: "kubectl label --overwrite crds baremetalhosts.metal3.io {{ item }}"
     with_items:
        - clusterctl.cluster.x-k8s.io=""
+       - clusterctl.cluster.x-k8s.io/move=""
+       - clusterctl.cluster.x-k8s.io/move-hierarchy=""
 
   - name: Label hardwareData CRD to pivot.
     shell: "kubectl label --overwrite crds hardwaredata.metal3.io {{ item }}"
@@ -136,6 +138,8 @@
     shell: "kubectl --kubeconfig /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml label crds baremetalhosts.metal3.io {{ item }} --overwrite "
     with_items:
       - clusterctl.cluster.x-k8s.io=""
+      - clusterctl.cluster.x-k8s.io/move=""
+      - clusterctl.cluster.x-k8s.io/move-hierarchy=""
 
   - name: Label hardwareData CRD in target cluster to pivot back.
     shell: "kubectl --kubeconfig /tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml label crds hardwaredata.metal3.io {{ item }} --overwrite "


### PR DESCRIPTION
The BMHs were previously depending partially on an owner reference for pivoting. Now we need to set these labels as the owner references are going away.

Reference: https://github.com/metal3-io/cluster-api-provider-metal3/pull/1742/files#diff-63199916efffe42d100a42d676875b41214bea828f0b12f95efa9fb4439a14fa