### PR TITLE
Migrate ansible filters from netcommon to utils

### DIFF
--- a/vm-setup/roles/common/defaults/main.yml
+++ b/vm-setup/roles/common/defaults/main.yml
@@ -58,8 +58,8 @@ provisioning_network_nat:
   - name: provisioning
     bridge: provisioning
     forward_mode: nat
-    address_v4: "{{ provisioning_network_cidr_v4|nthhost(1)|default('', true) }}"
-    netmask_v4: "{{ provisioning_network_cidr_v4|ipaddr('netmask') }}"
+    address_v4: "{{ provisioning_network_cidr_v4|ansible.utils.nthhost(1)|default('', true) }}"
+    netmask_v4: "{{ provisioning_network_cidr_v4|ansible.utils.ipaddr('netmask') }}"
     dhcp_range_v4:
       - "{{ provisioning_dhcp_v4_start }}"
       - "{{ provisioning_dhcp_v4_end }}"
@@ -82,13 +82,13 @@ external_network:
   - name: external
     bridge: external
     forward_mode: "{% if manage_external == 'y' %}nat{% else %}bridge{% endif %}"
-    address_v4: "{{ external_network_cidr_v4|nthhost(1)|default('', true) }}"
-    netmask_v4: "{{ external_network_cidr_v4|ipaddr('netmask') }}"
+    address_v4: "{{ external_network_cidr_v4|ansible.utils.nthhost(1)|default('', true) }}"
+    netmask_v4: "{{ external_network_cidr_v4|ansible.utils.ipaddr('netmask') }}"
     dhcp_range_v4:
       - "{{ external_dhcp_v4_start }}"
       - "{{ external_dhcp_v4_end }}"
-    address_v6: "{{ external_network_cidr_v6|nthhost(1)|default('', true) }}"
-    prefix_v6: "{{ external_network_cidr_v6|ipaddr('prefix') }}"
+    address_v6: "{{ external_network_cidr_v6|ansible.utils.nthhost(1)|default('', true) }}"
+    prefix_v6: "{{ external_network_cidr_v6|ansible.utils.ipaddr('prefix') }}"
     dhcp_range_v6:
       - "{{ external_dhcp_v6_start }}"
       - "{{ external_dhcp_v6_end }}"
@@ -103,7 +103,7 @@ external_network:
       forwarders:
         # Use 127.0.0.1 unless only IPv6 is enabled
         - domain: "apps.{{ cluster_domain }}"
-          addr: "{% if external_network_cidr_v4|ipv4 != False %}127.0.0.1{% else %}::1{% endif %}"
+          addr: "{% if external_network_cidr_v4|ansible.utils.ipv4 != False %}127.0.0.1{% else %}::1{% endif %}"
       srvs: "{{dns_externalsrvs | default([])}}"
 
 # Provisioning network is bridged and external network is nated

--- a/vm-setup/roles/common/tasks/extra_networks_tasks.yml
+++ b/vm-setup/roles/common/tasks/extra_networks_tasks.yml
@@ -22,9 +22,9 @@
   block:
     - set_fact:
         extra_network_v4: "{{ [{
-        'address_v4': cidr|nthhost(1),
-        'netmask_v4': cidr|ipaddr('netmask'),
-        'dhcp_range_v4': [ cidr|nthhost(20), cidr|nthhost(60)],
+        'address_v4': cidr|ansible.utils.nthhost(1),
+        'netmask_v4': cidr|ansible.utils.ipaddr('netmask'),
+        'dhcp_range_v4': [ cidr|ansible.utils.nthhost(20), cidr|ansible.utils.nthhost(60)],
         }]}}"
   when: "{{ lookup('vars', network_name + '_cidr_v4') != '' }}"
   vars:
@@ -34,9 +34,9 @@
   block:
     - set_fact:
         extra_network_v6: "{{ [{
-        'address_v6': cidr|nthhost(1),
-        'prefix_v6': cidr|ipaddr('prefix'),
-        'dhcp_range_v6': [ cidr|nthhost(20), cidr|nthhost(60)],
+        'address_v6': cidr|ansible.utils.nthhost(1),
+        'prefix_v6': cidr|ansible.utils.ipaddr('prefix'),
+        'dhcp_range_v6': [ cidr|ansible.utils.nthhost(20), cidr|ansible.utils.nthhost(60)],
         }]}}"
   when: "{{ lookup('vars', network_name + '_cidr_v6') != '' }}"
   vars:

--- a/vm-setup/roles/common/templates/ironic_nodes.json.j2
+++ b/vm-setup/roles/common/templates/ironic_nodes.json.j2
@@ -41,16 +41,16 @@
         "password": "{{ vbmc_password }}",
         {% if vm_driver_tmp =='redfish' -%}
         "port": "8000",
-        "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
+        "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ansible.utils.ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
         {% elif vm_driver_tmp == 'redfish-virtualmedia' -%}
         "port": "8000",
-        "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
+        "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ansible.utils.ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
         {% elif vm_driver_tmp == 'redfish-uefihttp' -%}
         "port": "8000",
-        "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
+        "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ansible.utils.ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
         {% else -%}
         "port": "{{ node.virtualbmc_port }}",
-        "address": "{{vm_driver_tmp}}://{{lvars['host_ip'] | ipwrap }}:{{node.virtualbmc_port}}",
+        "address": "{{vm_driver_tmp}}://{{lvars['host_ip'] | ansible.utils.ipwrap }}:{{node.virtualbmc_port}}",
         {% endif -%}
         "deploy_kernel": "http://{{ provisioning_url_host }}/images/ironic-python-agent.kernel",
         "deploy_ramdisk": "http://{{ provisioning_url_host }}/images/ironic-python-agent.initramfs"

--- a/vm-setup/roles/libvirt/templates/network.xml.j2
+++ b/vm-setup/roles/libvirt/templates/network.xml.j2
@@ -41,7 +41,7 @@
         {% set ironic_name = ironic_prefix + flavor + "_" + num|string %}
         {% set hostname_format = lookup('vars', flavor + '_hostname_format', default=flavor + '-%d') %}
         {% set hostname = hostname_format % num %}
-      <host mac='{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}' ip='{{item.dhcp_range_v4[0]|ipmath(ns.index|int)}}'>
+      <host mac='{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}' ip='{{item.dhcp_range_v4[0]|ansible.utils.ipmath(ns.index|int)}}'>
         <lease expiry='{{ item.lease_expiry }}'/>
       </host>
         {% set ns.index = ns.index + 1 %}
@@ -90,7 +90,7 @@
         {% set ironic_name = ironic_prefix + flavor + "_" + num|string %}
         {% set hostname_format = lookup('vars', flavor + '_hostname_format', default=flavor + '-%d') %}
         {% set hostname = hostname_format % num %}
-        <host id='00:03:00:01:{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}' ip='{{item.dhcp_range_v6[0]|ipmath(ns.index|int)}}'>
+        <host id='00:03:00:01:{{ node_mac_map.get(ironic_name).get(item.name)}}' name='{{hostname}}' ip='{{item.dhcp_range_v6[0]|ansible.utils.ipmath(ns.index|int)}}'>
           <lease expiry='{{ item.lease_expiry }}'/>
         </host>
         {% set ns.index = ns.index + 1 %}

--- a/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
+++ b/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
@@ -50,18 +50,18 @@
 
 - name: set vbmc address from IPv4 networks if possible, otherwise IPv6
   set_fact:
-    vbmc_address: "{% if vbmc_address_v4|ipv4 != False %}{{ vbmc_address_v4 }}{% else %}{{ vbmc_address_v6 }}{% endif %}"
+    vbmc_address: "{% if vbmc_address_v4|ansible.utils.ipv4 != False %}{{ vbmc_address_v4 }}{% else %}{{ vbmc_address_v6 }}{% endif %}"
 
 # The connection uri is slightly different when using qemu:///system
 # and requires the root user.
 - name: set qemu uri for qemu:///system usage
   set_fact:
-    vbmc_libvirt_uri: "qemu+ssh://root@{{ vbmc_address | ipwrap }}/system?&keyfile=/root/ssh/id_rsa_virt_power&no_verify=1&no_tty=1"
+    vbmc_libvirt_uri: "qemu+ssh://root@{{ vbmc_address | ansible.utils.ipwrap }}/system?&keyfile=/root/ssh/id_rsa_virt_power&no_verify=1&no_tty=1"
   when: libvirt_uri == "qemu:///system"
 
 - name: set qemu uri for qemu:///session usage
   set_fact:
-    vbmc_libvirt_uri: "qemu+ssh://{{ non_root_user }}@{{ vbmc_address | ipwrap }}/session?socket=/run/user/{{ non_root_user_uid }}/libvirt/libvirt-sock&keyfile=/root/ssh/id_rsa_virt_power&no_verify=1&no_tty=1"
+    vbmc_libvirt_uri: "qemu+ssh://{{ non_root_user }}@{{ vbmc_address | ansible.utils.ipwrap }}/session?socket=/run/user/{{ non_root_user_uid }}/libvirt/libvirt-sock&keyfile=/root/ssh/id_rsa_virt_power&no_verify=1&no_tty=1"
   when: vbmc_libvirt_uri is not defined
 
 - name: Create VirtualBMC directories


### PR DESCRIPTION
The netcommon filters will stop working soon, they've been migrated to the utils module.

Closes https://github.com/metal3-io/metal3-dev-env/issues/1491