### PR TITLE
Update renovate.json config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "config:base"
   ],
-  "enabled": "true",
+  "enabled": true,
   "baseBranches": [
     "main"
   ],
@@ -112,19 +112,5 @@
       "depNameTemplate": "registry",
       "datasourceTemplate": "docker"
     }
-  ],
-  "assignees": [
-    "kashifest"
-  ],
-  "assigneesSampleSize": 1,
-  "reviewers": [
-    "lentzi90",
-    "mboukhalfa",
-    "Rozzii",
-    "smoshiur1237",
-    "Sunnatillo",
-    "adilGhaffarDev",
-    "tuminoid"
-  ],
-  "reviewersSampleSize": 2
+  ]
 }


### PR DESCRIPTION
Renovate is quiet for few months now. The `"enabled": "true"` setting is using a string instead of boolean. Changing it to boolean to see if it triggers something. Also updating the assignee and the reviewers section
Signed-off-by: Kashif Khan <kashif.khan@est.tech>