### PR TITLE
enable tpm simulation for virtual machines

### DIFF
--- a/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
+++ b/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
@@ -44,6 +44,9 @@
   <on_reboot>restart</on_reboot>
   <on_crash>restart</on_crash>
   <devices>
+    <tpm model="tpm-tis">
+      <backend type="emulator" version="2.0"/>
+    </tpm>
     <disk type="file" device="cdrom">
       <target dev='{{ libvirt_cdromdev }}' bus='{{ libvirt_cdrombus }}'/>
       <readonly/>

--- a/vm-setup/roles/packages_installation/tasks/centos_required_packages.yml
+++ b/vm-setup/roles/packages_installation/tasks/centos_required_packages.yml
@@ -33,3 +33,8 @@
   become: yes
   when: CONTAINER_RUNTIME == "podman"
 
+- name: Install swtpm
+  dnf:
+    name: swtpm
+    state: present
+  become: yes

--- a/vm-setup/roles/packages_installation/tasks/ubuntu_required_packages.yml
+++ b/vm-setup/roles/packages_installation/tasks/ubuntu_required_packages.yml
@@ -7,11 +7,11 @@
         state: latest
 
     # TODO: (Sunnatillo) Remove this task after fully removing apt-key
-    - name: Remove OS old repository (without gpg key file location) 
+    - name: Remove OS old repository (without gpg key file location)
       apt_repository:
         repo: "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_{{ OS_VERSION_ID }}/ /"
         state: absent
-    
+
     - name: Remove Ubuntu Noble old repository (without gpg key file location)
       apt_repository:
         repo: "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_{{ OS_VERSION_ID }}/ /"
@@ -35,9 +35,9 @@
       when: ansible_distribution_release == "noble"
 
     - name: Dearmor Release key
-      shell: | 
+      shell: |
         cat /usr/share/keyrings/libcontainers-archive-keyring.asc | sudo gpg --dearmor -o /usr/share/keyrings/libcontainers-archive-keyring.gpg --yes
-    
+
     - name: Add OS repository
       lineinfile:
         path: /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
@@ -66,7 +66,7 @@
     - name: Podman
       block:
         - name: Install podman
-          apt: 
+          apt:
             name: podman
             state: present
 
@@ -92,19 +92,19 @@
             dest: /etc/apt/keyrings/docker.asc
             mode: '0644'
             force: true
-          
+
         - name: Dearmor GPG key
-          shell: | 
+          shell: |
             cat /etc/apt/keyrings/docker.asc | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg --yes
-                
+
         # TODO: (Sunnatillo) Remove this task after fully removing apt-key
-        - name: Remove Docker old repository (without gpg key file location) 
+        - name: Remove Docker old repository (without gpg key file location)
           apt_repository:
             repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
             state: absent
 
         # TODO: (Sunnatillo) Remove this task after fully removing apt-key
-        - name: Remove Docker old repository (without gpg key file location) 
+        - name: Remove Docker old repository (without gpg key file location)
           apt_repository:
             repo: "deb  https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
             state: absent
@@ -150,4 +150,10 @@
             append: yes
       when: CONTAINER_RUNTIME == "docker"
       become: yes
+
+    - name: Install swtpm
+      apt:
+        name: swtpm
+        state: present
+
   become: yes


### PR DESCRIPTION
This commit:
 - Appends the libvirt VM definition xml templates to include tpm simulation.

This commit is needed to enable the testing of use-cases where tpm features e.g. disk encryption, remote secure boot attestation, random hash generation, measured boot etc are used.