### PR TITLE
add option to toggle dev-env host package updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 all: install_requirements configure_host launch_mgmt_cluster verify
 
+nodep: configure_host launch_mgmt_cluster verify
+
 ci_run: configure_host launch_mgmt_cluster verify
 
 install_requirements:

--- a/vars.md
+++ b/vars.md
@@ -184,3 +184,11 @@ export NMSTATE2_NETWORK_SUBNET_V6='fd2e:6f44:5dd8:cc56::/120'
 By default, we pin downloaded binaries and packages with SHA256 digests.
 For testing purposes, verification of the digests will be skipped if
 `INSECURE_SKIP_DOWNLOAD_VERIFICATION` is set to `true`.
+
+## Make options
+
+- `make` will run the installation of all te dependencies and set up the
+   ephemeral controlplane
+- `make nodep` will skip the dependency installation
+- `make ci_run` will run only those make targets that are executed in the
+   CI


### PR DESCRIPTION
This PR:
 - Introduces `nodep` make target to skip redundant dependency installation
 - Moves container runtime cleanup to 02 config script
 - Moves the GO related bashrc check to 02 script

This commit is needed because on persistent hosts (e.g. developer's
workstation) it might be undesirable to update the local system packages.