### PR TITLE
fix iPXE integration for pre 1_10 environments

### DIFF
--- a/03_launch_mgmt_cluster_pre_1_10.sh
+++ b/03_launch_mgmt_cluster_pre_1_10.sh
@@ -698,7 +698,7 @@ build_ipxe_firmware()
         --name ipxe-builder ${POD_NAME} \
         -e "${IPXE_ENABLE_TLS_CENV_ARG}" \
         -e "${IPXE_ENABLE_IPV6_CENV_ARG}" \
-        -e "IRONIC_IP=${IRONIC_HOST_IP}" \
+        -e "IPXE_CHAIN_HOST=${IRONIC_HOST_IP}" \
         ${certs_mounts[@]} \
         -v "${IRONIC_DATA_DIR}":/shared \
         "${ipxe_builder_image}"


### PR DESCRIPTION
This commit:
 - Fixes the incorrect ipxe-builder variable used in the pre_1_10 environments.

This issue was already fixed in the regular 03 script.