### PR TITLE
Pin collections to latest ansible 2.15 compatible versions

### DIFF
--- a/vm-setup/requirements.yml
+++ b/vm-setup/requirements.yml
@@ -2,7 +2,11 @@ roles:
   - src: https://github.com/fubarhouse/ansible-role-golang.git
     version: master
     name: fubarhouse.golang
-  
+
 collections:
   - name: kubernetes.core
     version: 5.1.0
+  - name: ansible.netcommon
+    version: 7.2.0
+  - name: ansible.utils
+    version: 5.1.2


### PR DESCRIPTION
ansible.utils just released a new version that is incompatible with ansible-2.15 (https://github.com/ansible-collections/ansible.utils/commit/7059201078b6791def7665e39cc591070e03766f) and this results in:
```
    TASK [common : Show networks data for debugging (common role)] *****************
    task path: /home/dev-scripts/metal3-dev-env/vm-setup/roles/common/tasks/main.yml:42
    [WARNING]: Collection ansible.netcommon does not support Ansible version
    2.15.12
    [WARNING]: Collection ansible.utils does not support Ansible version 2.15.12
    redirecting (type: filter) ansible.builtin.nthhost to ansible.netcommon.nthhost
    redirecting (type: filter) ansible.builtin.nthhost to ansible.netcommon.nthhost
```
this is a proposal to pin these collections until we can upgrade to 2.16