### PR TITLE
Remove ancient ansible version

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -403,10 +403,8 @@ export TILT_SHA256="${TILT_SHA256:-b30ebbba68d4fd04f8afa11efc439515241dbcc2582ea
 # TODO: Ansible pinning
 if [[ "${DISTRO}" = "ubuntu24" ]]; then
     export ANSIBLE_VERSION="${ANSIBLE_VERSION:-10.6.0}"
-elif [[ "${DISTRO}" = "ubuntu22" ]] || [[ "${DISTRO}" = "centos9" ]]; then
-    export ANSIBLE_VERSION="${ANSIBLE_VERSION:-8.0.0}"
 else
-    export ANSIBLE_VERSION="${ANSIBLE_VERSION:-6.7.0}"
+    export ANSIBLE_VERSION="${ANSIBLE_VERSION:-8.0.0}"
 fi
 
 # Test and verification related variables


### PR DESCRIPTION
Really even ansible 8 is old but we need to keep it for compatibility with python binaries in CS9 and ubuntu22.