### PR TITLE
Add redfish SSL support

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -391,9 +391,11 @@ make_bm_hosts()
     mkdir -p "${WORKING_DIR}/bmhs"
 
     local i=0
-    while read -r name address user password mac; do
+    while read -r name address user password mac verify_ca; do
+        disableCertificateVerification=$([ "${verify_ca}" == "False" ] && echo -n "true" || echo -n "false")
         go run "${BMOPATH}"/cmd/make-bm-worker/main.go \
             -address "${address}" \
+            -disableCertificateVerification "${disableCertificateVerification}" \
             -password "${password}" \
             -user "${user}" \
             -boot-mac "${mac}" \

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -393,12 +393,12 @@ make_bm_hosts()
     local i=0
     while read -r name address user password mac verify_ca; do
         go run "${BMOPATH}"/cmd/make-bm-worker/main.go \
-            -address "${address}" \
-            -disableCertificateVerification "$(get_disableCertificateVerification_from_verify_ca "${verify_ca}")" \
-            -password "${password}" \
-            -user "${user}" \
-            -boot-mac "${mac}" \
-            -boot-mode "${BOOT_MODE}" \
+            -address="${address}" \
+            -disableCertificateVerification="$(get_disableCertificateVerification_from_verify_ca "${verify_ca}")" \
+            -password="${password}" \
+            -user="${user}" \
+            -boot-mac="${mac}" \
+            -boot-mode="${BOOT_MODE}" \
             "${name}" | \
             tee "${WORKING_DIR}/bmhs/node_${i}.yaml" >> "${WORKING_DIR}/bmhosts_crs.yaml"
         i=$((i+1))

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -392,10 +392,9 @@ make_bm_hosts()
 
     local i=0
     while read -r name address user password mac verify_ca; do
-        disableCertificateVerification=$([ "${verify_ca}" == "False" ] && echo -n "true" || echo -n "false")
         go run "${BMOPATH}"/cmd/make-bm-worker/main.go \
             -address "${address}" \
-            -disableCertificateVerification "${disableCertificateVerification}" \
+            -disableCertificateVerification "$(get_disableCertificateVerification_from_verify_ca "${verify_ca}")" \
             -password "${password}" \
             -user "${user}" \
             -boot-mac "${mac}" \

--- a/03_launch_mgmt_cluster_pre_1_10.sh
+++ b/03_launch_mgmt_cluster_pre_1_10.sh
@@ -385,10 +385,9 @@ make_bm_hosts()
 
     local i=0
     while read -r name address user password mac verify_ca; do
-        disableCertificateVerification=$([ "${verify_ca}" == "False" ] && echo -n "true" || echo -n "false")
         go run "${BMOPATH}"/cmd/make-bm-worker/main.go \
             -address "${address}" \
-            -disableCertificateVerification "${disableCertificateVerification}" \
+            -disableCertificateVerification "$(get_disableCertificateVerification_from_verify_ca "${verify_ca}")" \
             -password "${password}" \
             -user "${user}" \
             -boot-mac "${mac}" \

--- a/03_launch_mgmt_cluster_pre_1_10.sh
+++ b/03_launch_mgmt_cluster_pre_1_10.sh
@@ -386,12 +386,12 @@ make_bm_hosts()
     local i=0
     while read -r name address user password mac verify_ca; do
         go run "${BMOPATH}"/cmd/make-bm-worker/main.go \
-            -address "${address}" \
-            -disableCertificateVerification "$(get_disableCertificateVerification_from_verify_ca "${verify_ca}")" \
-            -password "${password}" \
-            -user "${user}" \
-            -boot-mac "${mac}" \
-            -boot-mode "${BOOT_MODE}" \
+            -address="${address}" \
+            -disableCertificateVerification="$(get_disableCertificateVerification_from_verify_ca "${verify_ca}")" \
+            -password="${password}" \
+            -user="${user}" \
+            -boot-mac="${mac}" \
+            -boot-mode="${BOOT_MODE}" \
             "${name}" | \
             tee "${WORKING_DIR}/bmhs/node_${i}.yaml" >> "${WORKING_DIR}/bmhosts_crs.yaml"
         i=$((i+1))

--- a/03_launch_mgmt_cluster_pre_1_10.sh
+++ b/03_launch_mgmt_cluster_pre_1_10.sh
@@ -384,9 +384,11 @@ make_bm_hosts()
     mkdir -p "${WORKING_DIR}/bmhs"
 
     local i=0
-    while read -r name address user password mac; do
+    while read -r name address user password mac verify_ca; do
+        disableCertificateVerification=$([ "${verify_ca}" == "False" ] && echo -n "true" || echo -n "false")
         go run "${BMOPATH}"/cmd/make-bm-worker/main.go \
             -address "${address}" \
+            -disableCertificateVerification "${disableCertificateVerification}" \
             -password "${password}" \
             -user "${user}" \
             -boot-mac "${mac}" \

--- a/04_verify.sh
+++ b/04_verify.sh
@@ -23,13 +23,14 @@ fi
 
 check_bm_hosts() {
     local FAILS_CHECK="${FAILS}"
-    local NAME ADDRESS USER PASSWORD MAC CRED_NAME CRED_SECRET
+    local NAME ADDRESS USER PASSWORD MAC VERIFY_CA CRED_NAME CRED_SECRET
     local BARE_METAL_HOSTS BARE_METAL_HOST BARE_METAL_VMS BARE_METAL_VMNAME BARE_METAL_VM_IFACES
     NAME="${1}"
     ADDRESS="${2}"
     USER="${3}"
     PASSWORD="${4}"
     MAC="${5}"
+    VERIFY_CA="${6}"
     BARE_METAL_HOSTS="$(kubectl --kubeconfig "${KUBECONFIG}" get baremetalhosts\
       -n metal3 -o json)"
     BARE_METAL_VMS="$(sudo virsh list --all)"
@@ -48,6 +49,10 @@ check_bm_hosts() {
       # Verify addresses of the host
       RESULT_STR="${NAME} Baremetalhost address correct"
       equals "$(echo "${BARE_METAL_HOST}" | jq -r '.spec.bmc.address')" "${ADDRESS}"
+
+      RESULT_STR="${NAME} Baremetalhost disableCertificateVerification correct"
+      disableCertificateVerification=$([ "${VERIFY_CA}" == "False" ] && echo -n "true" || echo -n "false")
+      equals "$(echo "${BARE_METAL_HOST}" | jq -r '.spec.bmc.disableCertificateVerification')" "${disableCertificateVerification}"
 
       RESULT_STR="${NAME} Baremetalhost mac address correct"
       equals "$(echo "${BARE_METAL_HOST}" | jq -r '.spec.bootMACAddress')" \
@@ -278,9 +283,9 @@ echo ""
 
 ## Verify
 if [[ -n "$(list_nodes)" ]]; then
-  while read -r name address user password mac; do
+  while read -r name address user password mac verify_ca; do
     iterate check_bm_hosts "${name}" "${address}" "${user}" \
-      "${password}" "${mac}"
+      "${password}" "${mac}" "${verify_ca}"
     echo ""
   done <<< "$(list_nodes)"
 fi

--- a/04_verify.sh
+++ b/04_verify.sh
@@ -51,8 +51,7 @@ check_bm_hosts() {
       equals "$(echo "${BARE_METAL_HOST}" | jq -r '.spec.bmc.address')" "${ADDRESS}"
 
       RESULT_STR="${NAME} Baremetalhost disableCertificateVerification correct"
-      disableCertificateVerification=$([ "${VERIFY_CA}" == "False" ] && echo -n "true" || echo -n "false")
-      equals "$(echo "${BARE_METAL_HOST}" | jq -r '.spec.bmc.disableCertificateVerification')" "${disableCertificateVerification}"
+      equals "$(echo "${BARE_METAL_HOST}" | jq -r '.spec.bmc.disableCertificateVerification')" "$(get_disableCertificateVerification_from_verify_ca "${VERIFY_CA}")"
 
       RESULT_STR="${NAME} Baremetalhost mac address correct"
       equals "$(echo "${BARE_METAL_HOST}" | jq -r '.spec.bootMACAddress')" \

--- a/04_verify.sh
+++ b/04_verify.sh
@@ -50,8 +50,13 @@ check_bm_hosts() {
       RESULT_STR="${NAME} Baremetalhost address correct"
       equals "$(echo "${BARE_METAL_HOST}" | jq -r '.spec.bmc.address')" "${ADDRESS}"
 
+      # Verify disableCertificateVerification, it's empty (=null) when false!
+      DISABLE_CERTIFICATE_VERIFICATION="$(get_disableCertificateVerification_from_verify_ca "${VERIFY_CA}")"
+      if [[ ${DISABLE_CERTIFICATE_VERIFICATION} == "false" ]]; then
+        DISABLE_CERTIFICATE_VERIFICATION="null"
+      fi
       RESULT_STR="${NAME} Baremetalhost disableCertificateVerification correct"
-      equals "$(echo "${BARE_METAL_HOST}" | jq -r '.spec.bmc.disableCertificateVerification')" "$(get_disableCertificateVerification_from_verify_ca "${VERIFY_CA}")"
+      equals "$(echo "${BARE_METAL_HOST}" | jq -r '.spec.bmc.disableCertificateVerification')" "${DISABLE_CERTIFICATE_VERIFICATION}"
 
       RESULT_STR="${NAME} Baremetalhost mac address correct"
       equals "$(echo "${BARE_METAL_HOST}" | jq -r '.spec.bootMACAddress')" \

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -499,11 +499,12 @@ list_nodes() {
            port:.driver_info.port,
            user:.driver_info.username,
            password:.driver_info.password,
+           verify_ca:.driver_info.redfish_verify_ca,
            mac: .ports[0].address
-           } |
+           } | if .verify_ca == null then .verify_ca="True" else . end |
            .name + " " +
            .address + " " +
-           .user + " " + .password + " " + .mac' \
+           .user + " " + .password + " " + .mac + " " + .verify_ca' \
        | sed 's/"//g'
 }
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -504,7 +504,10 @@ list_nodes() {
            } | if .verify_ca == null then .verify_ca="True" else . end |
            .name + " " +
            .address + " " +
-           .user + " " + .password + " " + .mac + " " + .verify_ca' \
+           .user + " " +
+           .password + " " +
+           .mac + " " +
+           .verify_ca' \
        | sed 's/"//g'
 }
 
@@ -659,3 +662,17 @@ manage_libvirtd() {
         ;;
 esac
 }
+
+#
+# Translate verify_ca, which is True or False and coming from ironic nodes,
+# to disableCertificateVerification, which is true or false, and is set in BMH
+#
+get_disableCertificateVerification_from_verify_ca() {
+  local VERIFY_CA="$1"
+  if [[ ${VERIFY_CA} == "False" ]]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+

--- a/vm-setup/roles/common/templates/ironic_nodes.json.j2
+++ b/vm-setup/roles/common/templates/ironic_nodes.json.j2
@@ -41,13 +41,16 @@
         "password": "{{ vbmc_password }}",
         {% if vm_driver_tmp =='redfish' -%}
         "port": "8000",
-        "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ansible.utils.ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
+        "address": "{{vm_driver_tmp}}+https://{{ lvars['host_ip'] | ansible.utils.ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
+        "redfish_verify_ca": "False",
         {% elif vm_driver_tmp == 'redfish-virtualmedia' -%}
         "port": "8000",
-        "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ansible.utils.ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
+        "address": "{{vm_driver_tmp}}+https://{{ lvars['host_ip'] | ansible.utils.ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
+        "redfish_verify_ca": "False",
         {% elif vm_driver_tmp == 'redfish-uefihttp' -%}
         "port": "8000",
-        "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ansible.utils.ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
+        "address": "{{vm_driver_tmp}}+https://{{ lvars['host_ip'] | ansible.utils.ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
+        "redfish_verify_ca": "False",
         {% else -%}
         "port": "{{ node.virtualbmc_port }}",
         "address": "{{vm_driver_tmp}}://{{lvars['host_ip'] | ansible.utils.ipwrap }}:{{node.virtualbmc_port}}",

--- a/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
+++ b/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
@@ -99,6 +99,16 @@
     name: "{{ vbmc_username }}"
     password: "{{ vbmc_password }}"
 
+- name: Create private key (RSA, 4096 bits) for redfish TLS
+  community.crypto.openssl_privatekey:
+    path: "{{ working_dir }}/virtualbmc/sushy-tools/key.pem"
+
+- name: Create self-signed certificate for redfish TLS
+  community.crypto.x509_certificate:
+    path: "{{ working_dir }}/virtualbmc/sushy-tools/cert.pem"
+    privatekey_path: "{{ working_dir }}/virtualbmc/sushy-tools/key.pem"
+    provider: selfsigned
+
 - name: Create the Redfish Virtual BMCs
   copy:
     mode: 0750
@@ -108,6 +118,8 @@
       SUSHY_EMULATOR_IGNORE_BOOT_DEVICE = {{ sushy_ignore_boot_device }}
       SUSHY_EMULATOR_VMEDIA_VERIFY_SSL = {{ sushy_vmedia_verify_ssl }}
       SUSHY_EMULATOR_AUTH_FILE = "/root/sushy/htpasswd"
+      SUSHY_EMULATOR_SSL_KEY = "/root/sushy/key.pem"
+      SUSHY_EMULATOR_SSL_CERT = "/root/sushy/cert.pem"
   become: true
   when: vm_platform|default("libvirt") != "fake"
 


### PR DESCRIPTION
Hello,

we are experimenting with using fence agents on cluster nodes. `fence_redfish` only supports `https` connections, but it's not possible to configure sushy to provide a SSL connection yet.

After discusion on this PR, it was decided to not make SSL support optional, but always use it, because that's what real world BMCs look like. Since the certificate is self signed, the `redfish_verify_ca` option is added and set to `False`