### PR TITLE
Update verify script to remove duplicate check

### DIFF
--- a/04_verify.sh
+++ b/04_verify.sh
@@ -254,18 +254,7 @@ done
 echo ""
 
 # Verify v1beta1 Operators, Deployments, Replicasets
-if [[ "${SKIP_APPLY_BMH:-false}" == "true" ]] && [[ "${EPHEMERAL_CLUSTER}" == "minikube" ]]; then
-  EXPTD_DEPLOYMENTS="capm3-system:capm3-controller-manager \
-  capi-system:capi-controller-manager \
-  capi-kubeadm-bootstrap-system:capi-kubeadm-bootstrap-controller-manager \
-  capi-kubeadm-control-plane-system:capi-kubeadm-control-plane-controller-manager \
-  baremetal-operator-system:baremetal-operator-controller-manager \
-  baremetal-operator-system:baremetal-operator-ironic"
-
-  iterate check_k8s_entity deployments "${EXPTD_DEPLOYMENTS}"
-else
-  iterate check_k8s_entity deployments "${EXPTD_DEPLOYMENTS}"
-fi
+iterate check_k8s_entity deployments "${EXPTD_DEPLOYMENTS}"
 iterate check_k8s_rs "${EXPTD_RS}"
 
 # Skip verification related to virsh when running with fakeIPA


### PR DESCRIPTION
We have added check for ironic deployment in  centos tests in the following [ merged PR](https://github.com/metal3-io/metal3-dev-env/pull/1536). As it is having check, doesn't need the same check during skip bmh action in CAPM3 e2e basic integration test. So this PR will remove the duplicate check in the verify script