### PR TITLE
DNM: Revert "Use SSL in sushy"

### DIFF
--- a/vm-setup/roles/common/templates/ironic_nodes.json.j2
+++ b/vm-setup/roles/common/templates/ironic_nodes.json.j2
@@ -41,16 +41,13 @@
         "password": "{{ vbmc_password }}",
         {% if vm_driver_tmp =='redfish' -%}
         "port": "8000",
-        "address": "{{vm_driver_tmp}}+https://{{ lvars['host_ip'] | ansible.utils.ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
-        "redfish_verify_ca": "False",
+        "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ansible.utils.ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
         {% elif vm_driver_tmp == 'redfish-virtualmedia' -%}
         "port": "8000",
-        "address": "{{vm_driver_tmp}}+https://{{ lvars['host_ip'] | ansible.utils.ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
-        "redfish_verify_ca": "False",
+        "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ansible.utils.ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
         {% elif vm_driver_tmp == 'redfish-uefihttp' -%}
         "port": "8000",
-        "address": "{{vm_driver_tmp}}+https://{{ lvars['host_ip'] | ansible.utils.ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
-        "redfish_verify_ca": "False",
+        "address": "{{vm_driver_tmp}}+http://{{ lvars['host_ip'] | ansible.utils.ipwrap }}:8000/redfish/v1/Systems/{{vm_id[node.name]}}",
         {% else -%}
         "port": "{{ node.virtualbmc_port }}",
         "address": "{{vm_driver_tmp}}://{{lvars['host_ip'] | ansible.utils.ipwrap }}:{{node.virtualbmc_port}}",

--- a/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
+++ b/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
@@ -99,16 +99,6 @@
     name: "{{ vbmc_username }}"
     password: "{{ vbmc_password }}"
 
-- name: Create private key (RSA, 4096 bits) for redfish TLS
-  community.crypto.openssl_privatekey:
-    path: "{{ working_dir }}/virtualbmc/sushy-tools/key.pem"
-
-- name: Create self-signed certificate for redfish TLS
-  community.crypto.x509_certificate:
-    path: "{{ working_dir }}/virtualbmc/sushy-tools/cert.pem"
-    privatekey_path: "{{ working_dir }}/virtualbmc/sushy-tools/key.pem"
-    provider: selfsigned
-
 - name: Create the Redfish Virtual BMCs
   copy:
     mode: 0750
@@ -118,8 +108,6 @@
       SUSHY_EMULATOR_IGNORE_BOOT_DEVICE = {{ sushy_ignore_boot_device }}
       SUSHY_EMULATOR_VMEDIA_VERIFY_SSL = {{ sushy_vmedia_verify_ssl }}
       SUSHY_EMULATOR_AUTH_FILE = "/root/sushy/htpasswd"
-      SUSHY_EMULATOR_SSL_KEY = "/root/sushy/key.pem"
-      SUSHY_EMULATOR_SSL_CERT = "/root/sushy/cert.pem"
   become: true
   when: vm_platform|default("libvirt") != "fake"
 


### PR DESCRIPTION
This reverts commit 11ffb1a250f1b756be7f1cfd92c6cf079adab755.

This commit is breaking scalability. @Rozzii is working on a fix, but I'm just checking that if reverting does actually solve it.

/hold
