### PR TITLE
Get NIC name from bmh for vrrp config

### DIFF
--- a/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
@@ -60,7 +60,7 @@ files:
 
       vrrp_instance VI_1 {
           state MASTER
-          interface {% if EXTERNAL_VLAN_ID == "" %}eth1{% else %}eth0.{{ EXTERNAL_VLAN_ID }}{% endif %}
+          interface {% if EXTERNAL_VLAN_ID == "" %}{{ bmh_nic_names[1] }}{% else %}{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}{% endif %}
 
           virtual_router_id 1
           priority 101

--- a/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-ubuntu.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-ubuntu.yaml
@@ -35,7 +35,7 @@ files:
 
       vrrp_instance VI_2 {
           state MASTER
-          interface {% if EXTERNAL_VLAN_ID == "" %}enp2s0{% else %}enp1s0.{{ EXTERNAL_VLAN_ID }}{% endif %}
+          interface {% if EXTERNAL_VLAN_ID == "" %}{{ bmh_nic_names[1] }}{% else %}{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}{% endif %}
 
           virtual_router_id 2
           priority 101


### PR DESCRIPTION
This PR changes hardcoded interface names in vrrp config and makes to get interface names from bmh