### PR TITLE
Partial revert of getting NIC name from bmh for vrrp config

### DIFF
--- a/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/cluster-template-controlplane-kubeadm-config-centos.yaml
@@ -60,7 +60,7 @@ files:
 
       vrrp_instance VI_1 {
           state MASTER
-          interface {% if EXTERNAL_VLAN_ID == "" %}{{ bmh_nic_names[1] }}{% else %}{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}{% endif %}
+          interface {% if EXTERNAL_VLAN_ID == "" %}eth1{% else %}eth0.{{ EXTERNAL_VLAN_ID }}{% endif %}
 
           virtual_router_id 1
           priority 101


### PR DESCRIPTION
NIC names are populated differently in centos and ubuntu. 
NICs names in bmh and provisioned os are not same. It is related to "net.ifnames" in kernel. On IPA it is enabled, for centos node image the config is disabled. Thus causing the difference. 

This PR fixes bml failure. Proper fix will be done later