### PR TITLE
Add support for full IPv6 networking

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -85,6 +85,9 @@ ANSIBLE_FORCE_COLOR=true "${ANSIBLE}-playbook" \
     -i vm-setup/inventory.ini \
     -b vm-setup/install-package-playbook.yml
 
+# NOTE(nuhakala): At this point we would want to replace containerd 1.7 with 2.0
+# if we were to use IPv6.
+#./hack/replace-containerd2.sh
 
 ## Install krew
 if ! kubectl krew > /dev/null 2>&1; then

--- a/hack/replace-containerd2.sh
+++ b/hack/replace-containerd2.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# This script install containerd 2.1.3, as it was the newest at the time of
+# writing this.
+#
+# Ubuntu's version of Docker depends on containerd 1.7, but > 2.0 is needed for
+# IPv6 support. This script replaces old containerd installation with
+# containerd 2.1.3, as it was the newest at the time of writing this.
+#
+# You might need to install Docker before running this script. If Docker is not
+# installed, dev env will install it and it might override the version. If
+# Docker is already installed, dev env won't install it again and these changes
+# will remain.
+
+set -eux
+
+sudo systemctl stop docker
+sudo systemctl stop containerd
+
+SAVE_DIR=${SAVE_DIR:-"/tmp"}
+CONTAINERD_VERSION=${CONTAINERD_VERSION:-"v2.1.3"}
+
+containerd="containerd.tar.gz"
+wget -O "${SAVE_DIR}"/"${containerd}" https://github.com/containerd/containerd/releases/download/"${CONTAINERD_VERSION}"/containerd-"${CONTAINERD_VERSION}"-linux-amd64.tar.gz
+
+### Install containerd
+# remove first old
+if [[ -e /usr/local/bin/containerd ]]; then
+    sudo mv /usr/local/bin/containerd /usr/local/bin/containerd.backup
+    sudo mv /usr/local/bin/containerd-shim-runc-v2 /usr/local/bin/containerd-shim-runc-v2.backup
+    sudo mv /usr/local/bin/ctr /usr/local/bin/ctr.backup
+    sudo mv /usr/local/bin/containerd-stress /usr/local/bin/containerd-stress.backup
+fi
+# Install new
+sudo tar Cxzvf /usr/local "${SAVE_DIR}"/"${containerd}"
+
+# Restart stuff
+sudo systemctl daemon-reexec
+sudo systemctl daemon-reload
+sudo systemctl start containerd
+sudo systemctl start docker

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -40,7 +40,6 @@ export POD_CIDR=${POD_CIDR:-"192.168.0.0/18"}
 
 # Enables single-stack IPv6
 BARE_METAL_PROVISIONER_SUBNET_IPV6_ONLY=${BARE_METAL_PROVISIONER_SUBNET_IPV6_ONLY:-false}
-IPV6_ADDR_PREFIX=${IPV6_ADDR_PREFIX:-"fd2e:6f44:5dd8:b856"}
 
 if [[ "${BARE_METAL_PROVISIONER_SUBNET_IPV6_ONLY}" == "true" ]]; then
   # IPV6 only works with UEFI boot mode
@@ -71,6 +70,9 @@ network_address CLUSTER_BARE_METAL_PROVISIONER_IP "${BARE_METAL_PROVISIONER_NETW
 
 export BARE_METAL_PROVISIONER_IP
 export CLUSTER_BARE_METAL_PROVISIONER_IP
+# These are inherited into ironic deployment in BMO, so we need to have duplicates
+export PROVISIONING_IP=${BARE_METAL_PROVISIONER_IP}
+export CLUSTER_PROVISIONING_IP=${CLUSTER_BARE_METAL_PROVISIONER_IP}
 
 # shellcheck disable=SC2153
 if [[ "$BARE_METAL_PROVISIONER_IP" = *":"* ]]; then

--- a/tests/roles/run_tests/templates/release-1.8/cluster-template-cluster.yaml
+++ b/tests/roles/run_tests/templates/release-1.8/cluster-template-cluster.yaml
@@ -25,7 +25,7 @@ metadata:
   namespace: ${ NAMESPACE }
 spec:
   controlPlaneEndpoint:
-    host: ${ CLUSTER_APIENDPOINT_HOST }
+    host: "${ CLUSTER_APIENDPOINT_HOST }"
     port: ${ CLUSTER_APIENDPOINT_PORT }
   noCloudProvider: true
 ---

--- a/tests/roles/run_tests/vars/main.yml
+++ b/tests/roles/run_tests/vars/main.yml
@@ -39,7 +39,7 @@ IPAM_EXTERNALV6_POOL_RANGE_START: "{{ lookup('env', 'IPAM_EXTERNALV6_POOL_RANGE_
 IPAM_EXTERNALV6_POOL_RANGE_END: "{{ lookup('env', 'IPAM_EXTERNALV6_POOL_RANGE_END') | default('fd55::200', true) }}"
 EXTERNAL_SUBNET_V6_PREFIX: "{{ lookup('env', 'EXTERNAL_SUBNET_V6_PREFIX') | default('64', true) }}"
 EXTERNAL_SUBNET_V6_HOST: "{{ lookup('env', 'EXTERNAL_SUBNET_V6_HOST') | default('fd55::1', true) }}"
-BARE_METAL_PROVISIONER_IP: "{{ lookup('env', 'BARE_METAL_PROVISIONER_IP') | default('172.22.0.1', true) }}"
+BARE_METAL_PROVISIONER_IP: "{{ lookup('env', 'BARE_METAL_PROVISIONER_URL_HOST') | default('172.22.0.1', true) }}"
 IRONIC_HOST: "{{ lookup('env', 'IRONIC_HOST') | default('172.22.0.2', true) }}"
 IRONIC_HOST_IP: "{{ lookup('env', 'IRONIC_HOST_IP') | default('172.22.0.2', true) }}"
 KUBECTL_ARGS: "--kubeconfig=/tmp/kubeconfig-{{ CLUSTER_NAME }}.yaml"

--- a/vars.md
+++ b/vars.md
@@ -193,3 +193,36 @@ For testing purposes, verification of the digests will be skipped if
 - `make nodep` will skip the dependency installation
 - `make ci_run` will run only those make targets that are executed in the
    CI
+
+## IPv6 support
+
+The environment supports IPv6-only networking, but this currently works
+**only with `kind`**. Minikube does not have official IPv6 support at the time
+of writing. IPv6 can also be enabled partially, but for full IPv6
+networking, the following additional steps are required:
+
+1. Build iPXE image builder with IPv6 support and with correct name (or rename
+   after building). By default the builder is named after the address it is
+   hosted at.
+1. Build iPXE with IPv6 support.
+1. The Docker engine depends on containerd 1.7. To configure image registries
+   using an IPv6 address, containerd version **2.0 or later** is required. You
+   can download the correct containerd binary and replace the existing one under
+   `/usr/local/bin`. There is a convenience script for this
+   `hack/replace-containerd2.sh`.
+1. You need to replace the default IPv4 addresses with IPv6 addresses in the
+   environment variables.
+
+The following variables need to be set:
+
+``` sh
+export IPXE_ENABLE_IPV6=true
+export BUILD_IPXE=true
+export IPXE_BUILDER_LOCAL_IMAGE="<path to local builder image>"
+export EPHEMERAL_CLUSTER="kind"
+export IP_STACK=v6
+export EXTERNAL_SUBNET_V6="fd55::/64"
+export BARE_METAL_PROVISIONER_SUBNET_IPV6_ONLY=true
+export DOCKER_USE_IPV6_INTERNALLY=true
+export POD_CIDR="fd00:6969::/64"
+```

--- a/vm-setup/roles/firewall/defaults/main.yml
+++ b/vm-setup/roles/firewall/defaults/main.yml
@@ -1,10 +1,15 @@
-use_firewalld: "{{ lookup('env', 'USE_FIREWALLD') | default(true, true) }}"
+use_firewalld: "{{ lookup('env', 'USE_FIREWALLD') | default('true', true) }}"
 external_interface: external
 provisioning_interface: provisioning
 bare_metal_provisioner_interface: "{{ lookup('env', 'BARE_METAL_PROVISIONER_INTERFACE') | default('ironicendpoint', true) }}"
+# Set external subnet based on the used protocol
+ip_stack: "{{ lookup('env', 'IP_STACK') | default('v4', true) }}"
 external_subnet_v4: "{{ lookup('env', 'EXTERNAL_SUBNET_V4') | default('192.168.111.0/24', true) }}"
-bare_metal_provisioner_subnet_v4: "{{ lookup('env', 'BARE_METAL_PROVISIONER_NETWORK') | default('172.22.0.0/24', true) }}"
-kind_subnet: '172.18.0.0/24'
+external_subnet_v6: "{{ lookup('env', 'EXTERNAL_SUBNET_V6') | default('fd55::/64', true) }}"
+# Bare metal provisioner subnet can also be IPv6, set in lib/network.sh line 48
+bare_metal_provisioner_subnet: "{{ lookup('env', 'BARE_METAL_PROVISIONER_NETWORK') | default('172.22.0.0/24', true) }}"
+# These values come from kind defaults.
+kind_subnet: "{{ '172.18.0.0/24' if ip_stack == 'v4' else 'fc00:f853:ccd:e793::/64' }}"
 registry_port: "{{ lookup('env', 'REGISTRY_PORT') | default('5000', true) }}"
 http_port: "{{ lookup('env', 'HTTP_PORT') | default('6180', true) }}"
 ironic_inspector_port: "{{ lookup('env', 'IRONIC_INSPECTOR_PORT') | default('5050', true) }}"

--- a/vm-setup/roles/firewall/tasks/iptables.yaml
+++ b/vm-setup/roles/firewall/tasks/iptables.yaml
@@ -116,7 +116,7 @@
         action: insert
         protocol: tcp
         match: tcp
-        destination: "{{ bare_metal_provisioner_subnet_v4 }}"
+        destination: "{{ bare_metal_provisioner_subnet }}"
         destination_port: "{{ item }}"
         jump: ACCEPT
         state: "{{ firewall_rule_state }}"
@@ -141,4 +141,54 @@
         destination: "{{ external_subnet_v4 }}"
         jump: ACCEPT
         state: "{{ firewall_rule_state }}"
-  when: (EPHEMERAL_CLUSTER == "kind")
+  when: (EPHEMERAL_CLUSTER == "kind") and (ip_stack == "v4")
+
+- block:
+    - name: "ip6tables: Allow access to external network from kind"
+      iptables:
+        ip_version: ipv6
+        chain: INPUT
+        action: insert
+        protocol: tcp
+        match: tcp
+        destination: "{{ external_subnet_v6 }}"
+        destination_port: "{{ item }}"
+        jump: ACCEPT
+        state: "{{ firewall_rule_state }}"
+      loop: "{{ vm_host_ports }}"
+
+    - name: "ip6tables: Allow access to bare metal provisioner network from kind"
+      iptables:
+        ip_version: ipv6
+        chain: INPUT
+        action: insert
+        protocol: tcp
+        match: tcp
+        destination: "{{ bare_metal_provisioner_subnet }}"
+        destination_port: "{{ item }}"
+        jump: ACCEPT
+        state: "{{ firewall_rule_state }}"
+      loop: "{{ ironic_ports }}"
+
+    - name: "ip6tables: Allow access to Kubernetes API from kind"
+      iptables:
+        ip_version: ipv6
+        chain: INPUT
+        action: insert
+        protocol: tcp
+        match: tcp
+        destination: "{{ kind_subnet }}"
+        destination_port: "{{ cluster_api_port }}"
+        jump: ACCEPT
+        state: "{{ firewall_rule_state }}"
+
+    - name: "ip6tables: Allow forwarding to baremetal network from kind"
+      iptables:
+        ip_version: ipv6
+        chain: FORWARD
+        action: insert
+        out_interface: "{{ external_interface }}"
+        destination: "{{ external_subnet_v6 }}"
+        jump: ACCEPT
+        state: "{{ firewall_rule_state }}"
+  when: (EPHEMERAL_CLUSTER == "kind") and (ip_stack == "v6")

--- a/vm-setup/roles/packages_installation/files/daemon.json
+++ b/vm-setup/roles/packages_installation/files/daemon.json
@@ -1,5 +1,5 @@
 {
     "ipv6": {{ DOCKER_IPV6_SUPPORT }},
-    "fixed-cidr-v6": "fd00::/80",
+    "fixed-cidr-v6": "fd00:d0c4::/32",
     "insecure-registries" : ["{{ REGISTRY }}"]
 }


### PR DESCRIPTION
This PR adds proper support for full IPv6 networking. Works only with kind cluster.

- Fix and complement some environment variables
- Fix kind-cluster IPv6 networking
- Fix kind-cluster registry configuration

### Testing

Here are short steps to test this yourself:

1. Build iPXE image builder with IPv6 support and with correct name (or rename after building). By default the builder is named after the address it is hosted at.
2. Build iPXE with IPv6 support.
3. The Docker engine depends on containerd 1.7. To configure image registries using an IPv6 address, containerd version **2.0 or later** is required. You can download the correct containerd binary and replace the existing one under `/usr/local/bin`.
4. You need to replace the default IPv4 addresses with IPv6 addresses in the environment variables.

After these steps running `make` and all traffic should be over IPv6.