### PR TITLE
Adding --nobest to dnf when installing packages on CentOS/RHEL

### DIFF
--- a/vm-setup/roles/packages_installation/tasks/main.yml
+++ b/vm-setup/roles/packages_installation/tasks/main.yml
@@ -61,6 +61,7 @@
       package:
           name: "{{ packages.centos.common.packages }}"
           state: present
+          nobest: true
     - name: Install packages using pip3
       pip:
         executable: "{{ ANSIBLE_VENV | default('/usr') }}/bin/pip"


### PR DESCRIPTION
Trying to resolve this error:
`"Depsolve Error occurred: \n Problem: cannot install both libvirt-libs-10.10.0-13.el9.x86_64 from appstream and libvirt-libs-10.10.0-12.el9.x86_64 from appstream\n  - package libvirt-devel-10.10.0-12.el9.x86_64 from crb requires libvirt-libs = 10.10.0-12.el9, but none of the providers can be installed\n  - package libvirt-10.10.0-13.el9.x86_64 from appstream requires libvirt-libs = 10.10.0-13.el9, but none of the providers can be installed\n  - cannot install the best candidate for the job",`