### PR TITLE
improve node image download logic

### DIFF
--- a/tests/roles/run_tests/tasks/download_image.yml
+++ b/tests/roles/run_tests/tasks/download_image.yml
@@ -1,15 +1,25 @@
 ---
-  - name: Check IMAGE_OS 
+  - name: Check IMAGE_OS
     block:
       - name: Get the facts about local image
         stat:
-          path: "{{ IRONIC_IMAGE_DIR }}/{{ RAW_IMAGE_NAME }}"
+          path: "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME }}"
         register: image_path
+
+      - name: Get the facts about local raw image
+        stat:
+          path: "{{ IRONIC_IMAGE_DIR }}/{{ RAW_IMAGE_NAME }}"
+        register: raw_image_path
+
+      - debug:
+          msg: "Local image {{ IMAGE_NAME }} is found"
+        when:
+          - image_path.stat.exists == True
 
       - debug:
           msg: "Local image {{ RAW_IMAGE_NAME }} is found"
         when:
-          - image_path.stat.exists == True
+          - raw_image_path.stat.exists == True
 
       - name: Download image.
         block:
@@ -17,9 +27,14 @@
               msg: "Local image {{ IMAGE_LOCATION }}/{{ IMAGE_NAME }} is not found, starting to download"
 
           - name: Verify specific image containing newer version of cloud-init is downloaded
-            shell: | 
-              wget -q "{{ IMAGE_LOCATION }}/{{ IMAGE_NAME }}" -O "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME }}" 
+            shell: |
+              wget -q "{{ IMAGE_LOCATION }}/{{ IMAGE_NAME }}" -O "{{ IRONIC_IMAGE_DIR }}/{{ IMAGE_NAME }}"
 
+        when:
+          - image_path.stat.exists == False
+
+      - name: Convert img to raw
+        block:
           - name: Create raw image
             shell: |
               qemu-img convert -O raw "{{ IRONIC_IMAGE_DIR }}/{{IMAGE_NAME}}" "{{ IRONIC_IMAGE_DIR }}/{{RAW_IMAGE_NAME}}"
@@ -28,14 +43,14 @@
             stat:
               path: "{{ IRONIC_IMAGE_DIR }}/{{ RAW_IMAGE_NAME }}"
               checksum_algorithm: sha256
-            register: image_sha256
+            register: raw_image_sha256
 
           - name: Create the sha256sum file
             copy:
               content: |
-                {{ image_sha256.stat.checksum }}
+                {{ raw_image_sha256.stat.checksum }}
 
               dest: "{{ IRONIC_IMAGE_DIR }}/{{ RAW_IMAGE_NAME }}.sha256sum"
               mode: 0664
         when:
-          - image_path.stat.exists == False
+          - raw_image_path.stat.exists == False


### PR DESCRIPTION
This commit:
 - Allows the user to provide a qcow2 image locally and convert it to raw image without triggering the download node image  logic thus wasting time.

This commit was needed because in the previous implementation the dev-env pulled the qcow2 node image even if only the raw image was missing. The previous logic had multiple faults:
- It didn't pull if the qcow2 was missing even though users might not use raw image streaming
- Pulled the qcow image if the raw image was missing instead of just converting the qcow2 to raw