### PR TITLE
Set node image to Ubuntu 24.04

### DIFF
--- a/lib/images.sh
+++ b/lib/images.sh
@@ -4,7 +4,7 @@
 IMAGE_OS="$(echo "${IMAGE_OS:-centos}" | tr '[:upper:]' '[:lower:]')"
 export "${IMAGE_OS?}"
 if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
-  export IMAGE_NAME=${IMAGE_NAME:-UBUNTU_22.04_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2}
+  export IMAGE_NAME=${IMAGE_NAME:-UBUNTU_24.04_NODE_IMAGE_K8S_${KUBERNETES_VERSION}.qcow2}
   export IMAGE_LOCATION=${IMAGE_LOCATION:-https://artifactory.nordix.org/artifactory/metal3/images/k8s_${KUBERNETES_VERSION}}
 elif [[ "${IMAGE_OS}" == "FCOS" ]]; then
   export IMAGE_NAME=${IMAGE_NAME:-fedora-coreos-32.20200923.2.0-openstack.x86_64.qcow2.xz}

--- a/tests/roles/run_tests/tasks/upgrade_k8s.yml
+++ b/tests/roles/run_tests/tasks/upgrade_k8s.yml
@@ -1,8 +1,8 @@
     - name: Download upgraded boot-disk image for deployment
       include_tasks: download_image.yml
       vars:
-        IMAGE_NAME: "UBUNTU_22.04_NODE_IMAGE_K8S_{{item}}.qcow2"
-        RAW_IMAGE_NAME: "UBUNTU_22.04_NODE_IMAGE_K8S_{{item}}-raw.img"
+        IMAGE_NAME: "UBUNTU_24.04_NODE_IMAGE_K8S_{{item}}.qcow2"
+        RAW_IMAGE_NAME: "UBUNTU_24.04_NODE_IMAGE_K8S_{{item}}-raw.img"
         IMAGE_LOCATION: "https://artifactory.nordix.org/artifactory/metal3/images/k8s_{{item}}"
         IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"
         IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
@@ -25,7 +25,7 @@
         CLUSTER_UID: "{{ clusters.resources[0].metadata.uid }}"
         M3MT_NAME: "{{CLUSTER_NAME}}-new-controlplane-image-{{item}}"
         DATA_TEMPLATE_NAME: "{{CLUSTER_NAME}}-controlplane-template"
-        RAW_IMAGE_NAME: "UBUNTU_22.04_NODE_IMAGE_K8S_{{item}}-raw.img"
+        RAW_IMAGE_NAME: "UBUNTU_24.04_NODE_IMAGE_K8S_{{item}}-raw.img"
         IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"
         IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
         NODE_REUSE_STATUS: "false"
@@ -41,7 +41,7 @@
         CLUSTER_UID: "{{ clusters.resources[0].metadata.uid }}"
         M3MT_NAME: "{{CLUSTER_NAME}}-new-workers-image-{{item}}"
         DATA_TEMPLATE_NAME: "{{CLUSTER_NAME}}-workers-template"
-        RAW_IMAGE_NAME: "UBUNTU_22.04_NODE_IMAGE_K8S_{{item}}-raw.img"
+        RAW_IMAGE_NAME: "UBUNTU_24.04_NODE_IMAGE_K8S_{{item}}-raw.img"
         IMAGE_URL: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}"
         IMAGE_CHECKSUM: "http://172.22.0.1/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
         NODE_REUSE_STATUS: "false"

--- a/tests/roles/run_tests/vars/main.yml
+++ b/tests/roles/run_tests/vars/main.yml
@@ -74,8 +74,8 @@ UPGRADED_IMAGE_NAME: "{{ lookup('env', 'UPGRADED_IMAGE_NAME') }}"
 UPGRADED_RAW_IMAGE_NAME: "{{ lookup('env', 'UPGRADED_RAW_IMAGE_NAME') }}"
 
 # Distibution specific environment variables
-IMAGE_NAME: "{{ lookup('env', 'IMAGE_NAME') | default('UBUNTU_22.04_NODE_IMAGE_K8S_{{KUBERNETES_VERSION}}.qcow2', true) }}"
-RAW_IMAGE_NAME: "{{ lookup('env', 'IMAGE_RAW_NAME') | default('UBUNTU_22.04_NODE_IMAGE_K8S_{{KUBERNETES_VERSION}}-raw.img', true) }}"
+IMAGE_NAME: "{{ lookup('env', 'IMAGE_NAME') | default('UBUNTU_24.04_NODE_IMAGE_K8S_{{KUBERNETES_VERSION}}.qcow2', true) }}"
+RAW_IMAGE_NAME: "{{ lookup('env', 'IMAGE_RAW_NAME') | default('UBUNTU_24.04_NODE_IMAGE_K8S_{{KUBERNETES_VERSION}}-raw.img', true) }}"
 IMAGE_LOCATION: "{{ lookup('env', 'IMAGE_LOCATION') | default('https://artifactory.nordix.org/artifactory/metal3/images/k8s_{{KUBERNETES_VERSION}}', true) }}"
 IMAGE_URL: "http://{{ BARE_METAL_PROVISIONER_IP }}/images/{{ RAW_IMAGE_NAME }}"
 IMAGE_FORMAT: "{{ lookup('env', 'IMAGE_FORMAT') | default('raw', true) }}"


### PR DESCRIPTION
This PR sets using Ubuntu 24.04 for node image in metal3 tests. 