### PR TITLE
Remove k8s yum repo from kubeadm config

### DIFF
--- a/tests/roles/run_tests/templates/main/cluster-template-controlplane-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/main/cluster-template-controlplane-kubeadm-config-centos.yaml
@@ -101,17 +101,6 @@ files:
       [ipv6]
       addr-gen-mode=eui64
       method=ignore
-  - path: /etc/yum.repos.d/kubernetes.repo
-    owner: root:root
-    permissions: '0644'
-    content: |
-      [kubernetes]
-      name=Kubernetes
-      baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-      enabled=1
-      gpgcheck=1
-      repo_gpgcheck=0
-      gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
   - path : /etc/containers/registries.conf
     content: |
       [registries.search]

--- a/tests/roles/run_tests/templates/main/cluster-template-controlplane-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/main/cluster-template-controlplane-kubeadm-config-leap.yaml
@@ -104,17 +104,6 @@ files:
     [ipv6]
     addr-gen-mode=eui64
     method=ignore
-- path: /etc/zypp/repos.d/kubernetes.repo
-  owner: root:root
-  permissions: '0644'
-  content: |
-    [kubernetes]
-    name=Kubernetes
-    baseurl=https://pkgs.k8s.io/core:/stable:/{{ KUBERNETES_VERSION_MINOR }}/rpm/
-    enabled=1
-    gpgcheck=1
-    repo_gpgcheck=0
-    gpgkey=https://pkgs.k8s.io/core:/stable:/{{ KUBERNETES_VERSION_MINOR }}/rpm/repodata/repomd.xml.key
 - path : /etc/containers/registries.conf
   content: |
     [registries.search]

--- a/tests/roles/run_tests/templates/main/cluster-template-workers-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/main/cluster-template-workers-kubeadm-config-centos.yaml
@@ -4,11 +4,11 @@ preKubeadmCommands:
   - systemctl restart NetworkManager.service
   - nmcli connection load /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
   - nmcli connection up {{ IRONIC_ENDPOINT_BRIDGE }}
-  - nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
-  - nmcli connection up {{ bmh_nic_names[0] }}
+  - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+  - nmcli connection up enp1s0
 {% if EXTERNAL_VLAN_ID != "" %}
-  - nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
-  - nmcli connection up /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+  - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+  - nmcli connection up /etc/NetworkManager/system-connections/enp1s0.{{ EXTERNAL_VLAN_ID }}.nmconnection
 {% endif %}
   - systemctl enable --now crio
   - sleep 30
@@ -33,7 +33,7 @@ files:
         else
           cat "$tmpfile"| sed '$d' > "$dst";
         fi
-  - path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
+  - path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
     owner: root:root
     permissions: '0600'
     content: |
@@ -64,17 +64,6 @@ files:
       [ipv6]
       addr-gen-mode=eui64
       method=ignore
-  - path: /etc/yum.repos.d/kubernetes.repo
-    owner: root:root
-    permissions: '0644'
-    content: |
-      [kubernetes]
-      name=Kubernetes
-      baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-      enabled=1
-      gpgcheck=1
-      repo_gpgcheck=0
-      gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
   - path : /etc/containers/registries.conf
     owner: root:root
     permissions: '0644'
@@ -85,7 +74,7 @@ files:
       [registries.insecure]
       registries = ['{{ REGISTRY }}']
 {% if EXTERNAL_VLAN_ID != "" %}
-  - path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+  - path: /etc/NetworkManager/system-connections/enp1s0.{{ EXTERNAL_VLAN_ID }}.nmconnection
     owner: root:root
     permissions: '0600'
     content: |

--- a/tests/roles/run_tests/templates/main/cluster-template-workers-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/main/cluster-template-workers-kubeadm-config-leap.yaml
@@ -68,17 +68,6 @@ files:
     [ipv6]
     addr-gen-mode=eui64
     method=ignore
-- path: /etc/zypp/repos.d/kubernetes.repo
-  owner: root:root
-  permissions: '0644'
-  content: |
-    [kubernetes]
-    name=Kubernetes
-    baseurl=https://pkgs.k8s.io/core:/stable:/{{ KUBERNETES_VERSION_MINOR }}/rpm/
-    enabled=1
-    gpgcheck=1
-    repo_gpgcheck=0
-    gpgkey=https://pkgs.k8s.io/core:/stable:/{{ KUBERNETES_VERSION_MINOR }}/rpm/repodata/repomd.xml.key
 - path : /etc/containers/registries.conf
   owner: root:root
   permissions: '0644'

--- a/tests/roles/run_tests/templates/release-1.10/cluster-template-controlplane-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/release-1.10/cluster-template-controlplane-kubeadm-config-centos.yaml
@@ -101,17 +101,6 @@ files:
       [ipv6]
       addr-gen-mode=eui64
       method=ignore
-  - path: /etc/yum.repos.d/kubernetes.repo
-    owner: root:root
-    permissions: '0644'
-    content: |
-      [kubernetes]
-      name=Kubernetes
-      baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-      enabled=1
-      gpgcheck=1
-      repo_gpgcheck=0
-      gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
   - path : /etc/containers/registries.conf
     content: |
       [registries.search]

--- a/tests/roles/run_tests/templates/release-1.10/cluster-template-workers-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/release-1.10/cluster-template-workers-kubeadm-config-centos.yaml
@@ -64,17 +64,6 @@ files:
       [ipv6]
       addr-gen-mode=eui64
       method=ignore
-  - path: /etc/yum.repos.d/kubernetes.repo
-    owner: root:root
-    permissions: '0644'
-    content: |
-      [kubernetes]
-      name=Kubernetes
-      baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-      enabled=1
-      gpgcheck=1
-      repo_gpgcheck=0
-      gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
   - path : /etc/containers/registries.conf
     owner: root:root
     permissions: '0644'

--- a/tests/roles/run_tests/templates/release-1.11/cluster-template-controlplane-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/release-1.11/cluster-template-controlplane-kubeadm-config-centos.yaml
@@ -101,17 +101,6 @@ files:
       [ipv6]
       addr-gen-mode=eui64
       method=ignore
-  - path: /etc/yum.repos.d/kubernetes.repo
-    owner: root:root
-    permissions: '0644'
-    content: |
-      [kubernetes]
-      name=Kubernetes
-      baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-      enabled=1
-      gpgcheck=1
-      repo_gpgcheck=0
-      gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
   - path : /etc/containers/registries.conf
     content: |
       [registries.search]

--- a/tests/roles/run_tests/templates/release-1.11/cluster-template-controlplane-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/release-1.11/cluster-template-controlplane-kubeadm-config-leap.yaml
@@ -104,17 +104,6 @@ files:
     [ipv6]
     addr-gen-mode=eui64
     method=ignore
-- path: /etc/zypp/repos.d/kubernetes.repo
-  owner: root:root
-  permissions: '0644'
-  content: |
-    [kubernetes]
-    name=Kubernetes
-    baseurl=https://pkgs.k8s.io/core:/stable:/{{ KUBERNETES_VERSION_MINOR }}/rpm/
-    enabled=1
-    gpgcheck=1
-    repo_gpgcheck=0
-    gpgkey=https://pkgs.k8s.io/core:/stable:/{{ KUBERNETES_VERSION_MINOR }}/rpm/repodata/repomd.xml.key
 - path : /etc/containers/registries.conf
   content: |
     [registries.search]

--- a/tests/roles/run_tests/templates/release-1.11/cluster-template-workers-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/release-1.11/cluster-template-workers-kubeadm-config-centos.yaml
@@ -64,17 +64,6 @@ files:
       [ipv6]
       addr-gen-mode=eui64
       method=ignore
-  - path: /etc/yum.repos.d/kubernetes.repo
-    owner: root:root
-    permissions: '0644'
-    content: |
-      [kubernetes]
-      name=Kubernetes
-      baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-      enabled=1
-      gpgcheck=1
-      repo_gpgcheck=0
-      gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
   - path : /etc/containers/registries.conf
     owner: root:root
     permissions: '0644'

--- a/tests/roles/run_tests/templates/release-1.11/cluster-template-workers-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/release-1.11/cluster-template-workers-kubeadm-config-leap.yaml
@@ -68,17 +68,6 @@ files:
     [ipv6]
     addr-gen-mode=eui64
     method=ignore
-- path: /etc/zypp/repos.d/kubernetes.repo
-  owner: root:root
-  permissions: '0644'
-  content: |
-    [kubernetes]
-    name=Kubernetes
-    baseurl=https://pkgs.k8s.io/core:/stable:/{{ KUBERNETES_VERSION_MINOR }}/rpm/
-    enabled=1
-    gpgcheck=1
-    repo_gpgcheck=0
-    gpgkey=https://pkgs.k8s.io/core:/stable:/{{ KUBERNETES_VERSION_MINOR }}/rpm/repodata/repomd.xml.key
 - path : /etc/containers/registries.conf
   owner: root:root
   permissions: '0644'

--- a/tests/roles/run_tests/templates/release-1.8/cluster-template-controlplane-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/release-1.8/cluster-template-controlplane-kubeadm-config-centos.yaml
@@ -101,17 +101,6 @@ files:
       [ipv6]
       addr-gen-mode=eui64
       method=ignore
-  - path: /etc/yum.repos.d/kubernetes.repo
-    owner: root:root
-    permissions: '0644'
-    content: |
-      [kubernetes]
-      name=Kubernetes
-      baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-      enabled=1
-      gpgcheck=1
-      repo_gpgcheck=0
-      gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
   - path : /etc/containers/registries.conf
     content: |
       [registries.search]

--- a/tests/roles/run_tests/templates/release-1.8/cluster-template-workers-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/release-1.8/cluster-template-workers-kubeadm-config-centos.yaml
@@ -64,17 +64,6 @@ files:
       [ipv6]
       addr-gen-mode=eui64
       method=ignore
-  - path: /etc/yum.repos.d/kubernetes.repo
-    owner: root:root
-    permissions: '0644'
-    content: |
-      [kubernetes]
-      name=Kubernetes
-      baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-      enabled=1
-      gpgcheck=1
-      repo_gpgcheck=0
-      gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
   - path : /etc/containers/registries.conf
     owner: root:root
     permissions: '0644'

--- a/tests/roles/run_tests/templates/release-1.9/cluster-template-controlplane-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/release-1.9/cluster-template-controlplane-kubeadm-config-centos.yaml
@@ -101,17 +101,6 @@ files:
       [ipv6]
       addr-gen-mode=eui64
       method=ignore
-  - path: /etc/yum.repos.d/kubernetes.repo
-    owner: root:root
-    permissions: '0644'
-    content: |
-      [kubernetes]
-      name=Kubernetes
-      baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-      enabled=1
-      gpgcheck=1
-      repo_gpgcheck=0
-      gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
   - path : /etc/containers/registries.conf
     content: |
       [registries.search]

--- a/tests/roles/run_tests/templates/release-1.9/cluster-template-workers-kubeadm-config-centos.yaml
+++ b/tests/roles/run_tests/templates/release-1.9/cluster-template-workers-kubeadm-config-centos.yaml
@@ -64,17 +64,6 @@ files:
       [ipv6]
       addr-gen-mode=eui64
       method=ignore
-  - path: /etc/yum.repos.d/kubernetes.repo
-    owner: root:root
-    permissions: '0644'
-    content: |
-      [kubernetes]
-      name=Kubernetes
-      baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-      enabled=1
-      gpgcheck=1
-      repo_gpgcheck=0
-      gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
   - path : /etc/containers/registries.conf
     owner: root:root
     permissions: '0644'


### PR DESCRIPTION
This PR removes kubernetes repo that was removed from google hosted.