### PR TITLE
🌱 Fixing IPA_BASEURI for IRSO

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -252,7 +252,7 @@ EOF
 launch_ironic_standalone_operator()
 {
     # shellcheck disable=SC2311
-    echo 'IPA_BASEURI="https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib"' > "${IRSOPATH}/config/manager/manager.env"
+    echo 'IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib' > "${IRSOPATH}/config/manager/manager.env"
     make -C "${IRSOPATH}" install deploy IMG="$(get_component_image "${IRSO_LOCAL_IMAGE:-${IRSO_IMAGE}}")"
     kubectl wait --for=condition=Available --timeout=60s \
         -n ironic-standalone-operator-system deployment/ironic-standalone-operator-controller-manager

--- a/03_launch_mgmt_cluster_pre_1_10.sh
+++ b/03_launch_mgmt_cluster_pre_1_10.sh
@@ -245,7 +245,7 @@ EOF
 launch_ironic_standalone_operator()
 {
     # shellcheck disable=SC2311
-    echo 'IPA_BASEURI="https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib"' > "${IRSOPATH}/config/manager/manager.env"
+    echo 'IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib' > "${IRSOPATH}/config/manager/manager.env"
     make -C "${IRSOPATH}" install deploy IMG="$(get_component_image "${IRSO_LOCAL_IMAGE:-${IRSO_IMAGE}}")"
     kubectl wait --for=condition=Available --timeout=60s \
         -n ironic-standalone-operator-system deployment/ironic-standalone-operator-controller-manager


### PR DESCRIPTION
test failed with the following error:

```
+ curl -g --dump-header ipa-centos9-master.tar.gz.headers -O '"https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib"/ipa-centos9-master.tar.gz'
curl: (3) URL using bad/illegal format or missing URL
```

removing " 