### PR TITLE
Rename cluster name from EPHEMERAL to BOOTSTRAP

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -100,7 +100,7 @@ if ! kubectl krew > /dev/null 2>&1; then
     download_and_install_krew
 fi
 
-if [[ "${EPHEMERAL_CLUSTER}" = "minikube" ]]; then
+if [[ "${BOOTSTRAP_CLUSTER}" = "minikube" ]]; then
     # shellcheck disable=SC2312
     if ! command -v minikube &>/dev/null || [[ "$(minikube version --short)" != "${MINIKUBE_VERSION}" ]]; then
         download_and_install_minikube
@@ -116,7 +116,7 @@ else
     if ! command -v kind &>/dev/null || [[ "v$(kind version -q)" != "${KIND_VERSION}" ]]; then
         download_and_install_kind
     fi
-    if [[ "${EPHEMERAL_CLUSTER}" = "tilt" ]]; then
+    if [[ "${BOOTSTRAP_CLUSTER}" = "tilt" ]]; then
         download_and_install_tilt
     fi
 fi

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -124,7 +124,7 @@ init_minikube()
     fi
 }
 
-if [[ "${EPHEMERAL_CLUSTER}" == "minikube" ]]; then
+if [[ "${BOOTSTRAP_CLUSTER}" == "minikube" ]]; then
     init_minikube
 fi
 
@@ -257,7 +257,7 @@ if [[ "${OS}" == "ubuntu" ]]; then
     source disable_apparmor_driver_libvirtd.sh
 else
     if [[ "${MANAGE_PRO_BRIDGE}" == "y" ]]; then
-        if [[ ${EPHEMERAL_CLUSTER} == "kind" ]]; then
+        if [[ ${BOOTSTRAP_CLUSTER} == "kind" ]]; then
             configure_kind_network
         else
             configure_minikube_network

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -59,7 +59,7 @@ launch_baremetal_operator()
     pushd "${BMOPATH}"
 
     # Deploy BMO using deploy.sh script
-    if [[ "${EPHEMERAL_CLUSTER}" != "tilt" ]]; then
+    if [[ "${BOOTSTRAP_CLUSTER}" != "tilt" ]]; then
         # Update container images to use local ones
         if [[ -n "${BARE_METAL_OPERATOR_LOCAL_IMAGE:-}" ]]; then
             update_component_image BMO "${BARE_METAL_OPERATOR_LOCAL_IMAGE}"
@@ -236,7 +236,7 @@ EOF
         update_component_image IPA-downloader "${IPA_DOWNLOADER_IMAGE}"
     fi
 
-    if [[ "${EPHEMERAL_CLUSTER}" != "minikube" ]]; then
+    if [[ "${BOOTSTRAP_CLUSTER}" != "minikube" ]]; then
         update_images
         ${RUN_LOCAL_IRONIC_SCRIPT}
         # Wait for ironic to become ready
@@ -352,7 +352,7 @@ launch_fake_ipa()
 {
     # Create a folder to host fakeIPA config and certs
     mkdir -p "${WORKING_DIR}/fake-ipa"
-    if [[ "${EPHEMERAL_CLUSTER}" = "kind" ]] && [[ "${IRONIC_TLS_SETUP}" = "true" ]]; then
+    if [[ "${BOOTSTRAP_CLUSTER}" = "kind" ]] && [[ "${IRONIC_TLS_SETUP}" = "true" ]]; then
         cp "${IRONIC_CACERT_FILE}" "${WORKING_DIR}/fake-ipa/ironic-ca.crt"
     elif [[ "${IRONIC_TLS_SETUP}" = "true" ]]; then
         # wait for ironic to be running to ensure ironic-cert is created
@@ -716,9 +716,9 @@ start_management_cluster()
 {
     local minikube_error
 
-    if [[ "${EPHEMERAL_CLUSTER}" = "kind" ]]; then
+    if [[ "${BOOTSTRAP_CLUSTER}" = "kind" ]]; then
         launch_kind
-    elif [[ "${EPHEMERAL_CLUSTER}" = "minikube" ]]; then
+    elif [[ "${BOOTSTRAP_CLUSTER}" = "minikube" ]]; then
         # This method, defined in lib/common.sh, will either ensure sockets are up'n'running
         # for CS9 and RHEL9, or restart the libvirtd.service for other DISTRO
         manage_libvirtd
@@ -810,7 +810,7 @@ build_ipxe_firmware()
 "${BMOPATH}"/tools/remove_local_ironic.sh
 create_clouds_yaml
 
-if [[ "${EPHEMERAL_CLUSTER}" = "tilt" ]]; then
+if [[ "${BOOTSTRAP_CLUSTER}" = "tilt" ]]; then
     # shellcheck disable=SC1091
     . tilt-setup/deploy_tilt_env.sh
     exit 0

--- a/03_launch_mgmt_cluster_pre_1_10.sh
+++ b/03_launch_mgmt_cluster_pre_1_10.sh
@@ -52,7 +52,7 @@ launch_baremetal_operator()
     pushd "${BMOPATH}"
 
     # Deploy BMO using deploy.sh script
-    if [[ "${EPHEMERAL_CLUSTER}" != "tilt" ]]; then
+    if [[ "${BOOTSTRAP_CLUSTER}" != "tilt" ]]; then
         # Update container images to use local ones
         if [[ -n "${BARE_METAL_OPERATOR_LOCAL_IMAGE:-}" ]]; then
             update_component_image BMO "${BARE_METAL_OPERATOR_LOCAL_IMAGE}"
@@ -229,7 +229,7 @@ EOF
         update_component_image IPA-downloader "${IPA_DOWNLOADER_IMAGE}"
     fi
 
-    if [[ "${EPHEMERAL_CLUSTER}" != "minikube" ]]; then
+    if [[ "${BOOTSTRAP_CLUSTER}" != "minikube" ]]; then
         update_images
         ${RUN_LOCAL_IRONIC_SCRIPT}
         # Wait for ironic to become ready
@@ -345,7 +345,7 @@ launch_fake_ipa()
 {
     # Create a folder to host fakeIPA config and certs
     mkdir -p "${WORKING_DIR}/fake-ipa"
-    if [[ "${EPHEMERAL_CLUSTER}" = "kind" ]] && [[ "${IRONIC_TLS_SETUP}" = "true" ]]; then
+    if [[ "${BOOTSTRAP_CLUSTER}" = "kind" ]] && [[ "${IRONIC_TLS_SETUP}" = "true" ]]; then
         cp "${IRONIC_CACERT_FILE}" "${WORKING_DIR}/fake-ipa/ironic-ca.crt"
     elif [[ "${IRONIC_TLS_SETUP}" = "true" ]]; then
         # wait for ironic to be running to ensure ironic-cert is created
@@ -640,9 +640,9 @@ start_management_cluster()
 {
     local minikube_error
 
-    if [[ "${EPHEMERAL_CLUSTER}" = "kind" ]]; then
+    if [[ "${BOOTSTRAP_CLUSTER}" = "kind" ]]; then
         launch_kind
-    elif [[ "${EPHEMERAL_CLUSTER}" = "minikube" ]]; then
+    elif [[ "${BOOTSTRAP_CLUSTER}" = "minikube" ]]; then
         # This method, defined in lib/common.sh, will either ensure sockets are up'n'running
         # for CS9 and RHEL9, or restart the libvirtd.service for other DISTRO
         manage_libvirtd
@@ -731,7 +731,7 @@ build_ipxe_firmware()
 "${BMOPATH}"/tools/remove_local_ironic.sh
 create_clouds_yaml
 
-if [[ "${EPHEMERAL_CLUSTER}" = "tilt" ]]; then
+if [[ "${BOOTSTRAP_CLUSTER}" = "tilt" ]]; then
     # shellcheck disable=SC1091
     . tilt-setup/deploy_tilt_env.sh
     exit 0

--- a/04_verify.sh
+++ b/04_verify.sh
@@ -17,7 +17,7 @@ source lib/images.sh
 # shellcheck disable=SC1091
 source lib/releases.sh
 
-if [ "${EPHEMERAL_CLUSTER}" == "tilt" ]; then
+if [ "${BOOTSTRAP_CLUSTER}" == "tilt" ]; then
   exit 0
 fi
 
@@ -195,7 +195,7 @@ EXPTD_DEPLOYMENTS="capm3-system:capm3-controller-manager \
     capi-kubeadm-control-plane-system:capi-kubeadm-control-plane-controller-manager \
     baremetal-operator-system:baremetal-operator-controller-manager"
 
-if [[ "${EPHEMERAL_CLUSTER}" == "minikube" ]]; then
+if [[ "${BOOTSTRAP_CLUSTER}" == "minikube" ]]; then
   if [[ "${USE_IRSO}" == "true" ]]; then
     EXPTD_DEPLOYMENTS+=" \
       baremetal-operator-system:ironic-service \

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ kubectl delete cluster "${CLUSTER_NAME:-"test1"}" -n metal3
 ### Deploying and developing with Tilt
 
 It is possible to use Tilt to run the CAPI, BMO, CAPM3 and IPAM components. Tilt
-ephemeral cluster will utilize Kind and Docker, so it requires an Ubuntu host.
+bootstrap cluster will utilize Kind and Docker, so it requires an Ubuntu host.
 For this, run:
 
 By default, Metal3 components are not built locally. To develop with Tilt, you
@@ -130,11 +130,11 @@ development branch content. Same for IPAM, BMO and CAPI.
 See `vars.md` for more information.
 
 After specifying the components and paths to your liking, bring the cluster up
-by setting the ephemeral cluster type to Tilt and image OS to Ubuntu.
+by setting the bootstrap cluster type to Tilt and image OS to Ubuntu.
 
 ```sh
 export IMAGE_OS=ubuntu
-export EPHEMERAL_CLUSTER="tilt"
+export BOOTSTRAP_CLUSTER="tilt"
 make
 ```
 

--- a/cluster_cleanup.sh
+++ b/cluster_cleanup.sh
@@ -6,13 +6,13 @@ set -eux
 source lib/common.sh
 
 # Delete cluster
-if [[ "${EPHEMERAL_CLUSTER}" = "kind" ]] || [[ "${EPHEMERAL_CLUSTER}" = "tilt" ]]; then
+if [[ "${BOOTSTRAP_CLUSTER}" = "kind" ]] || [[ "${BOOTSTRAP_CLUSTER}" = "tilt" ]]; then
     sudo su -l -c "kind delete cluster  || true" "${USER}"
     # Kill and remove the running ironic containers
     if [[ -x "${BMOPATH}/tools/remove_local_ironic.sh" ]]; then
         "${BMOPATH}"/tools/remove_local_ironic.sh
     fi
-    if [[ "${EPHEMERAL_CLUSTER}" = "tilt" ]]; then
+    if [[ "${BOOTSTRAP_CLUSTER}" = "tilt" ]]; then
         pushd "${CAPM3PATH}"
         pgrep tilt | xargs kill  || true
         make kind-reset
@@ -20,6 +20,6 @@ if [[ "${EPHEMERAL_CLUSTER}" = "kind" ]] || [[ "${EPHEMERAL_CLUSTER}" = "tilt" ]
     fi
 fi
 
-if [[ "${EPHEMERAL_CLUSTER}" = "minikube" ]]; then
+if [[ "${BOOTSTRAP_CLUSTER}" = "minikube" ]]; then
     sudo su -l -c "minikube delete" "${USER}"
 fi

--- a/config_example.sh
+++ b/config_example.sh
@@ -189,13 +189,13 @@
 # of the node.
 #export NODE_HOSTNAME_FORMAT="node-%d"
 
-# Ephemeral cluster used as management cluster for cluster API
+# Bootstrap cluster used as management cluster for cluster API
 # (can be "kind", "minikube" or "tilt"). Only "minikube" is supported with
 # CentOS
 # Selecting "tilt" does not deploy a management cluster, it is left up to the
 # user
 # Default is "kind" when CONTAINER_RUNTIME="docker", otherwise it is "minikube"
-#export EPHEMERAL_CLUSTER=minikube
+#export BOOTSTRAP_CLUSTER=minikube
 
 # Secure Ironic deployment with TLS ("true" or "false")
 #export IRONIC_TLS_SETUP="true"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -380,11 +380,11 @@ export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.34.1}"
 export KUBERNETES_BINARIES_VERSION="${KUBERNETES_BINARIES_VERSION:-${KUBERNETES_VERSION}}"
 export KUBERNETES_BINARIES_CONFIG_VERSION=${KUBERNETES_BINARIES_CONFIG_VERSION:-"v0.15.1"}
 
-# Ephemeral Cluster
+# Bootstrap Cluster
 if [[ "${CONTAINER_RUNTIME}" = "docker" ]]; then
-  export EPHEMERAL_CLUSTER=${EPHEMERAL_CLUSTER:-"kind"}
+  export BOOTSTRAP_CLUSTER=${BOOTSTRAP_CLUSTER:-"kind"}
 else
-  export EPHEMERAL_CLUSTER="minikube"
+  export BOOTSTRAP_CLUSTER="minikube"
 fi
 
 # Kubectl version - SHA256 is downloaded and verified
@@ -397,10 +397,10 @@ export KREW_SHA256="${KREW_SHA256:-5df32eaa0e888a2566439c4ccb2ef3a3e6e89522f2f21
 # Kustomize version
 export KUSTOMIZE_VERSION="${KUSTOMIZE_VERSION:-v5.4.1}"
 
-# Minikube version (if EPHEMERAL_CLUSTER=minikube)
+# Minikube version (if BOOTSTRAP_CLUSTER=minikube)
 export MINIKUBE_VERSION="${MINIKUBE_VERSION:-v1.37.0}"
 
-# Kind, kind node image versions (if EPHEMERAL_CLUSTER=kind)
+# Kind, kind node image versions (if BOOTSTRAP_CLUSTER=kind)
 export KIND_VERSION="${KIND_VERSION:-v0.30.0}"
 export KIND_NODE_IMAGE_VERSION="${KIND_NODE_IMAGE_VERSION:-v1.34.0}"
 export KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-${DOCKER_HUB_PROXY}/kindest/node:${KIND_NODE_IMAGE_VERSION}}"

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -140,7 +140,7 @@ else
 fi
 export CLUSTER_APIENDPOINT_PORT=${CLUSTER_APIENDPOINT_PORT:-"6443"}
 
-if [[ "${EPHEMERAL_CLUSTER}" == "minikube" ]] && [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
+if [[ "${BOOTSTRAP_CLUSTER}" == "minikube" ]] && [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
     network_address MINIKUBE_BMNET_V6_IP "${EXTERNAL_SUBNET_V6}" 9
 fi
 

--- a/tests/roles/run_tests/tasks/move.yml
+++ b/tests/roles/run_tests/tasks/move.yml
@@ -36,7 +36,7 @@
           state: absent
         with_items: "{{ ironic_containers }}"
 
-    when: EPHEMERAL_CLUSTER == "kind"
+    when: BOOTSTRAP_CLUSTER == "kind"
     become: yes
     become_user: root
 
@@ -55,7 +55,7 @@
 
     become: yes
     become_user: root
-    when: EPHEMERAL_CLUSTER == "minikube"
+    when: BOOTSTRAP_CLUSTER == "minikube"
 
   - name: Remove Ironic from source cluster (minikube cluster)
     kubernetes.core.k8s:
@@ -63,8 +63,8 @@
       kind: Deployment
       state: absent
       namespace: "{{ IRONIC_NAMESPACE }}"
-    when: EPHEMERAL_CLUSTER == "minikube"
-  
+    when: BOOTSTRAP_CLUSTER == "minikube"
+
   - name: Label baremetalhost CRD to pivot.
     shell: "kubectl label --overwrite crds baremetalhosts.metal3.io {{ item }}"
     with_items:

--- a/tests/roles/run_tests/tasks/move_back.yml
+++ b/tests/roles/run_tests/tasks/move_back.yml
@@ -18,18 +18,18 @@
     args:
       chdir: "{{ BMOPATH }}"
 
-  - name: Install Ironic in Source cluster (Ephemeral Cluster is kind)
+  - name: Install Ironic in Source cluster (Bootstrap Cluster is kind)
     shell: "{{ BMOPATH }}/tools/run_local_ironic.sh"
     environment:
       CONTAINER_RUNTIME: "{{ CONTAINER_RUNTIME }}"
-    when: EPHEMERAL_CLUSTER == "kind"
+    when: BOOTSTRAP_CLUSTER == "kind"
 
-  - name: Install Ironic in Source cluster (Ephemeral Cluster is minikube)
+  - name: Install Ironic in Source cluster (Bootstrap Cluster is minikube)
     shell: "{{ BMOPATH }}/tools/deploy.sh -i {{ BMO_IRONIC_ARGS }}"
     environment:
       IRONIC_HOST: "{{ IRONIC_HOST }}"
       IRONIC_HOST_IP: "{{ IRONIC_HOST_IP }}"
-    when: EPHEMERAL_CLUSTER == "minikube"
+    when: BOOTSTRAP_CLUSTER == "minikube"
     args:
       chdir: "{{ BMOPATH }}"
 

--- a/tests/roles/run_tests/vars/main.yml
+++ b/tests/roles/run_tests/vars/main.yml
@@ -5,7 +5,7 @@ IRONIC_NAMESPACE: "{{ lookup('env', 'IRONIC_NAMESPACE') | default('baremetal-ope
 NAMEPREFIX: "{{ lookup('env', 'NAMEPREFIX') | default('baremetal-operator', true) }}"
 CRS_PATH: "{{ metal3_dir }}/tests/roles/run_tests/templates"
 TEMP_GEN_DIR: "{{ metal3_dir }}/tests/roles/run_tests/files/manifests"
-EPHEMERAL_CLUSTER: "{{ lookup('env', 'EPHEMERAL_CLUSTER') | default('kind', true) }}"
+BOOTSTRAP_CLUSTER: "{{ lookup('env', 'BOOTSTRAP_CLUSTER') | default('kind', true) }}"
 CAPI_CONFIG_DIR: "{{ lookup('env', 'CAPI_CONFIG_DIR') | default('$HOME/.config/cluster-api', true) }}"
 CLUSTER_APIENDPOINT_HOST: "{{ lookup('env', 'CLUSTER_APIENDPOINT_HOST') }}"
 CLUSTER_APIENDPOINT_PORT: "{{ lookup('env', 'CLUSTER_APIENDPOINT_PORT') | default(6443, true) }}"

--- a/tests/scripts/fetch_manifests.sh
+++ b/tests/scripts/fetch_manifests.sh
@@ -10,7 +10,7 @@ DIR_NAME_AFTER_REPIVOT="/tmp/manifests/bootstrap-after-repivot"
 if [[ -d "${DIR_NAME}" ]] && [[ -d "${DIR_NAME_AFTER_PIVOT}" ]]; then
   DIR_NAME="${DIR_NAME_AFTER_REPIVOT}"
   mkdir -p "${DIR_NAME}"
-  # Ephemeral cluster kubeconfig
+  # Bootstrap cluster kubeconfig
   kconfig="/home/metal3ci/.kube/config"
 elif [[ -d "${DIR_NAME}" ]] && [[ ! -d "${DIR_NAME_AFTER_PIVOT}" ]]; then
   DIR_NAME="${DIR_NAME_AFTER_PIVOT}"
@@ -19,7 +19,7 @@ elif [[ -d "${DIR_NAME}" ]] && [[ ! -d "${DIR_NAME_AFTER_PIVOT}" ]]; then
   kconfig="$(sudo find /tmp/ -type f -name "kubeconfig*")"
 else
   mkdir -p "${DIR_NAME}"
-  # Ephemeral cluster kubeconfig
+  # Bootstrap cluster kubeconfig
   kconfig="/home/metal3ci/.kube/config"
 fi
 

--- a/vars.md
+++ b/vars.md
@@ -13,7 +13,7 @@ assured that they are persisted.
 | :------ | :------- | :--------------- | :-------- |
 | DOCKER_USE_IPV6_INTERNALLY | Choose whether Docker will use IPv6 internally. | "true", "false" | false |
 | MAX_SURGE_VALUE | This variable defines if controlplane should scale-in or scale-out during upgrade. | 0 (scale-in) or 1 (scale-out) |1|
-| EPHEMERAL_CLUSTER | Tool for running management/ephemeral cluster. | minikube, kind, tilt | "kind" when using docker as the container runtime (the default on Ubuntu), "minikube" otherwise |
+| BOOTSTRAP_CLUSTER | Tool for running management/bootstrap cluster. | minikube, kind, tilt | "kind" when using docker as the container runtime (the default on Ubuntu), "minikube" otherwise |
 | IP_STACK | Choose whether the "external" libvirt network will use IPv4, IPv6, or IPv4+IPv6. This network is the primary network interface for the virtual bare metal hosts. Note that this only sets up the underlying network, and fully provisioning IPv6 kubernetes clusters is not yet automated. If IPv6 is enabled, DHCPv6 will be available to the virtual bare metal hosts. | "v4", "v6", "v4v6" (dual-stack)) | v4 |
 | EXTERNAL_VLAN_ID | If the "external" network is tagged, this is the VLAN id for the network, set on the network interface for the bare metal hosts. | "" or 1-4096 | "" |
 | EXTERNAL_SUBNET_V4 | When using IPv4 stack, this is the subnet used on the "external" libvirt network, created as the primary network interface for the virtual bare metalhosts. | IPv4 CIDR | 192.168.111.0/24 |
@@ -152,7 +152,7 @@ not conflicting.
 ## Local IPA
 
 The use of local IPA enabled via `USE_LOCAL_IPA` is only supported on
-Ubuntu host when `EPHEMERAL_CLUSTER` is `kind` cluster and Ironic is
+Ubuntu host when `BOOTSTRAP_CLUSTER` is `kind` cluster and Ironic is
 directly deployed to  the OCI runtime (no K8s pod)
 
 ## Local images
@@ -190,7 +190,7 @@ For testing purposes, verification of the digests will be skipped if
 ## Make options
 
 - `make` will run the installation of all te dependencies and set up the
-   ephemeral controlplane
+   bootstrap controlplane
 - `make nodep` will skip the dependency installation
 - `make ci_run` will run only those make targets that are executed in the
    CI
@@ -224,7 +224,7 @@ The following variables need to be set:
 export IPXE_ENABLE_IPV6=true
 export BUILD_IPXE=true
 export IPXE_BUILDER_LOCAL_IMAGE="<path to local builder image>"
-export EPHEMERAL_CLUSTER="kind"
+export BOOTSTRAP_CLUSTER="kind"
 export IP_STACK=v6
 export EXTERNAL_SUBNET_V6="fd55::/64"
 export BARE_METAL_PROVISIONER_SUBNET_IPV6_ONLY=true

--- a/vm-setup/roles/firewall/defaults/main.yml
+++ b/vm-setup/roles/firewall/defaults/main.yml
@@ -48,4 +48,4 @@ ironic_keepalived_proto:
   - "112"
   - "icmp"
 
-EPHEMERAL_CLUSTER: "{{ lookup('env', 'EPHEMERAL_CLUSTER') | default('kind', true)}}"
+BOOTSTRAP_CLUSTER: "{{ lookup('env', 'BOOTSTRAP_CLUSTER') | default('kind', true)}}"

--- a/vm-setup/roles/firewall/tasks/iptables.yaml
+++ b/vm-setup/roles/firewall/tasks/iptables.yaml
@@ -141,7 +141,7 @@
         destination: "{{ external_subnet_v4 }}"
         jump: ACCEPT
         state: "{{ firewall_rule_state }}"
-  when: (EPHEMERAL_CLUSTER == "kind") and (ip_stack == "v4")
+  when: (BOOTSTRAP_CLUSTER == "kind") and (ip_stack == "v4")
 
 - block:
     - name: "ip6tables: Allow access to external network from kind"
@@ -191,4 +191,4 @@
         destination: "{{ external_subnet_v6 }}"
         jump: ACCEPT
         state: "{{ firewall_rule_state }}"
-  when: (EPHEMERAL_CLUSTER == "kind") and (ip_stack == "v6")
+  when: (BOOTSTRAP_CLUSTER == "kind") and (ip_stack == "v6")


### PR DESCRIPTION
We have been discussing to update Ephemeral cluster name to Bootstrap cluster instances. This PR will unify all the variables from EPHEMERAL_CLUSTER to BOOTSTRAP_CLUSTER.