### PR TITLE
change golang download url to official url + bump 1.24.10

### DIFF
--- a/vm-setup/install-package-playbook.yml
+++ b/vm-setup/install-package-playbook.yml
@@ -8,7 +8,8 @@
   - import_role:
       name: fubarhouse.golang
     vars:
-      go_version: 1.24.3
+      go_version: 1.24.10
       go_install_clean: true
+      go_custom_mirror: https://go.dev/dl/
       GOOS: linux
       GOARCH: amd64


### PR DESCRIPTION
Storage bucket is not allowing anonymous access, and official dl urls are expected to be used. Bump to 1.24.10 while at it.