### PR TITLE
Fix labeling of IRSO secrets

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -260,8 +260,9 @@ launch_ironic_via_irso()
 
     kubectl create secret generic ironic-auth -n "${IRONIC_NAMESPACE}" \
         --from-file=username="${IRONIC_AUTH_DIR}ironic-username"  \
-        --from-file=password="${IRONIC_AUTH_DIR}ironic-password" \
-        --labels='environment.metal3.io/ironic-standalone-operator=true'
+        --from-file=password="${IRONIC_AUTH_DIR}ironic-password"
+    kubectl label secret ironic-auth -n "${IRONIC_NAMESPACE}" \
+        environment.metal3.io/ironic-standalone-operator=true
 
     local ironic="${IRONIC_DATA_DIR}/ironic.yaml"
     cat > "${ironic}" <<EOF
@@ -298,8 +299,9 @@ EOF
     fi
 
     if [[ -r "${IRONIC_CERT_FILE}" ]] && [[ -r "${IRONIC_KEY_FILE}" ]]; then
-        kubectl create secret tls ironic-cert -n "${IRONIC_NAMESPACE}" --key="${IRONIC_KEY_FILE}" --cert="${IRONIC_CERT_FILE}" \
-            --labels='environment.metal3.io/ironic-standalone-operator=true'
+        kubectl create secret tls ironic-cert -n "${IRONIC_NAMESPACE}" --key="${IRONIC_KEY_FILE}" --cert="${IRONIC_CERT_FILE}"
+        kubectl label secret ironic-cert -n "${IRONIC_NAMESPACE}" \
+            environment.metal3.io/ironic-standalone-operator=true
         cat >> "${ironic}" <<EOF
   tls:
     certificateName: ironic-cert


### PR DESCRIPTION
There is no --labels for kubectl create secret. We need to label them separately.