### PR TITLE
Increase DNF retry count for CentOS/RHEL package tasks

### DIFF
--- a/vm-setup/roles/packages_installation/tasks/centos_required_packages.yml
+++ b/vm-setup/roles/packages_installation/tasks/centos_required_packages.yml
@@ -25,7 +25,7 @@
     state: latest
     nobest: true
   become: yes
-  retries: 3
+  retries: 5
   delay: 30
   register: upgrade_result
   until: upgrade_result is succeeded
@@ -35,7 +35,7 @@
     name: podman
     state: present
   become: yes
-  retries: 3
+  retries: 5
   delay: 30
   register: podman_result
   until: podman_result is succeeded

--- a/vm-setup/roles/packages_installation/tasks/main.yml
+++ b/vm-setup/roles/packages_installation/tasks/main.yml
@@ -64,8 +64,8 @@
   - name: Refresh DNF cache
     dnf:
       update_cache: yes
-    retries: 3
-    delay: 10
+    retries: 5
+    delay: 30
     register: cache_result
     until: cache_result is succeeded
 
@@ -74,7 +74,7 @@
       name: "{{ packages.centos.common.packages }}"
       state: present
       nobest: true
-    retries: 3
+    retries: 5
     delay: 30
     register: pkg_result
     until: pkg_result is succeeded


### PR DESCRIPTION
  Increase retries from 3 to 5 and delay from 10s to 30s for the DNF cache refresh task in the packages_installation role. This improves resilience against transient EPEL mirror
  failures.

  The "Refresh DNF cache" task was the weakest link with only 3 retries and 10s delay (30s total max wait). When EPEL mirrors (dl.fedoraproject.org) are unreachable for more than
  30s, the task fails and blocks the entire setup.

  Changes:
  - main.yml: Refresh DNF cache: 3 retries/10s delay -> 5 retries/30s delay
  - main.yml: Install packages: 3 retries/30s delay -> 5 retries/30s delay
  - centos_required_packages.yml: Upgrade all packages: 3 retries/30s delay -> 5 retries/30s delay
  - centos_required_packages.yml: Install podman: 3 retries/30s delay -> 5 retries/30s delay

  The total max wait increases from 30s to 150s for the cache refresh task, which should handle most transient mirror outages without significantly impacting overall setup time.