### PR TITLE
fix: add libvirt-python to ansible venv pip install

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -80,7 +80,7 @@ rm -rf "${ANSIBLE_VENV}"
 sudo python -m venv --system-site-packages "${ANSIBLE_VENV}"
 # TODO: since ansible 8.0.0, pinning by digest is PITA, due additional ansible
 # dependencies, which would need to be pinned as well, so it is skipped for now
-sudo "${ANSIBLE_VENV}/bin/pip" install --ignore-installed ansible=="${ANSIBLE_VERSION}"
+sudo "${ANSIBLE_VENV}/bin/pip" install --ignore-installed ansible=="${ANSIBLE_VERSION}" libvirt-python
 
 # Install requirements
 "${ANSIBLE}-galaxy" install -r vm-setup/requirements.yml


### PR DESCRIPTION
Fixes #1667

## What this PR does
Adds `libvirt-python` to the pip install step in `01_prepare_host.sh`
so it is installed in the Ansible venv alongside ansible.

## Why
The `vm-setup/setup-playbook.yml` uses the `community.libvirt` Ansible
module to create and manage KVM virtual machines. This module requires
the `libvirt` Python package to be importable in the same Python
environment that Ansible is running in.

Without this fix, the venv contains ansible but not libvirt-python,
causing the VM creation step to fail with:

"The `libvirt` module is not importable. Check the requirements."

This causes node_0 and node_1 to never be created, leaving Ironic
stuck waiting for bare metal nodes that don't exist.

## Change

Before:
sudo "${ANSIBLE_VENV}/bin/pip" install --ignore-installed ansible=="${ANSIBLE_VERSION}"

After:
sudo "${ANSIBLE_VENV}/bin/pip" install --ignore-installed ansible=="${ANSIBLE_VERSION}" libvirt-python

## Environment tested
- Host OS: Ubuntu 22.04 LTS
- Platform: GCP n2-standard-8 with nested virtualization
- metal3-dev-env: main branch

## Workaround (no longer needed with this fix)
/opt/metal3-dev-env/venv/bin/pip install libvirt-python