### PR TITLE
Change main branch templates to CAPM3 v1beta2 fields

### DIFF
--- a/tests/roles/run_tests/templates/main/cluster-template-cluster.yaml
+++ b/tests/roles/run_tests/templates/main/cluster-template-cluster.yaml
@@ -27,7 +27,7 @@ spec:
   controlPlaneEndpoint:
     host: ${ CLUSTER_APIENDPOINT_HOST }
     port: ${ CLUSTER_APIENDPOINT_PORT }
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: ipam.metal3.io/v1alpha1
 kind: IPPool

--- a/tests/roles/run_tests/templates/main/metal3datatemplate-template.yaml
+++ b/tests/roles/run_tests/templates/main/metal3datatemplate-template.yaml
@@ -13,12 +13,12 @@ spec:
         object: machine
       - key: local_hostname
         object: machine
-    ipAddressesFromIPPool:
+    ipAddressesFromPool:
       - key: provisioningIP
         name: provisioning-pool
         apiGroup: ""
         kind: ""
-    prefixesFromIPPool:
+    prefixesFromPool:
       - key: provisioningCIDR
         name: provisioning-pool
         apiGroup: ""


### PR DESCRIPTION
In v1beta2:
- noCloudProvider removed and cloudProviderEnabled field
added
- ipAddressesFromIPPool changed ipAddressesFromPool
- prefixesFromIPPool changed prefixesFromPool