### PR TITLE
fix: remove conflicting Docker apt source files before adding repo

### DIFF
--- a/vm-setup/roles/packages_installation/tasks/ubuntu_required_packages.yml
+++ b/vm-setup/roles/packages_installation/tasks/ubuntu_required_packages.yml
@@ -93,9 +93,10 @@
         mode: '0644'
         force: true
 
-    - name: Dearmor GPG key
-      shell: |
-        cat /etc/apt/keyrings/docker.asc | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg --yes
+    - name: Remove legacy Docker apt source file
+      file:
+        path: /etc/apt/sources.list.d/docker.list
+        state: absent
 
     # TODO: (Sunnatillo) Remove this task after fully removing apt-key
     - name: Remove Docker old repository (without gpg key file location)
@@ -110,9 +111,18 @@
         state: absent
 
     - name: Add Docker Repository
-      apt_repository:
-        repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
-        state: present
+      copy:
+        dest: /etc/apt/sources.list.d/docker.sources
+        owner: root
+        group: root
+        mode: '0644'
+        content: |
+          Types: deb
+          URIs: https://download.docker.com/linux/ubuntu
+          Suites: {{ ansible_distribution_release }}
+          Components: stable
+          Architectures: amd64
+          Signed-By: /etc/apt/keyrings/docker.asc
 
     - name: Update all packages to their latest version
       apt:


### PR DESCRIPTION
When Docker is pre-installed via the official Docker docs, it creates
/etc/apt/sources.list.d/docker.list with Signed-By pointing to docker.asc.
Metal3-dev-env previously used apt_repository with docker.gpg, causing:

  E:Conflicting values set for option Signed-By regarding source
  https://download.docker.com/linux/ubuntu/:
  /etc/apt/keyrings/docker.asc != /etc/apt/keyrings/docker.gpg

Fix by aligning with the official Docker docs:
- Switch to DEB822 format, writing directly to docker.sources
- Use docker.asc directly in Signed-By — no dearmor step needed
- Remove legacy docker.list if present to clean up old-format installs

Fixes #1367