### PR TITLE
Increase Minikube defaults to 4 CPUs and 6Gi memory

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -81,7 +81,8 @@ fi
 configure_minikube()
 {
     minikube config set driver kvm2
-    minikube config set memory 4096
+    minikube config set cpus 4
+    minikube config set memory 6144
 }
 
 #


### PR DESCRIPTION
Recently few runs showed symptomps that etcd got choked with resource constraints, bumping the resources for minikube a bit further.