### PR TITLE
Fix CPU model for native aarch64 KVM hosts

### DIFF
--- a/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
+++ b/vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
@@ -45,14 +45,15 @@
     <pae/>
 {% endif %}
   </features>
-{% if is_aarch64 %}
+{% if is_aarch64 and libvirt_domain_type == 'qemu' %}
   <!--
-       On aarch64 we use a fixed/custom CPU model (typically "cortex-a57",
-       configured via libvirt_aarch64_cpu_model) instead of host-model or
-       host-passthrough. This avoids inconsistencies in how libvirt exposes
-       host CPUs on ARM platforms and provides a stable, migration-friendly
-       CPU feature set to guests. The x86_64 path below can safely use
-       host-model/host-passthrough on common hypervisors.
+       On aarch64 under QEMU emulation (cross-arch from an x86_64 host) we
+       use a fixed/custom CPU model (typically "cortex-a57", configured via
+       libvirt_aarch64_cpu_model) instead of host-model or host-passthrough.
+       This avoids inconsistencies in how libvirt exposes host CPUs on ARM
+       platforms and provides a stable, migration-friendly CPU feature set
+       to guests. Native aarch64 KVM hosts fall through to host-passthrough
+       below.
   -->
   <cpu mode='custom' match='exact' check='none'>
     <model fallback='forbid'>{{ libvirt_aarch64_cpu_model }}</model>


### PR DESCRIPTION
## Summary

The `baremetalvm.xml.j2` template unconditionally uses a custom CPU model
(cortex-a57) for all aarch64 VMs. This only works under QEMU emulation
(cross-arch from x86_64 host). Native aarch64 KVM hosts — such as AWS
Graviton bare metal — require `host-passthrough` to expose the real CPU
features to guests.

## Changes

- `vm-setup/roles/libvirt/templates/baremetalvm.xml.j2`: Narrow the CPU
  model conditional from `{% if is_aarch64 %}` to
  `{% if is_aarch64 and libvirt_domain_type == 'qemu' %}` so native KVM
  falls through to `host-passthrough`

The `<os>`, `<features>`, and VNC sections remain gated on `is_aarch64`
alone (unchanged) — those are architecture-specific regardless of
emulation vs native KVM.

## Context

Discovered while enabling `openshift-metal3/dev-scripts` on AWS Graviton
bare metal (native aarch64 KVM). With cortex-a57, VMs fail to boot under
KVM. Related: [openshift-metal3/dev-scripts#1908](https://github.com/openshift-metal3/dev-scripts/pull/1908).

## Test plan

- [x] Full OCP 4.22 fencing-IPI deployment on AWS c7g.metal (Graviton3,
  native aarch64 KVM) — 2m+1a arbiter cluster, 50m41s, 35/35 COs Available
- [x] No change for cross-arch use case — `libvirt_domain_type` is `qemu`
  when architectures differ, so cortex-a57 is still used for x86→aarch64

🤖 Generated with [Claude Code](https://claude.com/claude-code)