### PR TITLE
Fix leap keepalived interface in template

### DIFF
--- a/tests/roles/run_tests/templates/main/cluster-template-controlplane-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/main/cluster-template-controlplane-kubeadm-config-leap.yaml
@@ -63,7 +63,7 @@ files:
 
     vrrp_instance VI_1 {
         state MASTER
-        interface {% if EXTERNAL_VLAN_ID == "" %}eth1{% else %}eth0.{{ EXTERNAL_VLAN_ID }}{% endif %}
+        interface {% if EXTERNAL_VLAN_ID == "" %}{{ bmh_nic_names[1] }}{% else %}{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}{% endif %}
 
         virtual_router_id 1
         priority 101

--- a/tests/roles/run_tests/templates/release-1.11/cluster-template-controlplane-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/release-1.11/cluster-template-controlplane-kubeadm-config-leap.yaml
@@ -63,7 +63,7 @@ files:
 
     vrrp_instance VI_1 {
         state MASTER
-        interface {% if EXTERNAL_VLAN_ID == "" %}eth1{% else %}eth0.{{ EXTERNAL_VLAN_ID }}{% endif %}
+        interface {% if EXTERNAL_VLAN_ID == "" %}{{ bmh_nic_names[1] }}{% else %}{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}{% endif %}
 
         virtual_router_id 1
         priority 101

--- a/tests/roles/run_tests/templates/release-1.12/cluster-template-controlplane-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/release-1.12/cluster-template-controlplane-kubeadm-config-leap.yaml
@@ -63,7 +63,7 @@ files:
 
     vrrp_instance VI_1 {
         state MASTER
-        interface {% if EXTERNAL_VLAN_ID == "" %}eth1{% else %}eth0.{{ EXTERNAL_VLAN_ID }}{% endif %}
+        interface {% if EXTERNAL_VLAN_ID == "" %}{{ bmh_nic_names[1] }}{% else %}{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}{% endif %}
 
         virtual_router_id 1
         priority 101

--- a/tests/roles/run_tests/templates/release-1.13/cluster-template-controlplane-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/release-1.13/cluster-template-controlplane-kubeadm-config-leap.yaml
@@ -63,7 +63,7 @@ files:
 
     vrrp_instance VI_1 {
         state MASTER
-        interface {% if EXTERNAL_VLAN_ID == "" %}eth1{% else %}eth0.{{ EXTERNAL_VLAN_ID }}{% endif %}
+        interface {% if EXTERNAL_VLAN_ID == "" %}{{ bmh_nic_names[1] }}{% else %}{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}{% endif %}
 
         virtual_router_id 1
         priority 101


### PR DESCRIPTION
The leap node image provisioning fails because the keepalived interface is wrong.