### PR TITLE
🌱 Remove MariaDB config

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -405,15 +405,12 @@ clone_repo "${CAPIREPO}" "${CAPIBRANCH}" "${CAPIPATH}" "${CAPICOMMIT}"
 detect_mismatch "${IRSO_LOCAL_IMAGE:-}" "${IRSOPATH}"
 clone_repo "${IRSOREPO}" "${IRSOBRANCH}" "${IRSOPATH}" "${IRSOCOMMIT}"
 
-# MariaDB and Ironic source is not needed unless the images are built locally
+# Ironic source is not needed unless the images are built locally
 # If the repo path does not match with the IMAGE location that means the image
 # is built from a repo that is not under dev-env's control thus there is no
 # need to clone the repo.
 # There is no need to keep the PATH and the IMAGE vars in sync as there
 # is no other use of the path variable than cloning
-if [[ "${MARIADB_LOCAL_IMAGE:-}" == "${MARIADB_IMAGE_PATH}" ]]; then
-    clone_repo "${MARIADB_IMAGE_REPO}" "${MARIADB_IMAGE_BRANCH}" "${MARIADB_IMAGE_PATH}" "${MARIADB_IMAGE_COMMIT}"
-fi
 
 if [[ "${IRONIC_LOCAL_IMAGE:-}" == "${IRONIC_IMAGE_PATH}" ]]; then
     clone_repo "${IRONIC_IMAGE_REPO}" "${IRONIC_IMAGE_BRANCH}" "${IRONIC_IMAGE_PATH}" "${IRONIC_IMAGE_COMMIT}"

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -211,12 +211,6 @@ EOF
         update_component_image Ironic "${IRONIC_IMAGE}"
     fi
 
-    if [[ -n "${MARIADB_LOCAL_IMAGE:-}" ]]; then
-        update_component_image Mariadb "${MARIADB_LOCAL_IMAGE}"
-    else
-        update_component_image Mariadb "${MARIADB_IMAGE}"
-    fi
-
     if [[ -n "${IRONIC_KEEPALIVED_LOCAL_IMAGE:-}" ]]; then
         update_component_image Keepalived "${IRONIC_KEEPALIVED_LOCAL_IMAGE}"
     else
@@ -486,9 +480,6 @@ update_component_image()
             ;;
         "Ironic")
             make set-manifest-image-ironic
-            ;;
-        "Mariadb")
-            make set-manifest-image-mariadb
             ;;
         "Keepalived")
             make set-manifest-image-keepalived

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -45,8 +45,6 @@ export CI_CONFIG_FILE="${TMP_DIR:-/tmp}/config_ci.sh"
 
 # Set variables
 export BOOT_MODE="${BOOT_MODE:-UEFI}"
-export MARIADB_HOST="mariaDB"
-export MARIADB_HOST_IP="127.0.0.1"
 # Additional DNS
 ADDN_DNS="${ADDN_DNS:-}"
 # External interface for routing traffic through the host
@@ -225,17 +223,11 @@ export IRONIC_IMAGE_REPO="${IRONIC_IMAGE_REPO:-https://github.com/metal3-io/iron
 export IRONIC_IMAGE_BRANCH="${IRONIC_IMAGE_BRANCH:-main}"
 export IRONIC_IMAGE_COMMIT="${IRONIC_IMAGE_COMMIT:-HEAD}"
 
-export MARIADB_IMAGE_PATH="${MARIADB_IMAGE_PATH:-/tmp/mariadb-image}"
-export MARIADB_IMAGE_REPO="${MARIADB_IMAGE_REPO:-https://github.com/metal3-io/mariadb-image.git}"
-export MARIADB_IMAGE_BRANCH="${MARIADB_IMAGE_BRANCH:-main}"
-export MARIADB_IMAGE_COMMIT="${MARIADB_IMAGE_COMMIT:-HEAD}"
-
 export BUILD_CAPM3_LOCALLY="${BUILD_CAPM3_LOCALLY:-false}"
 export BUILD_IPAM_LOCALLY="${BUILD_IPAM_LOCALLY:-false}"
 export BUILD_BMO_LOCALLY="${BUILD_BMO_LOCALLY:-false}"
 export BUILD_CAPI_LOCALLY="${BUILD_CAPI_LOCALLY:-false}"
 export BUILD_IRONIC_IMAGE_LOCALLY="${BUILD_IRONIC_IMAGE_LOCALLY:-false}"
-export BUILD_MARIADB_IMAGE_LOCALLY="${BUILD_MARIADB_IMAGE_LOCALLY:-false}"
 export BUILD_IRSO_LOCALLY="${BUILD_IRSO_LOCALLY:-false}"
 
 # If IRONIC_FROM_SOURCE has a "true" value that
@@ -260,9 +252,6 @@ if [[ "${BUILD_CAPI_LOCALLY}" == "true" ]]; then
 fi
 if [[ "${BUILD_IRONIC_IMAGE_LOCALLY}" == "true" ]]; then
   export IRONIC_LOCAL_IMAGE="${IRONIC_LOCAL_IMAGE:-${IRONIC_IMAGE_PATH}}"
-fi
-if [[ "${BUILD_MARIADB_IMAGE_LOCALLY}" == "true" ]]; then
-  export MARIADB_LOCAL_IMAGE="${MARIADB_IMAGE_PATH}"
 fi
 if [[ "${BUILD_IRSO_LOCALLY}" == "true" ]]; then
   export IRSO_LOCAL_IMAGE="${IRSOPATH}"
@@ -291,7 +280,6 @@ export MAX_SURGE_VALUE="${MAX_SURGE_VALUE:-1}"
 export IRONIC_TAG="${IRONIC_TAG:-latest}"
 export BARE_METAL_OPERATOR_TAG="${BARE_METAL_OPERATOR_TAG:-latest}"
 export KEEPALIVED_TAG="${KEEPALIVED_TAG:-latest}"
-export MARIADB_TAG="${MARIADB_TAG:-latest}"
 export IRSO_TAG="${IRSO_TAG:-latest}"
 export IRSO_IRONIC_VERSION="${IRSO_IRONIC_VERSION:-latest}"
 
@@ -372,8 +360,6 @@ export IPXE_ENABLE_IPV6="${IPXE_ENABLE_IPV6:-false}"
 export IPXE_RELEASE_BRANCH="${IPXE_RELEASE_BRANCH:-v1.21.1}"
 export IPXE_SOURCE_FORCE_UPDATE="${IPXE_SOURCE_FORCE_UPDATE:-false}"
 export IPXE_SOURCE_DIR="${IRONIC_DATA_DIR}/ipxe-source"
-
-export MARIADB_IMAGE="${MARIADB_IMAGE:-${CONTAINER_REGISTRY}/metal3-io/mariadb:${MARIADB_TAG}}"
 
 # Enable ironic restart feature when the TLS certificate is updated
 export RESTART_CONTAINER_CERTIFICATE_UPDATED="${RESTART_CONTAINER_CERTIFICATE_UPDATED:-${IRONIC_TLS_SETUP}}"

--- a/lib/ironic_tls_setup.sh
+++ b/lib/ironic_tls_setup.sh
@@ -18,11 +18,6 @@ if [[ "${IRONIC_TLS_SETUP,,}" == "true" ]]; then
     export IRONIC_INSPECTOR_CERT_FILE="${IRONIC_INSPECTOR_CERT_FILE:-"${WORKING_DIR}/certs/ironic-inspector.crt"}"
     export IRONIC_INSPECTOR_KEY_FILE="${IRONIC_INSPECTOR_KEY_FILE:-"${WORKING_DIR}/certs/ironic-inspector.key"}"
 
-    export MARIADB_CACERT_FILE="${MARIADB_CACERT_FILE:-"${WORKING_DIR}/certs/ironic-ca.pem"}"
-    export MARIADB_CAKEY_FILE="${IRONIC_CAKEY_FILE:-"${WORKING_DIR}/certs/ironic-ca.key"}"
-    export MARIADB_CERT_FILE="${MARIADB_CERT_FILE:-"${WORKING_DIR}/certs/mariadb.crt"}"
-    export MARIADB_KEY_FILE="${MARIADB_KEY_FILE:-"${WORKING_DIR}/certs/mariadb.key"}"
-
     # BMO run-local scripts automatically enables iPXE TLS if the certs are
     # present (BMO tooling does this with all certs) and iPXE TLS require
     # custom firmware building in dev-env thus this condition syncs
@@ -46,9 +41,6 @@ if [[ "${IRONIC_TLS_SETUP,,}" == "true" ]]; then
     if [[ ! -r "${IRONIC_INSPECTOR_CAKEY_FILE}" ]]; then
         openssl genrsa -out "${IRONIC_INSPECTOR_CAKEY_FILE}" 2048
     fi
-    if [[ ! -r "${MARIADB_CAKEY_FILE}" ]]; then
-        openssl genrsa -out "${MARIADB_CAKEY_FILE}" 2048
-    fi
     if [[ ! -r "${IPXE_CAKEY_FILE}" ]]  && [[ "${GENERATE_IPXE_CERTS}" == "true" ]]; then
         openssl genrsa -out "${IPXE_CAKEY_FILE}" 2048
     fi
@@ -60,9 +52,6 @@ if [[ "${IRONIC_TLS_SETUP,,}" == "true" ]]; then
     if [[ ! -r "${IRONIC_INSPECTOR_CACERT_FILE}" ]]; then
         openssl req -x509 -new -nodes -key "${IRONIC_INSPECTOR_CAKEY_FILE}" -sha256 -days 1825 -out "${IRONIC_INSPECTOR_CACERT_FILE}" -subj /CN="ironic inspector CA"/
     fi
-    if [[ ! -r "${MARIADB_CACERT_FILE}" ]]; then
-        openssl req -x509 -new -nodes -key "${MARIADB_CAKEY_FILE}" -sha256 -days 1825 -out "${MARIADB_CACERT_FILE}" -subj /CN="mariadb CA"/
-    fi
     if [[ ! -r "${IPXE_CACERT_FILE}" ]] && [[ "${GENERATE_IPXE_CERTS}" == "true" ]]; then
         openssl req -x509 -new -nodes -key "${IPXE_CAKEY_FILE}" -sha256 -days 1825 -out "${IPXE_CACERT_FILE}" -subj /CN="ipxe CA"/
     fi
@@ -73,9 +62,6 @@ if [[ "${IRONIC_TLS_SETUP,,}" == "true" ]]; then
     fi
     if [[ ! -r "${IRONIC_INSPECTOR_KEY_FILE}" ]]; then
         openssl genrsa -out "${IRONIC_INSPECTOR_KEY_FILE}" 2048
-    fi
-    if [[ ! -r "${MARIADB_KEY_FILE}" ]]; then
-        openssl genrsa -out "${MARIADB_KEY_FILE}" 2048
     fi
     if [[ ! -r "${IPXE_KEY_FILE}" ]] && [[ "${GENERATE_IPXE_CERTS}" == "true" ]]; then
         openssl genrsa -out "${IPXE_KEY_FILE}" 2048
@@ -89,11 +75,6 @@ if [[ "${IRONIC_TLS_SETUP,,}" == "true" ]]; then
     if [[ ! -r "${IRONIC_INSPECTOR_CERT_FILE}" ]]; then
         openssl req -new -key "${IRONIC_INSPECTOR_KEY_FILE}" -out /tmp/ironic.csr -subj /CN="${IRONIC_HOST}"/
         openssl x509 -req -in /tmp/ironic.csr -CA "${IRONIC_INSPECTOR_CACERT_FILE}" -CAkey "${IRONIC_INSPECTOR_CAKEY_FILE}" -CAcreateserial -out "${IRONIC_INSPECTOR_CERT_FILE}" -days 825 -sha256 -extfile <(printf "subjectAltName=IP:%s" "${IRONIC_HOST_IP}")
-    fi
-
-    if [[ ! -r "${MARIADB_CERT_FILE}" ]]; then
-        openssl req -new -key "${MARIADB_KEY_FILE}" -out /tmp/mariadb.csr -subj /CN="${MARIADB_HOST}"/
-        openssl x509 -req -in /tmp/mariadb.csr -CA "${MARIADB_CACERT_FILE}" -CAkey "${MARIADB_CAKEY_FILE}" -CAcreateserial -out "${MARIADB_CERT_FILE}" -days 825 -sha256 -extfile <(printf "subjectAltName=IP:%s" "${MARIADB_HOST_IP}")
     fi
     if [[ ! -r "${IPXE_CERT_FILE}" ]] && [[ "${GENERATE_IPXE_CERTS}" == "true" ]]; then
         openssl req -new -key "${IPXE_KEY_FILE}" -out /tmp/ipxe.csr -subj /CN="${IRONIC_HOST}"/
@@ -123,9 +104,6 @@ else
     unset IRONIC_INSPECTOR_CACERT_FILE
     unset IRONIC_INSPECTOR_CERT_FILE
     unset IRONIC_INSPECTOR_KEY_FILE
-    unset MARIADB_CACERT_FILE
-    unset MARIADB_CERT_FILE
-    unset MARIADB_KEY_FILE
     unset IPXE_CACERT_FILE
     unset IPXE_CERT_FILE
     unset IPXE_KEY_FILE

--- a/vars.md
+++ b/vars.md
@@ -94,10 +94,6 @@ assured that they are persisted.
 | IRONIC_API_PORT | Ironic Api port | | 6385 |
 | RESTART_CONTAINER_CERTIFICATE_UPDATED | Enable the ironic restart feature when TLS certificates are updated | "true", "false" | "true" |
 | NODE_DRAIN_TIMEOUT | Set the nodeDrainTimeoutSeconds for controlplane and worker template | | '0' |
-| MARIADB_KEY_FILE | Path to the key of MariaDB | | /opt/metal3-dev-env/certs/mariadb.key |
-| MARIADB_CERT_FILE | Path to the cert of MariaDB | | /opt/metal3-dev-env/certs/mariadb.crt |
-| MARIADB_CAKEY_FILE | Path to the CA key of MariaDB | | /opt/metal3-dev-env/certs/ironic-ca.key |
-| MARIADB_CACERT_FILE | Path to the CA certificate of MariaDB | | /opt/metal3-dev-env/certs/ironic-ca.pem |
 | M3PATH | Path to clone the Metal3 Development Environment repository | | $HOME/go/src/github.com/metal3-io |
 | BMOPATH | Path to clone the Bare Metal Operator repository | | $HOME/go/src/github.com/metal3-io/baremetal-operator |
 | CAPM3PATH | Path to clone the Cluster API Provider Metal3 repository | | $HOME/go/src/github.com/metal3-io/cluster-api-provider-metal3 |
@@ -119,17 +115,12 @@ assured that they are persisted.
 | IRONIC_IMAGE_REPO | Metal3's ironic-image Git repository address | | https://github.com/metal3-io/ironic-image.git |
 | IRONIC_IMAGE_BRANCH | Metal3's ironic-image Git repository branch | | main |
 | IRONIC_IMAGE_COMMIT | Metal3's ironic-image | | HEAD |
-| MARIADB_IMAGE_PATH | Path to clone the mariadb-image Git repository to | | /tmp/mariadb-image  |
-| MARIADB_IMAGE_REPO | mariadb-image Git repository address | | https://github.com/metal3-io/mariadb-image.git |
-| MARIADB_IMAGE_BRANCH | mariadb-mage branch to checkout | | main |
-| MARIADB_IMAGE_COMMIT | mariadb-image commit to checkout | | HEAD |
 | FORCE_REPO_UPDATE | discard existing directories | "true","false" | "true" |
 | BUILD_CAPM3_LOCALLY | build Cluster API Provider Metal3 based on CAPM3PATH | "true","false" | "false" |
 | BUILD_IPAM_LOCALLY | build IP Address Manager based on IPAMPATH | "true","false" | "false" |
 | BUILD_BMO_LOCALLY | build Baremetal Operator based on BMOPATH | "true","false" | "false" |
 | BUILD_CAPI_LOCALLY | build Cluster API based on CAPIPATH | "true","false" | "false" |
 | BUILD_IRONIC_IMAGE_LOCALLY | build the Metal3's ironic-image based on IRONIC_IMAGE_PATH | "true","false" | "false" |
-| BUILD_MARIADB_IMAGE_LOCALLY | build the MariaDB container image based on MARIADB_IMAGE_PATH | "true", "false" | "false" |
 | IRONIC_FROM_SOURCE | installs ironic from source during container image building, if `true` then the `BUILD_IRONIC_IMAGE_LOCALLY` will be also set to `true` | "true","false" | "false" |
 | IRONIC_SOURCE | absolute path of the ironic source code used to build the ironic services in the ironic container image | | |
 | IRONIC_INSPECTOR_SOURCE | absolute path of the ironic-inspector source code used to build the ironic-inspector services in the ironic container image | | |


### PR DESCRIPTION
Remove deprecated MariaDB env variables, local image-build support, and TLS setup:
- MARIADB_HOST and MARIADB_HOST_IP exports
- MARIADB_IMAGE, MARIA_TAG, MARIADB_LOCAL_IMAGE, MARIADB_IMAGE_* variables
- BUILD_MARIADB_IMAGE_LOCALLY and MariaDB image clone/build handling.
- MariaDB TLS certificate generation
- MariaDB documentation entries

The IRONIC_USE_MARIADB runtime toggle is remove separately in a follow PR. 