### PR TITLE
WIP: Make dev-env accept both root and non-root

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -144,6 +144,22 @@ if ! sudo test -f /root/.ssh/id_rsa_virt_power; then
     sudo cat /root/.ssh/id_rsa_virt_power.pub | sudo tee -a /root/.ssh/authorized_keys
 fi
 
+# Auto-detect sushy-tools container config directory based on image user
+_sushy_image="${SUSHY_TOOLS_LOCAL_IMAGE:-${SUSHY_TOOLS_IMAGE}}"
+image_user="$(sudo "${CONTAINER_RUNTIME}" inspect "${_sushy_image}" \
+    --format '{{.Config.User}}' 2>/dev/null || true)"
+SUSHY_TOOLS_EXTRA_OPTS=""
+case "${image_user}" in
+    ""|0|0:0|root|root:root)
+        : "${SUSHY_TOOLS_CONF_DIR:=/root/sushy}"
+        ;;
+    *)
+        : "${SUSHY_TOOLS_CONF_DIR:=/conf/sushy}"
+        SUSHY_TOOLS_EXTRA_OPTS="--group-add 0"
+        ;;
+esac
+export SUSHY_TOOLS_CONF_DIR
+
 ANSIBLE_FORCE_COLOR=true "${ANSIBLE}-playbook" \
     -e "working_dir=${WORKING_DIR}" \
     -e "num_nodes=${NUM_NODES}" \
@@ -544,7 +560,9 @@ sudo "${CONTAINER_RUNTIME}" run -d --net host --name vbmc ${POD_NAME_INFRA} \
 
 # shellcheck disable=SC2086
 sudo "${CONTAINER_RUNTIME}" run -d --net host --name sushy-tools ${POD_NAME_INFRA} \
-    -v "${WORKING_DIR}/virtualbmc/sushy-tools":/root/sushy -v "/root/.ssh":/root/ssh \
+    ${SUSHY_TOOLS_EXTRA_OPTS} \
+    -v "${WORKING_DIR}/virtualbmc/sushy-tools":"${SUSHY_TOOLS_CONF_DIR}" \
+    -v "/root/.ssh":/root/ssh \
     -v /var/run/libvirt:/var/run/libvirt \
     "${SUSHY_TOOLS_IMAGE}"
 

--- a/tests/roles/run_tests/templates/main/cluster-template-controlplane-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/main/cluster-template-controlplane-kubeadm-config-leap.yaml
@@ -6,8 +6,8 @@ preKubeadmCommands:
 - systemctl restart NetworkManager.service
 - nmcli connection load /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
 - nmcli connection up {{ IRONIC_ENDPOINT_BRIDGE }}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
-- nmcli connection up {{ bmh_nic_names[0] }}
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+- nmcli connection up eth0
 {% if VM_EXTRADISKS == "true" %}
 - (echo n; echo p; echo 1; echo  ;echo  ;echo w) | fdisk /dev/vda
 - mkfs.{{ VM_EXTRADISKS_FILE_SYSTEM }} /dev/vda1
@@ -15,8 +15,8 @@ preKubeadmCommands:
 - mount /dev/vda1 {{ VM_EXTRADISKS_MOUNT_DIR }}
 {% endif %}
 {% if EXTERNAL_VLAN_ID != "" %}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
-- nmcli connection up /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
 {% endif %}
 - rm /etc/cni/net.d/*
 - systemctl enable --now keepalived
@@ -75,14 +75,14 @@ files:
             k8s_api_check
         }
     }
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id={{ bmh_nic_names[0] }}
+    id=eth0
     type=ethernet
-    interface-name={{ bmh_nic_names[0] }}
+    interface-name=eth0
     master={{ IRONIC_ENDPOINT_BRIDGE }}
     slave-type=bridge
 - path: /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
@@ -112,20 +112,20 @@ files:
     [registries.insecure]
     registries = ['{{ REGISTRY }}']
 {% if EXTERNAL_VLAN_ID != "" %}
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id=Vlan {{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    id=Vlan eth0.{{ EXTERNAL_VLAN_ID }}
     type=vlan
     autoconnect-priority=999
-    interface-name={{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    interface-name=eth0.{{ EXTERNAL_VLAN_ID }}
 
     [vlan]
     flags=1
-    id={{ EXTERNAL_VLAN_ID }}
-    parent={{ bmh_nic_names[0] }}
+    id=3
+    parent=eth0
 
     [ipv4]
     method=auto

--- a/tests/roles/run_tests/templates/main/cluster-template-workers-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/main/cluster-template-workers-kubeadm-config-leap.yaml
@@ -8,11 +8,11 @@ preKubeadmCommands:
 - systemctl restart NetworkManager.service
 - nmcli connection load /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
 - nmcli connection up {{ IRONIC_ENDPOINT_BRIDGE }}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
-- nmcli connection up {{ bmh_nic_names[0] }}
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+- nmcli connection up eth0
 {% if EXTERNAL_VLAN_ID != "" %}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
-- nmcli connection up /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
 {% endif %}
 - systemctl enable --now crio
 - sleep 30
@@ -37,14 +37,14 @@ files:
       else
         cat "$tmpfile"| sed '$d' > "$dst";
       fi
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id={{ bmh_nic_names[0] }}
+    id=eth0
     type=ethernet
-    interface-name={{ bmh_nic_names[0] }}
+    interface-name=eth0
     master={{ IRONIC_ENDPOINT_BRIDGE }}
     slave-type=bridge
     autoconnect=yes
@@ -78,20 +78,20 @@ files:
     [registries.insecure]
     registries = ['{{ REGISTRY }}']
 {% if EXTERNAL_VLAN_ID != "" %}
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id=Vlan {{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    id=Vlan eth0.{{ EXTERNAL_VLAN_ID }}
     type=vlan
     autoconnect-priority=999
-    interface-name={{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    interface-name=eth0.{{ EXTERNAL_VLAN_ID }}
 
     [vlan]
     flags=1
-    id={{ EXTERNAL_VLAN_ID }}
-    parent={{ bmh_nic_names[0] }}
+    id=3
+    parent=eth0
 
     [ipv4]
     method=auto

--- a/tests/roles/run_tests/templates/release-1.11/cluster-template-controlplane-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/release-1.11/cluster-template-controlplane-kubeadm-config-leap.yaml
@@ -6,8 +6,8 @@ preKubeadmCommands:
 - systemctl restart NetworkManager.service
 - nmcli connection load /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
 - nmcli connection up {{ IRONIC_ENDPOINT_BRIDGE }}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
-- nmcli connection up {{ bmh_nic_names[0] }}
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+- nmcli connection up eth0
 {% if VM_EXTRADISKS == "true" %}
 - (echo n; echo p; echo 1; echo  ;echo  ;echo w) | fdisk /dev/vda
 - mkfs.{{ VM_EXTRADISKS_FILE_SYSTEM }} /dev/vda1
@@ -15,8 +15,8 @@ preKubeadmCommands:
 - mount /dev/vda1 {{ VM_EXTRADISKS_MOUNT_DIR }}
 {% endif %}
 {% if EXTERNAL_VLAN_ID != "" %}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
-- nmcli connection up /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
 {% endif %}
 - rm /etc/cni/net.d/*
 - systemctl enable --now keepalived
@@ -75,14 +75,14 @@ files:
             k8s_api_check
         }
     }
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id={{ bmh_nic_names[0] }}
+    id=eth0
     type=ethernet
-    interface-name={{ bmh_nic_names[0] }}
+    interface-name=eth0
     master={{ IRONIC_ENDPOINT_BRIDGE }}
     slave-type=bridge
 - path: /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
@@ -112,20 +112,20 @@ files:
     [registries.insecure]
     registries = ['{{ REGISTRY }}']
 {% if EXTERNAL_VLAN_ID != "" %}
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id=Vlan {{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    id=Vlan eth0.{{ EXTERNAL_VLAN_ID }}
     type=vlan
     autoconnect-priority=999
-    interface-name={{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    interface-name=eth0.{{ EXTERNAL_VLAN_ID }}
 
     [vlan]
     flags=1
-    id={{ EXTERNAL_VLAN_ID }}
-    parent={{ bmh_nic_names[0] }}
+    id=3
+    parent=eth0
 
     [ipv4]
     method=auto

--- a/tests/roles/run_tests/templates/release-1.11/cluster-template-workers-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/release-1.11/cluster-template-workers-kubeadm-config-leap.yaml
@@ -8,11 +8,11 @@ preKubeadmCommands:
 - systemctl restart NetworkManager.service
 - nmcli connection load /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
 - nmcli connection up {{ IRONIC_ENDPOINT_BRIDGE }}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
-- nmcli connection up {{ bmh_nic_names[0] }}
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+- nmcli connection up eth0
 {% if EXTERNAL_VLAN_ID != "" %}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
-- nmcli connection up /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
 {% endif %}
 - systemctl enable --now crio
 - sleep 30
@@ -37,14 +37,14 @@ files:
       else
         cat "$tmpfile"| sed '$d' > "$dst";
       fi
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id={{ bmh_nic_names[0] }}
+    id=eth0
     type=ethernet
-    interface-name={{ bmh_nic_names[0] }}
+    interface-name=eth0
     master={{ IRONIC_ENDPOINT_BRIDGE }}
     slave-type=bridge
     autoconnect=yes
@@ -78,20 +78,20 @@ files:
     [registries.insecure]
     registries = ['{{ REGISTRY }}']
 {% if EXTERNAL_VLAN_ID != "" %}
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id=Vlan {{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    id=Vlan eth0.{{ EXTERNAL_VLAN_ID }}
     type=vlan
     autoconnect-priority=999
-    interface-name={{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    interface-name=eth0.{{ EXTERNAL_VLAN_ID }}
 
     [vlan]
     flags=1
-    id={{ EXTERNAL_VLAN_ID }}
-    parent={{ bmh_nic_names[0] }}
+    id=3
+    parent=eth0
 
     [ipv4]
     method=auto

--- a/tests/roles/run_tests/templates/release-1.12/cluster-template-controlplane-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/release-1.12/cluster-template-controlplane-kubeadm-config-leap.yaml
@@ -6,8 +6,8 @@ preKubeadmCommands:
 - systemctl restart NetworkManager.service
 - nmcli connection load /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
 - nmcli connection up {{ IRONIC_ENDPOINT_BRIDGE }}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
-- nmcli connection up {{ bmh_nic_names[0] }}
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+- nmcli connection up eth0
 {% if VM_EXTRADISKS == "true" %}
 - (echo n; echo p; echo 1; echo  ;echo  ;echo w) | fdisk /dev/vda
 - mkfs.{{ VM_EXTRADISKS_FILE_SYSTEM }} /dev/vda1
@@ -15,8 +15,8 @@ preKubeadmCommands:
 - mount /dev/vda1 {{ VM_EXTRADISKS_MOUNT_DIR }}
 {% endif %}
 {% if EXTERNAL_VLAN_ID != "" %}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
-- nmcli connection up /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
 {% endif %}
 - rm /etc/cni/net.d/*
 - systemctl enable --now keepalived
@@ -75,14 +75,14 @@ files:
             k8s_api_check
         }
     }
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id={{ bmh_nic_names[0] }}
+    id=eth0
     type=ethernet
-    interface-name={{ bmh_nic_names[0] }}
+    interface-name=eth0
     master={{ IRONIC_ENDPOINT_BRIDGE }}
     slave-type=bridge
 - path: /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
@@ -112,20 +112,20 @@ files:
     [registries.insecure]
     registries = ['{{ REGISTRY }}']
 {% if EXTERNAL_VLAN_ID != "" %}
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id=Vlan {{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    id=Vlan eth0.{{ EXTERNAL_VLAN_ID }}
     type=vlan
     autoconnect-priority=999
-    interface-name={{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    interface-name=eth0.{{ EXTERNAL_VLAN_ID }}
 
     [vlan]
     flags=1
-    id={{ EXTERNAL_VLAN_ID }}
-    parent={{ bmh_nic_names[0] }}
+    id=3
+    parent=eth0
 
     [ipv4]
     method=auto

--- a/tests/roles/run_tests/templates/release-1.12/cluster-template-workers-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/release-1.12/cluster-template-workers-kubeadm-config-leap.yaml
@@ -8,11 +8,11 @@ preKubeadmCommands:
 - systemctl restart NetworkManager.service
 - nmcli connection load /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
 - nmcli connection up {{ IRONIC_ENDPOINT_BRIDGE }}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
-- nmcli connection up {{ bmh_nic_names[0] }}
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+- nmcli connection up eth0
 {% if EXTERNAL_VLAN_ID != "" %}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
-- nmcli connection up /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
 {% endif %}
 - systemctl enable --now crio
 - sleep 30
@@ -37,14 +37,14 @@ files:
       else
         cat "$tmpfile"| sed '$d' > "$dst";
       fi
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id={{ bmh_nic_names[0] }}
+    id=eth0
     type=ethernet
-    interface-name={{ bmh_nic_names[0] }}
+    interface-name=eth0
     master={{ IRONIC_ENDPOINT_BRIDGE }}
     slave-type=bridge
     autoconnect=yes
@@ -78,20 +78,20 @@ files:
     [registries.insecure]
     registries = ['{{ REGISTRY }}']
 {% if EXTERNAL_VLAN_ID != "" %}
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id=Vlan {{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    id=Vlan eth0.{{ EXTERNAL_VLAN_ID }}
     type=vlan
     autoconnect-priority=999
-    interface-name={{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    interface-name=eth0.{{ EXTERNAL_VLAN_ID }}
 
     [vlan]
     flags=1
-    id={{ EXTERNAL_VLAN_ID }}
-    parent={{ bmh_nic_names[0] }}
+    id=3
+    parent=eth0
 
     [ipv4]
     method=auto

--- a/tests/roles/run_tests/templates/release-1.13/cluster-template-controlplane-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/release-1.13/cluster-template-controlplane-kubeadm-config-leap.yaml
@@ -6,8 +6,8 @@ preKubeadmCommands:
 - systemctl restart NetworkManager.service
 - nmcli connection load /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
 - nmcli connection up {{ IRONIC_ENDPOINT_BRIDGE }}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
-- nmcli connection up {{ bmh_nic_names[0] }}
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+- nmcli connection up eth0
 {% if VM_EXTRADISKS == "true" %}
 - (echo n; echo p; echo 1; echo  ;echo  ;echo w) | fdisk /dev/vda
 - mkfs.{{ VM_EXTRADISKS_FILE_SYSTEM }} /dev/vda1
@@ -15,8 +15,8 @@ preKubeadmCommands:
 - mount /dev/vda1 {{ VM_EXTRADISKS_MOUNT_DIR }}
 {% endif %}
 {% if EXTERNAL_VLAN_ID != "" %}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
-- nmcli connection up /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
 {% endif %}
 - rm /etc/cni/net.d/*
 - systemctl enable --now keepalived
@@ -75,14 +75,14 @@ files:
             k8s_api_check
         }
     }
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id={{ bmh_nic_names[0] }}
+    id=eth0
     type=ethernet
-    interface-name={{ bmh_nic_names[0] }}
+    interface-name=eth0
     master={{ IRONIC_ENDPOINT_BRIDGE }}
     slave-type=bridge
 - path: /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
@@ -112,20 +112,20 @@ files:
     [registries.insecure]
     registries = ['{{ REGISTRY }}']
 {% if EXTERNAL_VLAN_ID != "" %}
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id=Vlan {{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    id=Vlan eth0.{{ EXTERNAL_VLAN_ID }}
     type=vlan
     autoconnect-priority=999
-    interface-name={{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    interface-name=eth0.{{ EXTERNAL_VLAN_ID }}
 
     [vlan]
     flags=1
-    id={{ EXTERNAL_VLAN_ID }}
-    parent={{ bmh_nic_names[0] }}
+    id=3
+    parent=eth0
 
     [ipv4]
     method=auto

--- a/tests/roles/run_tests/templates/release-1.13/cluster-template-workers-kubeadm-config-leap.yaml
+++ b/tests/roles/run_tests/templates/release-1.13/cluster-template-workers-kubeadm-config-leap.yaml
@@ -8,11 +8,11 @@ preKubeadmCommands:
 - systemctl restart NetworkManager.service
 - nmcli connection load /etc/NetworkManager/system-connections/{{ IRONIC_ENDPOINT_BRIDGE }}.nmconnection
 - nmcli connection up {{ IRONIC_ENDPOINT_BRIDGE }}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
-- nmcli connection up {{ bmh_nic_names[0] }}
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+- nmcli connection up eth0
 {% if EXTERNAL_VLAN_ID != "" %}
-- nmcli connection load /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
-- nmcli connection up /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection load /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- nmcli connection up /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
 {% endif %}
 - systemctl enable --now crio
 - sleep 30
@@ -37,14 +37,14 @@ files:
       else
         cat "$tmpfile"| sed '$d' > "$dst";
       fi
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id={{ bmh_nic_names[0] }}
+    id=eth0
     type=ethernet
-    interface-name={{ bmh_nic_names[0] }}
+    interface-name=eth0
     master={{ IRONIC_ENDPOINT_BRIDGE }}
     slave-type=bridge
     autoconnect=yes
@@ -78,20 +78,20 @@ files:
     [registries.insecure]
     registries = ['{{ REGISTRY }}']
 {% if EXTERNAL_VLAN_ID != "" %}
-- path: /etc/NetworkManager/system-connections/{{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}.nmconnection
+- path: /etc/NetworkManager/system-connections/eth0.{{ EXTERNAL_VLAN_ID }}.nmconnection
   owner: root:root
   permissions: '0600'
   content: |
     [connection]
-    id=Vlan {{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    id=Vlan eth0.{{ EXTERNAL_VLAN_ID }}
     type=vlan
     autoconnect-priority=999
-    interface-name={{ bmh_nic_names[0] }}.{{ EXTERNAL_VLAN_ID }}
+    interface-name=eth0.{{ EXTERNAL_VLAN_ID }}
 
     [vlan]
     flags=1
-    id={{ EXTERNAL_VLAN_ID }}
-    parent={{ bmh_nic_names[0] }}
+    id=3
+    parent=eth0
 
     [ipv4]
     method=auto

--- a/vm-setup/roles/virtbmc/defaults/main.yml
+++ b/vm-setup/roles/virtbmc/defaults/main.yml
@@ -7,3 +7,4 @@ sushy_vmedia_verify_ssl: false
 # BMC credentials
 vbmc_username: "admin"
 vbmc_password: "password"
+sushy_conf_dir: "{{ lookup('env', 'SUSHY_TOOLS_CONF_DIR') | default('/root/sushy', true) }}"

--- a/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
+++ b/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
@@ -53,11 +53,10 @@
     vbmc_address: "{% if vbmc_address_v4|ansible.utils.ipv4 != False %}{{ vbmc_address_v4 }}{% else %}{{ vbmc_address_v6 }}{% endif %}"
 
 # The connection uri is slightly different when using qemu:///system
-# Use a direct local socket connection to avoid SSH-related transient failures
-# that can cause vbmc to ack power-on without libvirt executing it.
+# and requires the root user.
 - name: set qemu uri for qemu:///system usage
   set_fact:
-    vbmc_libvirt_uri: "qemu:///system"
+    vbmc_libvirt_uri: "qemu+ssh://root@{{ vbmc_address | ansible.utils.ipwrap }}/system?&keyfile=/root/ssh/id_rsa_virt_power&no_verify=1&no_tty=1"
   when: libvirt_uri == "qemu:///system"
 
 - name: set qemu uri for qemu:///session usage
@@ -99,10 +98,12 @@
     crypt_scheme: bcrypt
     name: "{{ vbmc_username }}"
     password: "{{ vbmc_password }}"
+    mode: "0640"
 
 - name: Create private key (RSA, 4096 bits) for redfish TLS
   community.crypto.openssl_privatekey:
     path: "{{ working_dir }}/virtualbmc/sushy-tools/key.pem"
+    mode: "0640"
 
 - name: Create CSR for redfish TLS
   community.crypto.openssl_csr_pipe:
@@ -118,6 +119,7 @@
     csr_content: "{{ vbmc_csr.csr }}"
     privatekey_path: "{{ working_dir }}/virtualbmc/sushy-tools/key.pem"
     provider: selfsigned
+    mode: "0640"
 
 - name: Create the Redfish Virtual BMCs
   copy:
@@ -127,9 +129,10 @@
       SUSHY_EMULATOR_LIBVIRT_URI = "{{ vbmc_libvirt_uri }}"
       SUSHY_EMULATOR_IGNORE_BOOT_DEVICE = {{ sushy_ignore_boot_device }}
       SUSHY_EMULATOR_VMEDIA_VERIFY_SSL = {{ sushy_vmedia_verify_ssl }}
-      SUSHY_EMULATOR_AUTH_FILE = "/root/sushy/htpasswd"
-      SUSHY_EMULATOR_SSL_KEY = "/root/sushy/key.pem"
-      SUSHY_EMULATOR_SSL_CERT = "/root/sushy/cert.pem"
+      SUSHY_EMULATOR_AUTH_FILE = "{{ sushy_conf_dir }}/htpasswd"
+      SUSHY_EMULATOR_SSL_KEY = "{{ sushy_conf_dir }}/key.pem"
+      SUSHY_EMULATOR_SSL_CERT = "{{ sushy_conf_dir }}/cert.pem"
+
   become: true
   when: vm_platform|default("libvirt") != "fake"
 
@@ -169,11 +172,11 @@
       SUSHY_EMULATOR_LIBVIRT_URI = "{{ vbmc_libvirt_uri }}"
       SUSHY_EMULATOR_IGNORE_BOOT_DEVICE = {{ sushy_ignore_boot_device }}
       SUSHY_EMULATOR_VMEDIA_VERIFY_SSL = {{ sushy_vmedia_verify_ssl }}
-      SUSHY_EMULATOR_AUTH_FILE = "/root/sushy/htpasswd"
+      SUSHY_EMULATOR_AUTH_FILE = "{{ sushy_conf_dir }}/htpasswd"
       SUSHY_EMULATOR_FAKE_DRIVER = True
       SUSHY_EMULATOR_FAKE_IPA = True
-      SUSHY_EMULATOR_SSL_KEY = "/root/sushy/key.pem"
-      SUSHY_EMULATOR_SSL_CERT = "/root/sushy/cert.pem"
+      SUSHY_EMULATOR_SSL_KEY = "{{ sushy_conf_dir }}/key.pem"
+      SUSHY_EMULATOR_SSL_CERT = "{{ sushy_conf_dir }}/cert.pem"
       SUSHY_EMULATOR_FAKE_SYSTEMS = {{ lookup('ansible.builtin.file', fake_nodes_file ) }}
   become: true
   when: vm_platform|default("libvirt") == "fake"


### PR DESCRIPTION
Change address from root to conf. 
The sushy-tools container now runs as a non-root user. 
Add --group-add 0 to the container run so it can read files owned by root-
Set key.pem to mode 0640 since openssl_privatekey defaults to 0600 

Done in order to allow https://github.com/metal3-io/ironic-image/pull/1032 to merge