### PR TITLE
vbmc: use local libvirt socket instead of SSH

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -532,14 +532,20 @@ else
 fi
 
 # Start vbmc and sushy containers
+# Mount the libvirt socket directly to avoid SSH-based qemu+ssh:// connections
+# which are prone to transient failures causing power-on commands to be acked
+# by vbmc but not executed by libvirt (observed as VMs stuck powered off after
+# cleaning in CI, e.g. pivoting test flakiness).
 # shellcheck disable=SC2086
 sudo "${CONTAINER_RUNTIME}" run -d --net host --name vbmc ${POD_NAME_INFRA} \
     -v "${WORKING_DIR}/virtualbmc/vbmc":/root/.vbmc -v "/root/.ssh":/root/ssh \
+    -v /var/run/libvirt:/var/run/libvirt \
     "${VBMC_IMAGE}"
 
 # shellcheck disable=SC2086
 sudo "${CONTAINER_RUNTIME}" run -d --net host --name sushy-tools ${POD_NAME_INFRA} \
     -v "${WORKING_DIR}/virtualbmc/sushy-tools":/root/sushy -v "/root/.ssh":/root/ssh \
+    -v /var/run/libvirt:/var/run/libvirt \
     "${SUSHY_TOOLS_IMAGE}"
 
 # Installing the openstack/ironic clients on the host is optional

--- a/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
+++ b/vm-setup/roles/virtbmc/tasks/setup_tasks.yml
@@ -53,10 +53,11 @@
     vbmc_address: "{% if vbmc_address_v4|ansible.utils.ipv4 != False %}{{ vbmc_address_v4 }}{% else %}{{ vbmc_address_v6 }}{% endif %}"
 
 # The connection uri is slightly different when using qemu:///system
-# and requires the root user.
+# Use a direct local socket connection to avoid SSH-related transient failures
+# that can cause vbmc to ack power-on without libvirt executing it.
 - name: set qemu uri for qemu:///system usage
   set_fact:
-    vbmc_libvirt_uri: "qemu+ssh://root@{{ vbmc_address | ansible.utils.ipwrap }}/system?&keyfile=/root/ssh/id_rsa_virt_power&no_verify=1&no_tty=1"
+    vbmc_libvirt_uri: "qemu:///system"
   when: libvirt_uri == "qemu:///system"
 
 - name: set qemu uri for qemu:///session usage


### PR DESCRIPTION
Replace the qemu+ssh:// connection URI with a direct qemu:///system socket connection for VirtualBMC. Mount the libvirt socket into the vbmc container to enable this.

By removing SSH from the critical path, vbmc talks to libvirtd through a Unix socket, eliminating the network/auth layer that caused the race.