### PR TITLE
Set dhcp vars for dnsmasq via IRSO

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -251,6 +251,54 @@ launch_ironic_standalone_operator()
         -n ironic-standalone-operator-system deployment/ironic-standalone-operator-controller-manager
 }
 
+#
+# Build optional dnsmasq DHCP settings as YAML list entries for the IRSO Ironic
+# CR (spec.networking.dhcp.hosts/ignore), one entry per ';'-separated item in
+# DHCP_HOSTS/DHCP_IGNORE. These replace the DHCP_HOSTS/DHCP_IGNORE env vars
+# previously written into the ironic configmap when ironic was launched without
+# IRSO. Prints a YAML fragment (leading newline, no trailing newline) to stdout;
+# empty when neither setting applies.
+#
+build_dhcp_yaml()
+{
+    local dhcp_yaml=""
+
+    if [[ -n "${DHCP_HOSTS:-}" ]]; then
+        dhcp_yaml+=$'\n      hosts:'
+        local dhcp_host_list host_entry
+        IFS=';' read -ra dhcp_host_list <<< "${DHCP_HOSTS}"
+        for host_entry in "${dhcp_host_list[@]}"; do
+            [[ -n "${host_entry}" ]] || continue
+            dhcp_yaml+=$'\n        - "'"${host_entry}"'"'
+        done
+    fi
+
+    # DHCP_IGNORE | DHCP_HOSTS | dhcp_ignore result
+    # ------------+------------+----------------------------------------
+    # set         | (any)      | DHCP_IGNORE (explicit override wins)
+    # unset       | set        | tag:!known (allow-list)
+    # unset       | unset      | empty -> no "ignore:" emitted
+    #
+    # Default to ignoring any host not explicitly listed in DHCP_HOSTS
+    # (dnsmasq dhcp-ignore=tag:!known) only when DHCP_HOSTS is set, so that a
+    # plain run with neither variable keeps DHCP permissive. DHCP_IGNORE always
+    # overrides when set.
+    local dhcp_ignore="${DHCP_IGNORE:-${DHCP_HOSTS:+tag:!known}}"
+    if [[ -n "${dhcp_ignore}" ]]; then
+        dhcp_yaml+=$'\n      ignore:'
+        local dhcp_ignore_list ignore_entry
+        IFS=';' read -ra dhcp_ignore_list <<< "${dhcp_ignore}"
+        for ignore_entry in "${dhcp_ignore_list[@]}"; do
+            [[ -n "${ignore_entry}" ]] || continue
+            dhcp_yaml+=$'\n        - "'"${ignore_entry}"'"'
+        done
+    fi
+
+    # Strip the leading newline so the fragment can sit on its own line in the
+    # heredoc (spec.networking.dhcp) already correctly indented.
+    printf '%s' "${dhcp_yaml#$'\n'}"
+}
+
 launch_ironic_via_irso()
 {
     if [[ "${IRONIC_BASIC_AUTH}" != "true" ]]; then
@@ -285,6 +333,7 @@ spec:
       rangeBegin: "${CLUSTER_DHCP_RANGE_START}"
       rangeEnd: "${CLUSTER_DHCP_RANGE_END}"
       networkCIDR: "${BARE_METAL_PROVISIONER_NETWORK}"
+$(build_dhcp_yaml)
     interface: "${BARE_METAL_PROVISIONER_INTERFACE}"
     ipAddress: "${CLUSTER_BARE_METAL_PROVISIONER_IP}"
     ipAddressManager: keepalived

--- a/vars.md
+++ b/vars.md
@@ -135,7 +135,7 @@ assured that they are persisted.
 | IRONIC_INSPECTOR_SOURCE | absolute path of the ironic-inspector source code used to build the ironic-inspector services in the ironic container image | | |
 | SUSHY_SOURCE | absolute path of the sushy source code used to build the sushy library in the ironic container image | | |
 | DHCP_HOSTS | A list of `;` separated dhcp-host directives for dnsmasq | e.g. `00:20:e0:3b:13:af;00:20:e0:3b:14:af` | |
-| DHCP_IGNORE | A set of tags on hosts to be ignored by dnsmasq | e.g. `tag:!known` | |
+| DHCP_IGNORE | A list of `;` separated dhcp-ignore tags for dnsmasq. When unset and `USE_IRSO=true`, defaults to `tag:!known` if `DHCP_HOSTS` is set (ignore any host not explicitly listed), otherwise empty | e.g. `tag:!known` | |
 | ENABLE_NATED_PROVISIONING_NETWORK | A single boolean to configure whether provisioner and provisioning networks are in separate subnets and there is NAT betweend them or not | "true","false" | "false" |
 | CAPI_CONFIG_DIR | Cluster API config directory path  | `$HOME/.cluster-api/`, `$XDG_CONFIG_HOME/cluster-api`, `$HOME/.config/cluster-api` | `$HOME/.config/cluster-api` |
 | IPA_BASEURI | IPA downloader will download IPA from this url | | https://tarballs.opendev.org/openstack/ironic-python-agent/dib |


### PR DESCRIPTION
This PR sets dhcp_hosts and dhcp_ignore vars for dnsmasq via IRSO