### PR TITLE
Make dev-env logs less noisy for Make

### DIFF
--- a/01_prepare_host.sh
+++ b/01_prepare_host.sh
@@ -16,8 +16,8 @@ if [[ "${OS}" = "ubuntu" ]]; then
     # Set apt retry limit to higher than default to
     # make the data retrival more reliable
     sudo sh -c ' echo "Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries '
-    sudo apt-get update
-    sudo apt-get -y install python3-pip python3-dev python3-venv jq curl wget pkg-config bash-completion
+    sudo apt-get -q update
+    sudo apt-get -qy install python3-pip python3-dev python3-venv jq curl wget pkg-config bash-completion
 
     # Set update-alternatives to python3
     case "${DISTRO}" in
@@ -62,6 +62,12 @@ elif [[ "${OS}" = "opensuse-leap" ]]; then
     sudo aa-teardown
 fi
 
+# Save current value so it can be restored during cleanup.
+_prev_detached_head_advice="$(git config --global --get advice.detachedHead 2>/dev/null || true)"
+printf '%s\n' "${_prev_detached_head_advice:-__UNSET__}" > "${WORKING_DIR}/.git_advice_detachedHead_prev"
+
+# Suppress detached HEAD advice for this run.
+git config --global advice.detachedHead false
 # NOTE(tuminoid) lib/releases.sh must be after the jq and python installation
 # TODO: fix all of the lib/ scripts not to actually run code, but only define functions
 # shellcheck disable=SC1091
@@ -80,7 +86,7 @@ rm -rf "${ANSIBLE_VENV}"
 sudo python -m venv --system-site-packages "${ANSIBLE_VENV}"
 # TODO: since ansible 8.0.0, pinning by digest is PITA, due additional ansible
 # dependencies, which would need to be pinned as well, so it is skipped for now
-sudo "${ANSIBLE_VENV}/bin/pip" install --ignore-installed ansible=="${ANSIBLE_VERSION}"
+sudo "${ANSIBLE_VENV}/bin/pip" install -q --ignore-installed ansible=="${ANSIBLE_VERSION}"
 
 # Install requirements
 "${ANSIBLE}-galaxy" install -r vm-setup/requirements.yml

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -465,9 +465,9 @@ for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*"); do
 
     cd - || exit
     if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
-        sudo "${CONTAINER_RUNTIME}" push --tls-verify=false "${IMAGE_URL}"
+        sudo "${CONTAINER_RUNTIME}" push --quiet --tls-verify=false "${IMAGE_URL}"
     else
-        sudo "${CONTAINER_RUNTIME}" push --platform="${LOCAL_CONTAINER_PLATFORM}" "${IMAGE_URL}"
+        sudo "${CONTAINER_RUNTIME}" push --quiet --platform="${LOCAL_CONTAINER_PLATFORM}" "${IMAGE_URL}"
     fi
 
     # store the locally built images to config, so they're passed to "make test"
@@ -504,16 +504,17 @@ for IMAGE_VAR in $(env | grep -v "_LOCAL_IMAGE=" | grep "_IMAGE=" | grep -o "^[^
     # shellcheck disable=SC2086
     LOCAL_IMAGE="${REGISTRY}/localimages/${IMAGE_NAME%@*}"
     if [[ "${LOCAL_IMAGE}" != "${IMAGE}" ]]; then
-        sudo "${CONTAINER_RUNTIME}" rmi "${LOCAL_IMAGE}" || true
+        sudo "${CONTAINER_RUNTIME}" rmi "${LOCAL_IMAGE}" > /dev/null 2>&1 || true
     fi
     if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
         sudo "${CONTAINER_RUNTIME}" tag "${IMAGE}" "${LOCAL_IMAGE}"
-        sudo "${CONTAINER_RUNTIME}" push --tls-verify=false "${LOCAL_IMAGE}"
+        sudo "${CONTAINER_RUNTIME}" push --quiet --tls-verify=false "${LOCAL_IMAGE}"
     else
         sudo "${CONTAINER_RUNTIME}" run --rm --network host \
             -v "/${WORKING_DIR}/registries.conf:/etc/containers/registries.conf:ro" \
             quay.io/skopeo/stable:latest \
             copy \
+            --quiet \
             --dest-tls-verify=false \
             "docker://${IMAGE}" "docker://${LOCAL_IMAGE}"
     fi

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -536,7 +536,7 @@ EOF
     if [[ "${GINKGO_FOCUS:-}" == "in-place-upgrade" ]]; then
         export TEST_EXTENSION_MANIFEST_IMG="${REGISTRY}/metal3-io/test-extension:latest"
         make docker-build-test-extension TEST_EXTENSION_IMG="${TEST_EXTENSION_MANIFEST_IMG}"
-        "${CONTAINER_RUNTIME}" push --tls-verify=false "${TEST_EXTENSION_MANIFEST_IMG}"
+        "${CONTAINER_RUNTIME}" push --quiet --tls-verify=false "${TEST_EXTENSION_MANIFEST_IMG}"
         make set-manifest-image-test-extension TEST_EXTENSION_IMG="${TEST_EXTENSION_MANIFEST_IMG}"
         make test-extension-manifests
 
@@ -637,11 +637,11 @@ launch_cluster_api_provider_metal3()
     # shellcheck disable=SC2153
     if [[ "${GINKGO_FOCUS:-}" == "in-place-upgrade" ]]; then
         clusterctl init --core cluster-api:"${CAPIRELEASE}" --bootstrap kubeadm:"${CAPIRELEASE}" \
-          --control-plane kubeadm:"${CAPIRELEASE}" --infrastructure=metal3:"${CAPM3RELEASE}" -v5 --ipam=metal3:"${IPAMRELEASE}" \
+          --control-plane kubeadm:"${CAPIRELEASE}" --infrastructure=metal3:"${CAPM3RELEASE}" -v3 --ipam=metal3:"${IPAMRELEASE}" \
           --runtime-extension=test-extension:"${CAPM3RELEASE}"
     else
         clusterctl init --core cluster-api:"${CAPIRELEASE}" --bootstrap kubeadm:"${CAPIRELEASE}" \
-          --control-plane kubeadm:"${CAPIRELEASE}" --infrastructure=metal3:"${CAPM3RELEASE}" -v5 --ipam=metal3:"${IPAMRELEASE}"
+          --control-plane kubeadm:"${CAPIRELEASE}" --infrastructure=metal3:"${CAPM3RELEASE}" -v3 --ipam=metal3:"${IPAMRELEASE}"
     fi
 
     if [[ "${CAPM3_RUN_LOCAL}" = true ]]; then
@@ -697,7 +697,7 @@ launch_kind()
   skip_verify = true
 EOF
 
-        cat <<EOF | sudo su -l -c "kind create cluster --name kind --image=${KIND_NODE_IMAGE} --config=- " "${USER}"
+        cat <<EOF | sudo su -l -c "kind create cluster -q --name kind --image=${KIND_NODE_IMAGE} --config=- " "${USER}"
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
@@ -719,7 +719,7 @@ EOF
         docker exec kind-control-plane cp /hosts.toml /etc/containerd/certs.d/"${REGISTRY}"/hosts.toml
 
     else
-        cat <<EOF | sudo su -l -c "kind create cluster --name kind --image=${KIND_NODE_IMAGE} --config=- " "${USER}"
+        cat <<EOF | sudo su -l -c "kind create cluster -q --name kind --image=${KIND_NODE_IMAGE} --config=- " "${USER}"
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:

--- a/04_verify.sh
+++ b/04_verify.sh
@@ -248,6 +248,20 @@ for name in ${LIST_OF_CRDS[@]}; do
 done
 echo ""
 
+#Reset detachedHead to user prefreence
+prev_file="${WORKING_DIR}/.git_advice_detachedHead_prev"
+
+if [ -f "$prev_file" ]; then
+    prev="$(cat "$prev_file")"
+
+    if [ "$prev" = "__UNSET__" ]; then
+        git config --global --unset advice.detachedHead
+    else
+        git config --global advice.detachedHead "$prev"
+    fi
+
+    rm -f "$prev_file"
+fi
 # Verify v1beta1 Operators, Deployments, Replicasets
 iterate check_k8s_entity deployments "${EXPTD_DEPLOYMENTS}"
 iterate check_k8s_rs "${EXPTD_RS}"

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,6 +2,7 @@
 callbacks_enabled=ansible.posix.profile_tasks
 stdout_callback=community.general.diy
 show_task_path_on_failure=true
+deprecation_warnings=False
 
 [callback_profile_tasks]
 task_output_limit = 3

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -x
-
 # shellcheck disable=SC1091
 source lib/logging.sh
 # shellcheck disable=SC1091

--- a/lib/image_prepull.sh
+++ b/lib/image_prepull.sh
@@ -70,5 +70,5 @@ fi
 # Pulling all the images except any local image.
 for IMAGE_VAR in $(env | grep -v "_LOCAL_IMAGE=" | grep "_IMAGE=" | grep -o "^[^=]*") ; do
   IMAGE="${!IMAGE_VAR}"
-  sudo "${CONTAINER_RUNTIME}" pull --platform="${LOCAL_CONTAINER_PLATFORM}" "${IMAGE}"
+  sudo "${CONTAINER_RUNTIME}" pull --quiet --platform="${LOCAL_CONTAINER_PLATFORM}" "${IMAGE}"
  done

--- a/vm-setup/roles/firewall/tasks/iptables.yaml
+++ b/vm-setup/roles/firewall/tasks/iptables.yaml
@@ -1,9 +1,15 @@
+- name: "iptables: Check if firewalld is available"
+  command: systemctl cat firewalld
+  register: firewalld_check
+  failed_when: false
+  changed_when: false
+
 - name: "iptables: Firewalld service stopped"
   service:
     name: firewalld
     state: stopped
     enabled: no
-  ignore_errors: true
+  when: firewalld_check.rc == 0
 
 - name: "iptables: VBMC Ports"
   iptables:

--- a/vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml
+++ b/vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml
@@ -35,7 +35,7 @@
   command: >
     virsh pool-uuid "{{ libvirt_volume_pool }}"
   register: pool_check
-  ignore_errors: true
+  failed_when: false
   changed_when: false
   environment:
     LIBVIRT_DEFAULT_URI: "{{ libvirt_uri }}"
@@ -44,11 +44,11 @@
   template:
     src: volume_pool.xml.j2
     dest: "{{ working_dir }}/volume_pool.xml"
-  when: pool_check is failed
+  when: pool_check.rc != 0
 
 - name: Define volume pool
   command: "virsh pool-define {{ working_dir }}/volume_pool.xml"
-  when: pool_check is failed
+  when: pool_check.rc != 0
   environment:
     LIBVIRT_DEFAULT_URI: "{{ libvirt_uri }}"
 
@@ -84,14 +84,15 @@
     command: >
       virsh vol-info --pool '{{ libvirt_volume_pool }}' '{{ item.name }}.qcow2'
     register: vm_vol_check
-    ignore_errors: true
+    failed_when: false
+    changed_when: false
     with_items: "{{ vm_nodes }}"
 
   - name: Create vm vm storage
     command: >
       virsh vol-create-as '{{ libvirt_volume_pool }}' '{{ item.item.name }}'.qcow2 '{{ flavors[item.item.flavor].disk }}'G --format qcow2
     when:
-    - item is failed
+    - item.rc != 0
     with_items: "{{ vm_vol_check.results }}"
 
   # Define (but do not start) the vm nodes.  These will be


### PR DESCRIPTION
Remove git detachedhand advice message.
Add quiet flages to apt-get pip install, docker full, skopeo copy and kind create cluster to remove unnessary detail.
Reduce clusterctl init  verbosiry to level 3.
Add Firewalld Ansible task to avoid error
Modify virsh Ansible tasks to not appar as errors since they are expected.



| Category | Clean Modification                                                 | Example of Removed/Suppressed Output                                                                                                                                                           |
| -------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1        | `git config --global advice.detachedHead false`                    | `Note: switching to '6.2.0'. You are in 'detached HEAD' state... Turn off this advice by setting config variable advice.detachedHead to false`                                                 |
| 2        | `apt-get -q` flag added                                            | `Get:1 https://cli.github.com/packages stable InRelease [3917 B], Fetched 3917 B in 1s (6595 B/s), Reading package lists...`                                                                   |
| 3        | `pip install -q` flag added                                        | `Collecting ansible==10.7.0, Using cached ansible-10.7.0-py3-none-any.whl.metadata (8.0 kB), Successfully installed MarkupSafe-3.0.3 PyYAML-6.0.3 ansible-10.7.0...`                           |
| 4        | `docker pull --quiet` flag added                                   | `Using default tag: latest, latest: Pulling from metal3-io/vbmc, Digest: sha256:ba34b6c57325d6a..., Status: Image is up to date for quay.io/metal3-io/vbmc:latest`                             |
| 5        | `skopeo copy --quiet` flag added                                   | `Getting image source signatures, Copying blob sha256:d3c894b5b2b0fa..., Copying config sha256:217ab2f6b797d7..., Writing manifest to image destination`                                       |
| 6        | `kind create cluster -q` flag added                                | `Creating cluster "kind"... ✓ Ensuring node image 🖼 ✓ Preparing nodes 📦 ✓ Starting control-plane 🕹️ Thanks for using kind! 😊`                                                              |
| 7        | `clusterctl init -v3` instead of `-v5`                             | `Creating CustomResourceDefinition="challenges.acme.cert-manager.io", Creating ServiceAccount="cert-manager-cainjector", Creating Issuer="test-selfsigned" (×44 retries), hundreds more lines` |
| 8        | Firewalld Ansible task: check-then-skip instead of stop-and-ignore | `fatal: [localhost]: FAILED! => {"msg": "Could not find the requested service firewalld: host"}, ...ignoring`                                                                                  |
| 9        | `virsh` Ansible tasks: `failed_when: false` on pool/volume checks  | `fatal: [localhost]: FAILED! => {"stderr": "error: failed to get pool 'oooq_pool'...Storage pool not found"}, ...ignoring`                                                                     |


This will reduce logs by around 400 lines.
