### PR TITLE
:seedling: Pre load IPA image to fix flaky test

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -35,6 +35,14 @@ fi
 sudo mkdir -p "${IRONIC_DATA_DIR}"
 sudo chown -R "${USER}:${USER}" "${IRONIC_DATA_DIR}"
 
+# Use locally pre-downloaded IPA images served by httpd-infra to avoid slow
+# remote downloads during Ironic deployment (which can cause timeouts in CI).
+IPA_FILENAME="ipa-${IPA_FLAVOR}-$(echo "${IPA_BRANCH}" | tr / -).tar.gz"
+if [[ "${IPA_DOWNLOAD_ENABLED}" == "true" ]] && [[ "${USE_LOCAL_IPA}" != "true" ]] \
+    && [[ -f "${IRONIC_IMAGE_DIR}/${IPA_FILENAME}" ]]; then
+    export IPA_BASEURI="http://${BARE_METAL_PROVISIONER_URL_HOST}/images"
+fi
+
 # shellcheck disable=SC1091
 source lib/ironic_tls_setup.sh
 # shellcheck disable=SC1091
@@ -245,7 +253,7 @@ EOF
 launch_ironic_standalone_operator()
 {
     # shellcheck disable=SC2311
-    echo 'IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote/ironic-python-agent/dib' > "${IRSOPATH}/config/manager/manager.env"
+    echo "IPA_BASEURI=${IPA_BASEURI}" > "${IRSOPATH}/config/manager/manager.env"
     make -C "${IRSOPATH}" install deploy IMG="$(get_component_image "${IRSO_LOCAL_IMAGE:-${IRSO_IMAGE}}")"
     kubectl wait --for=condition=Available --timeout=60s \
         -n ironic-standalone-operator-system deployment/ironic-standalone-operator-controller-manager

--- a/04_verify.sh
+++ b/04_verify.sh
@@ -21,6 +21,7 @@ if [ "${BOOTSTRAP_CLUSTER}" == "tilt" ]; then
   exit 0
 fi
 
+# shellcheck disable=SC2329
 check_bm_hosts() {
     local FAILS_CHECK="${FAILS}"
     local NAME ADDRESS USER PASSWORD MAC VERIFY_CA CRED_NAME CRED_SECRET
@@ -112,6 +113,7 @@ check_bm_hosts() {
 
 
 # Verify that a resource exists in a type
+# shellcheck disable=SC2329
 check_k8s_entity() {
   local FAILS_CHECK="${FAILS}"
   local ENTITY
@@ -140,6 +142,7 @@ check_k8s_entity() {
 
 
 # Verify that a resource exists in a type
+# shellcheck disable=SC2329
 check_k8s_rs() {
   local FAILS_CHECK="${FAILS}"
   local ENTITY
@@ -170,6 +173,7 @@ check_k8s_rs() {
 }
 
 # Verify a container is running
+# shellcheck disable=SC2329
 check_container(){
   local NAME="$1"
   RESULT_STR="Container ${NAME} running"

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -8,7 +8,8 @@ CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 if [ "${IS_CONTAINER}" != "false" ]; then
   TOP_DIR="${1:-.}"
   find "${TOP_DIR}" \
-    -type f -name '*.sh' -type f -exec shellcheck -s bash {} \+
+    -type d -name .git -prune -o \
+    -type f -name '*.sh' -exec shellcheck -s bash {} \+
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \

--- a/lib/image_prepull.sh
+++ b/lib/image_prepull.sh
@@ -15,7 +15,7 @@ pushd "${IRONIC_IMAGE_DIR}"
 # Download and prepare node images (unless skipped)
 if [[ ! -f "${IMAGE_NAME}" ]]; then
     if [[ -f "${IMAGE_LOCATION}/${IMAGE_NAME}" ]]; then
-      # Copy local image  
+      # Copy local image
       cp "${IMAGE_LOCATION}/${IMAGE_NAME}" .
     elif [[ "${IMAGE_LOCATION}" =~ ^http.* ]]; then
       if [[ "${SKIP_NODE_IMAGE_PREPULL}" = "true" ]]; then
@@ -60,6 +60,22 @@ if [[ -f "${IMAGE_NAME}" ]]; then
 fi
 
 popd
+
+# Pre-download IPA (Ironic Python Agent) images to serve from local httpd.
+# This avoids slow remote downloads during Ironic deployment that can cause
+# timeouts, especially in CI.
+if [[ "${IPA_DOWNLOAD_ENABLED}" == "true" ]] && [[ "${USE_LOCAL_IPA}" != "true" ]]; then
+    IPA_FILENAME="ipa-${IPA_FLAVOR}-$(echo "${IPA_BRANCH}" | tr / -).tar.gz"
+    if [[ ! -f "${IRONIC_IMAGE_DIR}/${IPA_FILENAME}" ]]; then
+        echo "Pre-downloading IPA image: ${IPA_BASEURI}/${IPA_FILENAME}"
+        wget --no-verbose --no-check-certificate -O "${IRONIC_IMAGE_DIR}/${IPA_FILENAME}" \
+            "${IPA_BASEURI}/${IPA_FILENAME}"
+    fi
+    if [[ ! -f "${IRONIC_IMAGE_DIR}/${IPA_FILENAME}.sha256" ]]; then
+        wget --no-verbose --no-check-certificate -O "${IRONIC_IMAGE_DIR}/${IPA_FILENAME}.sha256" \
+            "${IPA_BASEURI}/${IPA_FILENAME}.sha256"
+    fi
+fi
 
 # NOTE(elfosardo): workaround for https://github.com/moby/moby/issues/44970
 # should be fixed in docker-ce 23.0.2


### PR DESCRIPTION
## Problem

The `centos-e2e-integration-test-main` job intermittently fails ~22-29 minutes into the run when waiting for Ironic to become ready. The root cause is that the IPA (Ironic Python Agent) download inside the ironic-ipa-downloader init container is too slow, even when fetched from a cache. This causes the `IRONIC_ROLLOUT_WAIT` timeout to be exceeded and the Ironic CR never reaches the `Ready` condition.

Observed failures:

- Periodic: [June 7](https://jenkins.nordix.org/blue/organizations/jenkins/metal3-periodic-centos-e2e-integration-test-main/detail/metal3-periodic-centos-e2e-integration-test-main/869/pipeline), [17](https://jenkins.nordix.org/blue/organizations/jenkins/metal3-periodic-centos-e2e-integration-test-main/detail/metal3-periodic-centos-e2e-integration-test-main/869/pipeline), [18](https://jenkins.nordix.org/blue/organizations/jenkins/metal3-periodic-centos-e2e-integration-test-main/detail/metal3-periodic-centos-e2e-integration-test-main/880/pipeline)
- PR jobs: [June 30](https://jenkins.nordix.org/blue/organizations/jenkins/metal3-centos-e2e-integration-test-main/detail/metal3-centos-e2e-integration-test-main/2990/pipeline), [July 1](https://jenkins.nordix.org/blue/organizations/jenkins/metal3-centos-e2e-integration-test-main/detail/metal3-centos-e2e-integration-test-main/3012/pipeline), [3](https://jenkins.nordix.org/blue/organizations/jenkins/metal3-centos-e2e-integration-test-main/detail/metal3-centos-e2e-integration-test-main/3025/pipeline)

## Fix

Move the IPA download to the earlier image prepull phase (`02_configure_host.sh`) and serve the pre-downloaded archive from the local `httpd-infra` image server. The IPA downloader init container then fetches from localhost instead of a remote server.