### PR TITLE
Split EL9/EL10-specific packages for RHEL 10 support

### DIFF
--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -68,7 +68,6 @@ packages:
       - dnsmasq
       - edk2-ovmf
       - firewalld
-      - genisoimage
       - httpd-tools
       - jq
       - libguestfs-tools
@@ -82,7 +81,6 @@ packages:
       - podman
       - polkit-pkla-compat
       - psmisc
-      - python3-bcrypt
       - python3-libvirt
       - python3-lxml
       - python3-netaddr
@@ -94,6 +92,13 @@ packages:
       - vim-enhanced
       - virt-install
       - wget
+    el9:
+      packages:
+      - genisoimage
+      - python3-bcrypt
+    el10:
+      packages:
+      - xorriso
     pip3:
     - flask_oauthlib==0.9.6
     - jmespath

--- a/vm-setup/roles/packages_installation/tasks/main.yml
+++ b/vm-setup/roles/packages_installation/tasks/main.yml
@@ -78,6 +78,26 @@
     delay: 30
     register: pkg_result
     until: pkg_result is succeeded
+  - name: Install EL9-specific packages (genisoimage, python3-bcrypt)
+    when: ansible_distribution_major_version == "9"
+    package:
+      name: "{{ packages.centos.el9.packages }}"
+      state: present
+      nobest: true
+    retries: 5
+    delay: 30
+    register: el9_pkg_result
+    until: el9_pkg_result is succeeded
+  - name: Install EL10-specific packages (xorriso replaces genisoimage)
+    when: ansible_distribution_major_version == "10"
+    package:
+      name: "{{ packages.centos.el10.packages }}"
+      state: present
+      nobest: true
+    retries: 5
+    delay: 30
+    register: el10_pkg_result
+    until: el10_pkg_result is succeeded
   - name: Install packages using pip3
     pip:
       executable: "{{ ANSIBLE_VENV | default('/usr') }}/bin/pip"


### PR DESCRIPTION
## Summary

- Move `genisoimage` and `python3-bcrypt` from `centos.common.packages` to a new `centos.el9` section
- Add `centos.el10` section with `xorriso` (replaces `genisoimage` on EL10)
- Add version-gated install tasks in `main.yml`, following the existing Ubuntu `jammy`/`noble` pattern

## Why

RHEL 10 / CentOS Stream 10 drops two packages from the common list:
- **`genisoimage`**: replaced by `xorriso`, which provides a `mkisofs` compatibility wrapper
- **`python3-bcrypt`**: not available in RHEL 10 base repos. It's a soft dependency of `passlib` (used for password hashing) and not required — passlib has other hash backends

Without this change, `dnf install` fails on EL10 hosts because these packages don't exist.

## Context

Found while adding RHEL 10 provisioning host support to [openshift-metal3/dev-scripts#1922](https://github.com/openshift-metal3/dev-scripts/pull/1922). Currently worked around with `sed` patches in dev-scripts' `01_install_requirements.sh` — this PR fixes the issue at the source.

## Test plan

- [x] Verify EL9 CI still installs `genisoimage` and `python3-bcrypt` (no regression)
- [x] Verify EL10 installs `xorriso` instead of `genisoimage` and skips `python3-bcrypt`
- [ ] YAML lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)