### PR TITLE
Remove MariaDB support

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -25,9 +25,6 @@ BMO_IRONIC_ARGS=(-k)
 if [[ "${IRONIC_TLS_SETUP:-true}" = "true" ]]; then
     BMO_IRONIC_ARGS+=("-t")
 fi
-if [[ "${IRONIC_USE_MARIADB:-false}" = "true" ]]; then
-    BMO_IRONIC_ARGS+=("-m")
-fi
 
 sudo mkdir -p "${IRONIC_DATA_DIR}"
 sudo chown -R "${USER}:${USER}" "${IRONIC_DATA_DIR}"
@@ -158,7 +155,6 @@ IRONIC_ENDPOINT=${IRONIC_URL}
 CACHEURL=http://${BARE_METAL_PROVISIONER_URL_HOST}/images
 RESTART_CONTAINER_CERTIFICATE_UPDATED="${RESTART_CONTAINER_CERTIFICATE_UPDATED}"
 IRONIC_RAMDISK_SSH_KEY=${SSH_PUB_KEY_CONTENT}
-IRONIC_USE_MARIADB=${IRONIC_USE_MARIADB:-false}
 IPA_BASEURI=${IPA_BASEURI}
 IPA_BRANCH=${IPA_BRANCH}
 IPA_FLAVOR=${IPA_FLAVOR}
@@ -289,20 +285,6 @@ EOF
         kubectl create secret tls ironic-cacert -n "${IRONIC_NAMESPACE}" --key="${IRONIC_CAKEY_FILE}" --cert="${IRONIC_CACERT_FILE}"
     fi
 
-    if [[ "${IRONIC_USE_MARIADB:-false}" = "true" ]]; then
-        cat >> "${ironic}" <<EOF
-  databaseName: ironic-db
----
-apiVersion: ironic.metal3.io/v1alpha1
-kind: IronicDatabase
-metadata:
-  name: ironic-db
-  namespace: "${IRONIC_NAMESPACE}"
-spec:
-  image: "$(get_component_image "${MARIADB_LOCAL_IMAGE:-${MARIADB_IMAGE}}")"
-EOF
-  fi
-
     # NOTE(dtantsur): the webhook may not be ready immediately, retry if needed
     while ! kubectl create -f "${ironic}"; do
         sleep 3
@@ -311,9 +293,6 @@ EOF
     if ! kubectl wait --for=condition=Ready --timeout="${IRONIC_ROLLOUT_WAIT}m" -n "${IRONIC_NAMESPACE}" ironic/ironic; then
         # FIXME(dtantsur): remove this when Ironic objects are collected in the CI
         kubectl get -n "${IRONIC_NAMESPACE}" -o yaml ironic/ironic
-        if [[ "${IRONIC_USE_MARIADB:-false}" = "true" ]]; then
-            kubectl get -n "${IRONIC_NAMESPACE}" -o yaml ironicdatabase/ironic-db
-        fi
         exit 1
     fi
 }

--- a/tests/roles/run_tests/vars/main.yml
+++ b/tests/roles/run_tests/vars/main.yml
@@ -83,10 +83,9 @@ IMAGE_FORMAT: "{{ lookup('env', 'IMAGE_FORMAT') | default('raw', true) }}"
 IMAGE_CHECKSUM_TYPE: "{{ lookup('env', 'IMAGE_CHECKSUM_TYPE') | default('sha256', true) }}"
 IMAGE_CHECKSUM: "http://{{ BARE_METAL_PROVISIONER_IP }}/images/{{ RAW_IMAGE_NAME }}.{{ IMAGE_CHECKSUM_TYPE }}sum"
 
-# Environment variables to install Ironic with TLS, Basic Auth and MariaDB
+# Environment variables to install Ironic with TLS
 GOPATH: "{{ lookup('env', 'GOPATH')}}"
 IRONIC_TLS_SETUP: "{{ lookup('env', 'IRONIC_TLS_SETUP') | default('true', true) }}"
-IRONIC_USE_MARIADB: "{{ lookup('env', 'IRONIC_USE_MARIADB') | default('false', true) }}"
 
 # Metrics
 CAPM3_DIAGNOSTICS_ADDRESS: "localhost:8080"
@@ -95,8 +94,8 @@ IPAM_DIAGNOSTICS_ADDRESS: "localhost:8080"
 IPAM_INSECURE_DIAGNOSTICS: "true"
 
 # Args to pass to the deploy.sh script when deploying Ironic and BMO
-# [k]eepalived [t]ls or [m]ariadb
-BMO_IRONIC_ARGS: "-k {{ (IRONIC_TLS_SETUP == 'true') | ternary('-t', '') }} {{ (IRONIC_USE_MARIADB == 'true') | ternary('-m', '') }}"
+# [k]eepalived [t]ls
+BMO_IRONIC_ARGS: "-k {{ (IRONIC_TLS_SETUP == 'true') | ternary('-t', '') }}"
 
 provision_cluster_actions:
 - "ci_test_provision"

--- a/vars.md
+++ b/vars.md
@@ -80,7 +80,6 @@ assured that they are persisted.
 | IRONIC_KEY_FILE | Path to the certificate key of Ironic | | /opt/metal3-dev-env/certs/ironic.key |
 | IRONIC_USERNAME | Username for Ironic basic auth | | |
 | IRONIC_PASSWORD | Password for Ironic basic auth | | |
-| IRONIC_USE_MARIADB | Use MariaDB instead of SQLite. Setting this to "true" does not work with v0.2.0 and older versions of BMO. MariaDB cannot be used without TLS. | "true", "false" | "false" |
 | REGISTRY_PORT | Container image registry port | | 5000 |
 | HTTP_PORT | Httpd server port | | 6180 |
 | IRONIC_API_PORT | Ironic Api port | | 6385 |


### PR DESCRIPTION
This removes the IRONIC_USE_MARIADB option that let the dev-env deploy Ironic with a MariaDB backend.

It drops the -m flag passed to the BMO deploy script, the IRONIC_USE_MARIADB entry written into the Ironic configmap, and the IronicDatabase resource created on the IRSO path, together with the matching test variable and the documentation row in vars.md.

**NOTE**:The related MariaDB image-build variables and TLS certificate setup are removed separately in #1698. In addition, a follow-up  BMO PR removes the -m flag and the kustomize component, it depends on this merging first.