### PR TITLE
Silence shellcheck SC2329 false positives

### DIFF
--- a/04_verify.sh
+++ b/04_verify.sh
@@ -2,7 +2,7 @@
 # ignore shellcheck v0.9.0 introduced SC2317 about unreachable code
 # that doesn't understand traps, variables, functions etc causing all
 # code called via iterate() to false trigger SC2317
-# shellcheck disable=SC2317
+# shellcheck disable=SC2317,SC2329
 
 set -u
 


### PR DESCRIPTION
The check_* functions in `04_verify.sh` are invoked indirectly via `iterate()`, so shellsheck's SC2329 ("function never invoked") is a false positive. Add it to the existing disable directive together with SC2317.