### PR TITLE
Clean up Ironic credentials handling

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -92,8 +92,8 @@ EOF
 
         sudo mkdir -p /opt/metal3/auth/ironic
         sudo chown "${USER}":"${USER}" /opt/metal3/auth/ironic
-        cp "${IRONIC_AUTH_DIR}ironic-username" /opt/metal3/auth/ironic/username
-        cp "${IRONIC_AUTH_DIR}ironic-password" /opt/metal3/auth/ironic/password
+        cp "${IRONIC_USERNAME_FILE}" /opt/metal3/auth/ironic/username
+        cp "${IRONIC_PASSWORD_FILE}" /opt/metal3/auth/ironic/password
 
         export IRONIC_ENDPOINT=${IRONIC_URL}
 
@@ -235,8 +235,8 @@ launch_ironic_standalone_operator()
 launch_ironic_via_irso()
 {
     kubectl create secret generic ironic-auth -n "${IRONIC_NAMESPACE}" \
-        --from-file=username="${IRONIC_AUTH_DIR}ironic-username"  \
-        --from-file=password="${IRONIC_AUTH_DIR}ironic-password"
+        --from-file=username="${IRONIC_USERNAME_FILE}"  \
+        --from-file=password="${IRONIC_PASSWORD_FILE}"
     kubectl label secret ironic-auth -n "${IRONIC_NAMESPACE}" \
         environment.metal3.io/ironic-standalone-operator=true
 

--- a/lib/ironic_basic_auth.sh
+++ b/lib/ironic_basic_auth.sh
@@ -1,24 +1,28 @@
 #!/bin/bash
 
 # Create usernames and passwords and other files related to basic auth
-IRONIC_AUTH_DIR="${IRONIC_AUTH_DIR:-"${IRONIC_DATA_DIR}/auth/"}"
+IRONIC_AUTH_DIR="${IRONIC_AUTH_DIR:-"${IRONIC_DATA_DIR}/auth"}"
 mkdir -p "${IRONIC_AUTH_DIR}"
+
+IRONIC_USERNAME_FILE="${IRONIC_AUTH_DIR}/ironic-username"
+IRONIC_PASSWORD_FILE="${IRONIC_AUTH_DIR}/ironic-password"
 
 # If usernames and passwords are unset, read them from file or generate them
 if [ -z "${IRONIC_USERNAME:-}" ]; then
-    if [ ! -f "${IRONIC_AUTH_DIR}ironic-username" ]; then
+    if [ ! -f "${IRONIC_USERNAME_FILE}" ]; then
         IRONIC_USERNAME="$(uuidgen)"
-        echo -n "$IRONIC_USERNAME" > "${IRONIC_AUTH_DIR}ironic-username"
+        echo -n "$IRONIC_USERNAME" > "${IRONIC_USERNAME_FILE}"
     else
-        IRONIC_USERNAME="$(cat "${IRONIC_AUTH_DIR}ironic-username")"
+        IRONIC_USERNAME="$(cat "${IRONIC_USERNAME_FILE}")"
     fi
 fi
 if [ -z "${IRONIC_PASSWORD:-}" ]; then
-    if [ ! -f "${IRONIC_AUTH_DIR}ironic-password" ]; then
+    if [ ! -f "${IRONIC_PASSWORD_FILE}" ]; then
         IRONIC_PASSWORD="$(uuidgen)"
-        echo -n "$IRONIC_PASSWORD" > "${IRONIC_AUTH_DIR}ironic-password"
+        echo -n "$IRONIC_PASSWORD" > "${IRONIC_PASSWORD_FILE}"
+        chmod 0600 "${IRONIC_PASSWORD_FILE}"
     else
-        IRONIC_PASSWORD="$(cat "${IRONIC_AUTH_DIR}ironic-password")"
+        IRONIC_PASSWORD="$(cat "${IRONIC_PASSWORD_FILE}")"
     fi
 fi
 


### PR DESCRIPTION
1. Do not assume that IRONIC_AUTH_DIR has a trailing slash
2. Use shared variables for username and password paths
3. Chmod 0600 for the generated password file

Follow-up to https://github.com/metal3-io/metal3-dev-env/pull/1714

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
